### PR TITLE
ci: use system Python as fallback on self-hosted runner

### DIFF
--- a/.github/workflows/openwebui-test-deploy.yml
+++ b/.github/workflows/openwebui-test-deploy.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
+      - name: Use system Python (fallback for self-hosted)
+        run: |
+          python3 --version || true
+          python3 -m pip install --upgrade pip || true
 
       - name: Install deps
         run: |


### PR DESCRIPTION
Self-hosted runner failed running actions/setup-python; as a pragmatic fallback, use system python3 for OpenWebUI tests. This keeps tests green on homelab while we investigate setup-python behavior.