### PR TITLE
ci(openwebui): add workflow to write OPENWEBUI token to homelab runner

### DIFF
--- a/.github/workflows/write-openwebui-token.yml
+++ b/.github/workflows/write-openwebui-token.yml
@@ -1,0 +1,43 @@
+name: Write OpenWebUI token to homelab
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  write-token:
+    name: Write OpenWebUI token to homelab runner
+    runs-on: [self-hosted, homelab]
+    env:
+      OPENWEBUI_API_KEY: ${{ secrets.OPENWEBUI_API_KEY }}
+      OPENWEBUI_URL: ${{ secrets.OPENWEBUI_URL }}
+    steps:
+      - name: Show runner info
+        run: |
+          echo "Runner: $RUNNER_NAME" || true
+
+      - name: Write token to file
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENWEBUI_API_KEY:-}" ]; then
+            echo "No OPENWEBUI_API_KEY provided in secrets" >&2
+            exit 1
+          fi
+
+          echo "Writing token to ~/.openwebui_token"
+          mkdir -p "$HOME"
+          echo "${OPENWEBUI_API_KEY}" > "$HOME/.openwebui_token"
+          chmod 600 "$HOME/.openwebui_token"
+          echo "WROTE: $(stat -c '%a %n' "$HOME/.openwebui_token")"
+
+      - name: Verify token can access API
+        run: |
+          set -euo pipefail
+          URL="${OPENWEBUI_URL:-http://127.0.0.1:3000}"
+          echo "Checking $URL/api/v1/functions"
+          if curl -fsS -H "Authorization: Bearer $(cat ~/.openwebui_token)" "$URL/api/v1/functions" | jq -e . >/dev/null 2>&1; then
+            echo "API access OK"
+          else
+            echo "API access failed (response printed below)"
+            curl -sS -H "Authorization: Bearer $(cat ~/.openwebui_token)" "$URL/api/v1/functions" || true
+            exit 1
+          fi


### PR DESCRIPTION
Add a one-off workflow to write the repo secret OPENWEBUI_API_KEY to ~/.openwebui_token on the homelab runner and validate API access. This is safe-by-default and runs only on the self-hosted 'homelab' runner.