### PR TITLE
ci: fix rotate-openwebui-api-key workflow

### DIFF
--- a/.github/workflows/rotate-openwebui-api-key.yml
+++ b/.github/workflows/rotate-openwebui-api-key.yml
@@ -8,6 +8,9 @@ jobs:
     name: Rotate and verify OpenWebUI API key
     runs-on: [self-hosted, homelab-only]
     environment: homelab
+    env:
+      OPENWEBUI_EMAIL: ${{ secrets.OPENWEBUI_EMAIL }}
+      OPENWEBUI_PASSWORD: ${{ secrets.OPENWEBUI_PASSWORD }}
     steps:
       - name: Check runner
         run: |
@@ -16,41 +19,41 @@ jobs:
       - name: Rotate API key and write token
         run: |
           set -euo pipefail
-          PY='''
-          import json, urllib.request, urllib.error, sys
+            PY='''
+            import json, urllib.request, urllib.error, sys, os
 
-          BASE='http://127.0.0.1:3000'
-          EMAIL='edenilson.adm@gmail.com'
-          PASSWORD='Eddie@2026'
+            BASE='http://127.0.0.1:3000'
+            EMAIL = os.environ.get('OPENWEBUI_EMAIL')
+            PASSWORD = os.environ.get('OPENWEBUI_PASSWORD')
 
-          def http_post(url, data=None, headers=None):
+            def http_post(url, data=None, headers=None):
               d = json.dumps(data).encode() if data is not None else b''
               req = urllib.request.Request(url, data=d, headers=headers or {}, method='POST')
               with urllib.request.urlopen(req, timeout=15) as r:
-                  return json.load(r)
+                return json.load(r)
 
-          try:
+            try:
               # Sign in
               signin = http_post(f"{BASE}/api/v1/auths/signin", {"email": EMAIL, "password": PASSWORD}, {"Content-Type": "application/json"})
               token = signin.get('token')
               if not token:
-                  print('signin_failed', signin)
-                  sys.exit(2)
+                print('signin_failed', signin)
+                sys.exit(2)
 
               # Create API key
               ak = http_post(f"{BASE}/api/v1/auths/api_key", None, {"Authorization": f"Bearer {token}"})
               api_key = ak.get('api_key')
               if not api_key:
-                  print('create_key_failed', ak)
-                  sys.exit(3)
+                print('create_key_failed', ak)
+                sys.exit(3)
 
               # Write token file
               open('/home/homelab/.openwebui_token', 'w').write(api_key)
               print('OK')
-          except Exception as e:
+            except Exception as e:
               print('error', type(e).__name__, str(e))
               sys.exit(4)
-          '''
+            '''
 
           python3 - <<'PY'
           ${PY}


### PR DESCRIPTION
Fix YAML indentation in rotate-openwebui-api-key.yml to resolve CI parse failure.