### PR TITLE
fix: positive-only sells — desabilita stop-loss

### DIFF
--- a/btc_trading_agent/config_BTC_USDT_aggressive.json
+++ b/btc_trading_agent/config_BTC_USDT_aggressive.json
@@ -51,7 +51,7 @@
   },
   "live_mode": true,
   "auto_stop_loss": {
-    "enabled": true,
+    "enabled": false,
     "pct": 0.05
   },
   "auto_take_profit": {
@@ -71,5 +71,5 @@
   "profile": "aggressive",
   "guardrails_active": true,
   "guardrails_min_sell_pnl_pct": 0.01,
-  "guardrails_positive_only_sells": false
+  "guardrails_positive_only_sells": true
 }

--- a/btc_trading_agent/config_BTC_USDT_conservative.json
+++ b/btc_trading_agent/config_BTC_USDT_conservative.json
@@ -51,7 +51,7 @@
   },
   "live_mode": true,
   "auto_stop_loss": {
-    "enabled": true,
+    "enabled": false,
     "pct": 0.03
   },
   "auto_take_profit": {
@@ -77,5 +77,5 @@
   },
   "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_active": true,
-  "guardrails_positive_only_sells": false
+  "guardrails_positive_only_sells": true
 }

--- a/patches/config_BTC_USDT_aggressive_optimized.json
+++ b/patches/config_BTC_USDT_aggressive_optimized.json
@@ -51,7 +51,7 @@
   },
   "live_mode": true,
   "auto_stop_loss": {
-    "enabled": true,
+    "enabled": false,
     "pct": 0.05
   },
   "auto_take_profit": {
@@ -71,5 +71,5 @@
   "profile": "aggressive",
   "guardrails_active": true,
   "guardrails_min_sell_pnl_pct": 0.01,
-  "guardrails_positive_only_sells": false
+  "guardrails_positive_only_sells": true
 }

--- a/patches/config_BTC_USDT_conservative_optimized.json
+++ b/patches/config_BTC_USDT_conservative_optimized.json
@@ -51,7 +51,7 @@
   },
   "live_mode": true,
   "auto_stop_loss": {
-    "enabled": true,
+    "enabled": false,
     "pct": 0.03
   },
   "auto_take_profit": {
@@ -77,5 +77,5 @@
   },
   "guardrails_min_sell_pnl_pct": 0.01,
   "guardrails_active": true,
-  "guardrails_positive_only_sells": false
+  "guardrails_positive_only_sells": true
 }


### PR DESCRIPTION
Stop-loss substituído por política positive-only: auto_stop_loss.enabled=false + guardrails_positive_only_sells=true. O trailing stop continua ativo (activation=1%, trail=0.5%).