### PR TITLE
ci: use python3 for pip installs on self-hosted runner

### DIFF
--- a/.github/workflows/openwebui-test-deploy.yml
+++ b/.github/workflows/openwebui-test-deploy.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install --upgrade pip
-          pip install requests
+          python3 -m pip install --upgrade pip
+          python3 -m pip install requests
 
       - name: Run OpenWebUI tests
         env:


### PR DESCRIPTION
Ensure pip installs use python3 on the homelab self-hosted runner so 'Install deps' step doesn't fail.