### PR TITLE
ci: ensure pyyaml installed for YAML validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install check dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
       - name: Verificar sintaxe Python
         run: |
           echo "🔍 Verificando arquivos Python..."


### PR DESCRIPTION
Install pyyaml in the check job to allow YAML validation step to run.