### PR TITLE
docs: add runbook for Bitwarden unlock and OpenWebUI token recovery

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,3 +32,37 @@ If you want, I can add a GitHub Actions workflow that runs this script in a
 controlled runner, but that would require storing a Bitwarden session token
 or a PAT with appropriate permissions — let me know if you prefer that
 approach and I will implement it safely.
+
+Runbook / recovery steps (homelab runner) — quick reference
+---------------------------------------------------------
+
+- Ensure the homelab runner user has Bitwarden CLI and gh installed and is
+  able to unlock Bitwarden:
+
+    bw login <email>
+    bw unlock
+
+- To manually export a session and avoid interactive unlock during automation:
+
+    bw unlock --raw > /tmp/bw_session
+    export BW_SESSION=$(cat /tmp/bw_session)
+
+- If `bw get password openwebui/api_key` fails, check that the item exists and
+  that the runner has access to the organization or collection where the item
+  is stored.
+
+- Manual verification on homelab:
+
+    # Ensure token file is present and permissions are correct
+    ls -l ~/.openwebui_token
+
+    # Test API access
+    curl -sS -H "Authorization: Bearer $(cat ~/.openwebui_token)" http://127.0.0.1:3000/api/v1/models | jq .
+
+- If you need to re-run the sync from Bitwarden locally:
+
+    ./scripts/sync_openwebui_from_bw.sh --run-workflow
+
+- If Bitwarden isn't logged in on the runner and interactive login is not possible,
+  use a maintenance session on the homelab runner to unlock once and store
+  the `BW_SESSION` in the session environment for subsequent dispatches.


### PR DESCRIPTION
Adds runbook entries to  describing how to unlock Bitwarden on the homelab runner, export  for automation, and manual verification steps for  and OpenWebUI endpoints.