### PR TITLE
ci(openwebui): run write-token only on homelab runner

### DIFF
--- a/.github/workflows/write-openwebui-token.yml
+++ b/.github/workflows/write-openwebui-token.yml
@@ -15,6 +15,13 @@ jobs:
         run: |
           echo "Runner: $RUNNER_NAME" || true
 
+      - name: Ensure runner is the homelab host
+        run: |
+          if [ "${RUNNER_NAME:-}" != "homelab" ]; then
+            echo "Runner '${RUNNER_NAME:-unknown}' is not 'homelab'. Skipping write." >&2
+            exit 0
+          fi
+
       - name: Write token to file
         run: |
           set -euo pipefail


### PR DESCRIPTION
Add a guard to ensure the write-openwebui-token workflow only writes the token when running on runner named 'homelab'.