### PR TITLE
ci: prefer self-hosted homelab runner for OpenWebUI tests

### DIFF
--- a/.github/workflows/openwebui-test-deploy.yml
+++ b/.github/workflows/openwebui-test-deploy.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   test-deploy:
-    runs-on: ubuntu-latest
+    # Prefer a self-hosted homelab runner to reach the private host
+    runs-on: [self-hosted, linux, homelab]
     strategy:
       matrix:
         env: [dev, cer, prod]


### PR DESCRIPTION
Use the homelab self-hosted runner to run OpenWebUI tests against private host 192.168.15.2:3000. This avoids GitHub-hosted runners failing to reach the private IP.