### PR TITLE
Add NAS tape ops and Q30 BLE label workflow

### DIFF
--- a/scripts/automation/nas_tape_ops.sh
+++ b/scripts/automation/nas_tape_ops.sh
@@ -34,7 +34,7 @@ trim() {
 is_loaded() {
   local nst="$1"
   local out
-  if ! out="$(timeout 8 mt -f "$nst" status 2>&1 || true)"; then
+  if ! out="$(timeout 8 mt -f "$nst" status 2>&1)"; then
     return 1
   fi
   if grep -q "DR_OPEN" <<<"$out"; then

--- a/scripts/automation/nas_tape_ops.sh
+++ b/scripts/automation/nas_tape_ops.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Uso:
+  nas_tape_ops.sh status [--tape <barcode_ou_serial>]
+  nas_tape_ops.sh eject --tape <barcode_ou_serial>
+  nas_tape_ops.sh bench-rw --tape <barcode_ou_serial> [--size-mb N] --yes-destructive
+
+Exemplos:
+  nas_tape_ops.sh status
+  nas_tape_ops.sh status --tape SG0R26
+  nas_tape_ops.sh eject --tape SG0R26
+  nas_tape_ops.sh bench-rw --tape SG0R26 --size-mb 512 --yes-destructive
+EOF
+}
+
+require_cmds() {
+  local missing=0
+  for c in lsscsi mt sg_logs timeout; do
+    if ! command -v "$c" >/dev/null 2>&1; then
+      echo "Erro: comando ausente: $c" >&2
+      missing=1
+    fi
+  done
+  [[ "$missing" -eq 0 ]] || exit 1
+}
+
+trim() {
+  sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+is_loaded() {
+  local nst="$1"
+  local out
+  if ! out="$(timeout 8 mt -f "$nst" status 2>&1 || true)"; then
+    return 1
+  fi
+  if grep -q "DR_OPEN" <<<"$out"; then
+    return 1
+  fi
+  if grep -qi "No medium" <<<"$out"; then
+    return 1
+  fi
+  grep -q "ONLINE" <<<"$out"
+}
+
+get_field_from_logs() {
+  local sg="$1"
+  local field="$2"
+  timeout 10 sg_logs -p 0x17 "$sg" 2>/dev/null | awk -F':' -v k="$field" '$1 ~ k {print $2; exit}' | trim
+}
+
+list_tapes() {
+  lsscsi -g | awk '
+    $2=="tape" {
+      st=""; sg="";
+      for (i=1; i<=NF; i++) {
+        if ($i ~ /^\/dev\/st[0-9]+$/) st=$i;
+        if ($i ~ /^\/dev\/sg[0-9]+$/) sg=$i;
+      }
+      if (st != "" && sg != "") print st, sg;
+    }
+  '
+}
+
+resolve_nst_from_st() {
+  local st="$1"
+  local n="${st##*/st}"
+  echo "/dev/nst${n}"
+}
+
+find_candidates() {
+  local query="${1:-}"
+  local st sg nst barcode serial
+  while read -r st sg; do
+    [[ -n "${st:-}" && -n "${sg:-}" ]] || continue
+    nst="$(resolve_nst_from_st "$st")"
+    barcode="$(get_field_from_logs "$sg" "Volume barcode")"
+    serial="$(get_field_from_logs "$sg" "Volume serial number")"
+    if [[ -n "$query" ]]; then
+      shopt -s nocasematch
+      if [[ "$barcode" == *"$query"* || "$serial" == *"$query"* ]]; then
+        echo "$st|$nst|$sg|$barcode|$serial"
+      fi
+      shopt -u nocasematch
+    else
+      if is_loaded "$nst"; then
+        echo "$st|$nst|$sg|$barcode|$serial"
+      fi
+    fi
+  done < <(list_tapes)
+}
+
+print_status() {
+  local st nst sg barcode serial
+  echo "st|nst|sg|loaded|barcode|serial"
+  while IFS='|' read -r st nst sg barcode serial; do
+    [[ -n "${st:-}" ]] || continue
+    if is_loaded "$nst"; then
+      echo "$st|$nst|$sg|yes|$barcode|$serial"
+    else
+      echo "$st|$nst|$sg|no|$barcode|$serial"
+    fi
+  done < <(
+    while read -r st sg; do
+      nst="$(resolve_nst_from_st "$st")"
+      barcode="$(get_field_from_logs "$sg" "Volume barcode")"
+      serial="$(get_field_from_logs "$sg" "Volume serial number")"
+      echo "$st|$nst|$sg|$barcode|$serial"
+    done < <(list_tapes)
+  )
+}
+
+unmount_ltfs_for_sg() {
+  local sg="$1"
+  local mp
+  while read -r mp; do
+    [[ -n "${mp:-}" ]] || continue
+    umount "$mp" 2>/dev/null || umount -l "$mp" 2>/dev/null || true
+  done < <(mount | awk -v s="ltfs:${sg}" '$1==s {print $3}')
+}
+
+kill_ltfs_for_sg() {
+  local sg="$1"
+  local pids
+  pids="$(ps -ef | awk -v d="$sg" '$0 ~ /ltfs/ && $0 ~ ("devname=" d) {print $2}')"
+  if [[ -n "$pids" ]]; then
+    kill $pids 2>/dev/null || true
+    sleep 1
+    kill -9 $pids 2>/dev/null || true
+  fi
+}
+
+safe_eject() {
+  local st="$1" nst="$2" sg="$3"
+  echo "Eject alvo: st=$st nst=$nst sg=$sg"
+  unmount_ltfs_for_sg "$sg"
+  kill_ltfs_for_sg "$sg"
+  sync; sync
+  timeout 20 mt -f "$nst" unlock >/dev/null 2>&1 || true
+  if command -v sg_prevent >/dev/null 2>&1; then
+    timeout 20 sg_prevent --allow "$sg" >/dev/null 2>&1 || true
+  fi
+  timeout 30 mt -f "$nst" rewind >/dev/null 2>&1 || true
+  timeout 30 mt -f "$nst" rewoffl >/dev/null 2>&1 || true
+  timeout 30 mt -f "$nst" offline >/dev/null 2>&1 || true
+  timeout 30 mt -f "$nst" eject >/dev/null 2>&1 || true
+
+  local out
+  out="$(timeout 10 mt -f "$nst" status 2>&1 || true)"
+  if grep -q "DR_OPEN" <<<"$out" || grep -qi "No medium" <<<"$out"; then
+    echo "OK: fita ejetada ($nst)"
+  else
+    echo "ATENCAO: estado apos eject requer validacao manual."
+    echo "$out"
+    return 1
+  fi
+}
+
+bench_rw() {
+  local nst="$1" size_mb="$2" destructive_ok="$3"
+  if [[ "$destructive_ok" != "yes" ]]; then
+    echo "Erro: bench-rw exige --yes-destructive" >&2
+    return 1
+  fi
+
+  echo "Benchmark RW em $nst (append no EOD), tamanho=${size_mb}MiB"
+  timeout 30 mt -f "$nst" status >/dev/null
+  timeout 60 mt -f "$nst" eod
+
+  echo "[WRITE]"
+  (dd if=/dev/zero of="$nst" bs=1M count="$size_mb" status=progress) 2>&1
+  timeout 30 mt -f "$nst" weof 1
+
+  echo "[READBACK]"
+  timeout 30 mt -f "$nst" bsf 1 || true
+  (dd if="$nst" of=/dev/null bs=1M iflag=fullblock count="$size_mb" status=progress) 2>&1
+
+  timeout 60 mt -f "$nst" rewind || true
+}
+
+OP="${1:-}"
+shift || true
+TAPE_QUERY=""
+SIZE_MB=512
+DESTRUCTIVE_OK="no"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tape)
+      TAPE_QUERY="${2:-}"
+      shift 2
+      ;;
+    --size-mb)
+      SIZE_MB="${2:-512}"
+      shift 2
+      ;;
+    --yes-destructive)
+      DESTRUCTIVE_OK="yes"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Argumento invalido: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_cmds
+
+case "$OP" in
+  status)
+    print_status
+    if [[ -n "$TAPE_QUERY" ]]; then
+      echo
+      echo "Filtro por tape='$TAPE_QUERY':"
+      find_candidates "$TAPE_QUERY" || true
+    fi
+    ;;
+  eject)
+    [[ -n "$TAPE_QUERY" ]] || { echo "Erro: informe --tape <barcode_ou_serial>" >&2; exit 1; }
+    mapfile -t matches < <(find_candidates "$TAPE_QUERY")
+    [[ "${#matches[@]}" -ge 1 ]] || { echo "Erro: fita '$TAPE_QUERY' nao encontrada." >&2; exit 1; }
+    if [[ "${#matches[@]}" -gt 1 ]]; then
+      echo "Erro: consulta ambigua para '$TAPE_QUERY':" >&2
+      printf '%s\n' "${matches[@]}" >&2
+      exit 1
+    fi
+    IFS='|' read -r st nst sg barcode serial <<<"${matches[0]}"
+    safe_eject "$st" "$nst" "$sg"
+    ;;
+  bench-rw)
+    [[ -n "$TAPE_QUERY" ]] || { echo "Erro: informe --tape <barcode_ou_serial>" >&2; exit 1; }
+    mapfile -t matches < <(find_candidates "$TAPE_QUERY")
+    [[ "${#matches[@]}" -ge 1 ]] || { echo "Erro: fita '$TAPE_QUERY' nao encontrada." >&2; exit 1; }
+    if [[ "${#matches[@]}" -gt 1 ]]; then
+      echo "Erro: consulta ambigua para '$TAPE_QUERY':" >&2
+      printf '%s\n' "${matches[@]}" >&2
+      exit 1
+    fi
+    IFS='|' read -r _st nst _sg _barcode _serial <<<"${matches[0]}"
+    bench_rw "$nst" "$SIZE_MB" "$DESTRUCTIVE_OK"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/automation/print_q30_tape_label.sh
+++ b/scripts/automation/print_q30_tape_label.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Uso:
+  print_q30_tape_label.sh --tape-name <NOME_FITA> [opcoes]
+
+Opcoes:
+  --health <valor>          Saude da fita (ex: 100%, N/A). Padrao: N/A
+  --status <valor>          Status da fita. Padrao: TESTE
+  --bt-mac <mac>            MAC BLE da Q30 (padrao: DD:FE:25:83:BE:69)
+  --driver-dir <path>       Diretorio do driver phomemo-q30-driver
+                            (padrao: /tmp/phomemo-q30-driver)
+  --python <bin>            Python a usar (padrao: /tmp/phomemo-venv/bin/python, fallback python3)
+  --label-width-mm <n>      Largura da fita em mm (padrao: 12)
+  --label-length-mm <n>     Comprimento da etiqueta em mm (padrao: 50)
+  --font-size <n>           Tamanho da fonte (padrao: 26)
+  --retries <n>             Tentativas de reconexao BLE (padrao: 5)
+  --date-format <fmt>       Formato da data (padrao: %d/%m/%Y)
+  --dry-run                 Mostra comando sem imprimir
+  -h, --help                Ajuda
+
+Exemplo:
+  ./print_q30_tape_label.sh --tape-name SG0R26 --health 100% --status ONLINE
+EOF
+}
+
+TAPE_NAME=""
+HEALTH="N/A"
+STATUS_TEXT="TESTE"
+BT_MAC="${Q30_BT_MAC:-DD:FE:25:83:BE:69}"
+DRIVER_DIR="/tmp/phomemo-q30-driver"
+if [[ -x "/tmp/phomemo-venv/bin/python" ]]; then
+  PYTHON_BIN="/tmp/phomemo-venv/bin/python"
+else
+  PYTHON_BIN="python3"
+fi
+LABEL_WIDTH_MM=12
+LABEL_LENGTH_MM=50
+FONT_SIZE=26
+RETRIES=5
+DATE_FMT="%d/%m/%Y"
+DRY_RUN="no"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tape-name)
+      TAPE_NAME="${2:-}"
+      shift 2
+      ;;
+    --health)
+      HEALTH="${2:-}"
+      shift 2
+      ;;
+    --status)
+      STATUS_TEXT="${2:-}"
+      shift 2
+      ;;
+    --bt-mac)
+      BT_MAC="${2:-}"
+      shift 2
+      ;;
+    --driver-dir)
+      DRIVER_DIR="${2:-}"
+      shift 2
+      ;;
+    --python)
+      PYTHON_BIN="${2:-}"
+      shift 2
+      ;;
+    --label-width-mm)
+      LABEL_WIDTH_MM="${2:-12}"
+      shift 2
+      ;;
+    --label-length-mm)
+      LABEL_LENGTH_MM="${2:-50}"
+      shift 2
+      ;;
+    --font-size)
+      FONT_SIZE="${2:-26}"
+      shift 2
+      ;;
+    --retries)
+      RETRIES="${2:-5}"
+      shift 2
+      ;;
+    --date-format)
+      DATE_FMT="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="yes"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Argumento invalido: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAPE_NAME" ]]; then
+  echo "Erro: informe --tape-name <NOME_FITA>" >&2
+  exit 1
+fi
+
+if [[ ! -d "$DRIVER_DIR" ]]; then
+  echo "Erro: diretorio do driver nao encontrado: $DRIVER_DIR" >&2
+  exit 1
+fi
+
+TODAY="$(date +"$DATE_FMT")"
+LABEL_TEXT="FITA: ${TAPE_NAME}
+SAUDE: ${HEALTH}
+STATUS: ${STATUS_TEXT}
+DATA: ${TODAY}"
+
+if [[ "$LABEL_WIDTH_MM" -ne 12 ]]; then
+  echo "Aviso: o driver Q30 atual suporta largura efetiva de 12mm. Usando 12mm." >&2
+  LABEL_WIDTH_MM=12
+fi
+
+echo "Etiqueta:"
+echo "$LABEL_TEXT"
+echo
+echo "Config:"
+echo "  MAC BLE: $BT_MAC"
+echo "  Driver:  $DRIVER_DIR"
+echo "  Python:  $PYTHON_BIN"
+echo "  Fita:    ${LABEL_WIDTH_MM}x${LABEL_LENGTH_MM}mm"
+echo "  Fonte:   ${FONT_SIZE}"
+echo "  Retries: ${RETRIES}"
+
+if [[ "$DRY_RUN" == "yes" ]]; then
+  exit 0
+fi
+
+Q30_BT_MAC="$BT_MAC" \
+Q30_DRIVER_DIR="$DRIVER_DIR" \
+Q30_LABEL_TEXT="$LABEL_TEXT" \
+Q30_LABEL_WIDTH_MM="$LABEL_WIDTH_MM" \
+Q30_LABEL_LENGTH_MM="$LABEL_LENGTH_MM" \
+Q30_FONT_SIZE="$FONT_SIZE" \
+Q30_RETRIES="$RETRIES" \
+"$PYTHON_BIN" -u - <<'PY'
+import asyncio
+import os
+import sys
+from PIL import Image, ImageDraw, ImageFont
+
+driver_dir = os.environ["Q30_DRIVER_DIR"]
+sys.path.insert(0, driver_dir)
+
+from phomemo_q30 import PhomemoQ30  # noqa: E402
+from image_processor import ImageProcessor  # noqa: E402
+from bleak import BleakScanner  # noqa: E402
+
+mac = os.environ["Q30_BT_MAC"]
+tape_text = os.environ["Q30_LABEL_TEXT"]
+width_mm = int(os.environ["Q30_LABEL_WIDTH_MM"])
+length_mm = int(os.environ["Q30_LABEL_LENGTH_MM"])
+font_size = int(os.environ["Q30_FONT_SIZE"])
+retries = int(os.environ["Q30_RETRIES"])
+
+# Conversao conhecida para Q30 (largura em bytes = mm * 8 / 8 = mm)
+width_px_map = {12: 96}
+ImageProcessor.LABEL_WIDTH_MM = width_mm
+ImageProcessor.LABEL_WIDTH_PX = width_px_map.get(width_mm, 96)
+
+img_h = ImageProcessor.LABEL_WIDTH_PX
+img_w = max(320, length_mm * 8)
+img = Image.new("L", (img_w, img_h), 255)
+draw = ImageDraw.Draw(img)
+font_paths = [
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+]
+font = ImageFont.load_default()
+for p in font_paths:
+    if os.path.exists(p):
+        font = ImageFont.truetype(p, font_size)
+        break
+draw.text((8, 8), tape_text, fill=0, font=font)
+img_path = "/tmp/q30_tape_label.png"
+img.save(img_path)
+
+async def main():
+    async def discover_targets():
+        targets = []
+        if mac:
+            targets.append(mac.upper())
+        try:
+            found = await BleakScanner.discover(timeout=8.0)
+            for d in found:
+                name = (d.name or "").upper()
+                if ("Q30" in name) or ("PHOMEMO" in name) or ("D30" in name):
+                    addr = (d.address or "").upper()
+                    if addr and addr not in targets:
+                        targets.append(addr)
+        except Exception as e:
+            print(f"DISCOVERY_WARN {e}", flush=True)
+        return targets
+
+    for attempt in range(1, retries + 1):
+        print(f"ATTEMPT {attempt}", flush=True)
+        targets = await discover_targets()
+        print("TARGETS", ",".join(targets) if targets else "NONE", flush=True)
+        if not targets:
+            await asyncio.sleep(2)
+            continue
+        for addr in targets:
+            printer = PhomemoQ30(length_mm)
+            ok = await printer.connect_async(addr)
+            print(f"CONNECT {addr} {ok}", flush=True)
+            if not ok:
+                continue
+            printed = await printer.print_image_async(img_path)
+            print(f"PRINT {addr} {printed}", flush=True)
+            await printer.disconnect_async()
+            if printed:
+                return 0
+        await asyncio.sleep(2)
+    return 1
+
+rc = asyncio.run(main())
+raise SystemExit(rc)
+PY

