### PR TITLE
ci(openwebui): run token write only on runner.name 'homelab'

### DIFF
--- a/.github/workflows/write-openwebui-token.yml
+++ b/.github/workflows/write-openwebui-token.yml
@@ -23,7 +23,7 @@ jobs:
           fi
 
       - name: Write token to file
-        if: ${{ env.RUNNER_NAME == 'homelab' }}
+        if: ${{ runner.name == 'homelab' }}
         run: |
           set -euo pipefail
           if [ -z "${OPENWEBUI_API_KEY:-}" ]; then
@@ -38,7 +38,7 @@ jobs:
           echo "WROTE: $(stat -c '%a %n' "$HOME/.openwebui_token")"
 
       - name: Verify token can access API
-        if: ${{ env.RUNNER_NAME == 'homelab' }}
+        if: ${{ runner.name == 'homelab' }}
         run: |
           set -euo pipefail
           URL="${OPENWEBUI_URL:-http://127.0.0.1:3000}"


### PR DESCRIPTION
Fix: use 'runner.name' in step 'if' so write/verify steps execute only when picked by the homelab runner.