### PR TITLE
fix: TP mínimo 1.3% + guardrail 1% net

### DIFF
--- a/btc_trading_agent/config_BTC_USDT_aggressive.json
+++ b/btc_trading_agent/config_BTC_USDT_aggressive.json
@@ -57,7 +57,7 @@
   "auto_take_profit": {
     "enabled": true,
     "pct": 0.015,
-    "min_pct": 0.005
+    "min_pct": 0.013
   },
   "min_net_profit": {
     "usd": 0.1,
@@ -70,6 +70,6 @@
   },
   "profile": "aggressive",
   "guardrails_active": true,
-  "guardrails_min_sell_pnl_pct": 0.003,
+  "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_positive_only_sells": false
 }

--- a/btc_trading_agent/config_BTC_USDT_conservative.json
+++ b/btc_trading_agent/config_BTC_USDT_conservative.json
@@ -57,7 +57,7 @@
   "auto_take_profit": {
     "enabled": true,
     "pct": 0.02,
-    "min_pct": 0.005
+    "min_pct": 0.013
   },
   "min_net_profit": {
     "usd": 0.1,
@@ -75,7 +75,7 @@
     "hodl_benchmark": "+$22.30 (41d)",
     "date": "2025-04-09"
   },
-  "guardrails_min_sell_pnl_pct": 0.003,
+  "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_active": true,
   "guardrails_positive_only_sells": false
 }

--- a/patches/config_BTC_USDT_aggressive_optimized.json
+++ b/patches/config_BTC_USDT_aggressive_optimized.json
@@ -57,7 +57,7 @@
   "auto_take_profit": {
     "enabled": true,
     "pct": 0.015,
-    "min_pct": 0.005
+    "min_pct": 0.013
   },
   "min_net_profit": {
     "usd": 0.1,
@@ -70,6 +70,6 @@
   },
   "profile": "aggressive",
   "guardrails_active": true,
-  "guardrails_min_sell_pnl_pct": 0.003,
+  "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_positive_only_sells": false
 }

--- a/patches/config_BTC_USDT_conservative_optimized.json
+++ b/patches/config_BTC_USDT_conservative_optimized.json
@@ -57,7 +57,7 @@
   "auto_take_profit": {
     "enabled": true,
     "pct": 0.02,
-    "min_pct": 0.005
+    "min_pct": 0.013
   },
   "min_net_profit": {
     "usd": 0.1,
@@ -75,7 +75,7 @@
     "hodl_benchmark": "+$22.30 (41d)",
     "date": "2025-04-09"
   },
-  "guardrails_min_sell_pnl_pct": 0.003,
+  "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_active": true,
   "guardrails_positive_only_sells": false
 }


### PR DESCRIPTION
Causa raiz: AI trade window definia TP em ~0.80% gross → net ~0.74% < guardrail 1%. Fix: min_pct do auto_take_profit = 1.3% → net ~1.08% após taxas.