--- a/scripts/automation/print_q30_tape_label.sh
+++ b/scripts/automation/print_q30_tape_label.sh
@@ -121,6 +121,14 @@ SAUDE: ${HEALTH}
 STATUS: ${STATUS_TEXT}
 DATA: ${TODAY}"
 
+for _numvar in LABEL_WIDTH_MM LABEL_LENGTH_MM FONT_SIZE RETRIES; do
+  _val="${!_numvar}"
+  if ! [[ "$_val" =~ ^[0-9]+$ ]]; then
+    echo "Erro: --${_numvar,,} exige valor numerico inteiro, recebido: '$_val'" >&2
+    exit 1
+  fi
+done
+
 if [[ "$LABEL_WIDTH_MM" -ne 12 ]]; then
   echo "Aviso: o driver Q30 atual suporta largura efetiva de 12mm. Usando 12mm." >&2
   LABEL_WIDTH_MM=12
@@ -187,7 +195,10 @@ for p in font_paths:
         font = ImageFont.truetype(p, font_size)
         break
 draw.text((8, 8), tape_text, fill=0, font=font)
-img_path = "/tmp/q30_tape_label.png"
+import tempfile as _tempfile
+_tf = _tempfile.NamedTemporaryFile(suffix=".png", delete=False, dir="/tmp", prefix="q30_tape_")
+img_path = _tf.name
+_tf.close()
 img.save(img_path)
 
 async def main():
@@ -229,5 +240,10 @@ async def main():
     return 1
 
 rc = asyncio.run(main())
+try:
+    import os as _os
+    _os.unlink(img_path)
+except OSError:
+    pass
 raise SystemExit(rc)
 PY


### PR DESCRIPTION
## Summary
- add dynamic NAS tape operations by tape barcode or serial instead of fixed deck assumptions
- add BLE-based Q30 tape label printing with retry/discovery logic and validated 12x50 effective profile
- keep the new tape and printer automation isolated from unrelated local worktree changes

## Validation
- bash -n scripts/automation/nas_tape_ops.sh
- bash -n scripts/automation/print_q30_tape_label.sh
- validated live BLE printing to the Q30 with successful physical output
- validated NAS tape status and non-destructive benchmark flow against the library