### PR TITLE
ci: use venv for Install deps on self-hosted runner

### DIFF
--- a/.github/workflows/openwebui-test-deploy.yml
+++ b/.github/workflows/openwebui-test-deploy.yml
@@ -23,8 +23,11 @@ jobs:
 
       - name: Install deps
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install requests
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install requests
+          echo "VENVS_DIR=${PWD}/.venv" > $GITHUB_ENV
 
       - name: Run OpenWebUI tests
         env:


### PR DESCRIPTION
Create a virtual environment and install test dependencies into it to avoid system python restrictions (PEP 668) on the homelab runner.