### PR TITLE
ci: require homelab-only runner label for OpenWebUI workflows

### DIFF
--- a/.github/workflows/rotate-openwebui-api-key.yml
+++ b/.github/workflows/rotate-openwebui-api-key.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   rotate-and-verify:
     name: Rotate and verify OpenWebUI API key
-    runs-on: homelab
+    runs-on: [self-hosted, homelab-only]
     environment: homelab
     steps:
       - name: Check runner

--- a/.github/workflows/write-openwebui-token.yml
+++ b/.github/workflows/write-openwebui-token.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   write-token:
     name: Write OpenWebUI token to homelab runner
-    runs-on: homelab
+    runs-on: [self-hosted, homelab-only]
     env:
       OPENWEBUI_API_KEY: ${{ secrets.OPENWEBUI_API_KEY }}
       OPENWEBUI_URL: ${{ secrets.OPENWEBUI_URL }}


### PR DESCRIPTION
Use a homelab-only self-hosted runner label so token write/rotate jobs run only on the intended machine. Also include instructions to add the label to the runner.