### PR TITLE
[codex] feat(trading): add kucoin quote command

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -161,6 +161,11 @@ KUCOIN_BASE = os.getenv("KUCOIN_BASE", "https://api.kucoin.com").rstrip("/")
 _SERVER_TIME_OFFSET_MS = 0
 _SERVER_TIME_SYNC_TTL_SECONDS = 30.0
 _SERVER_TIME_LAST_SYNC = 0.0
+_SYMBOLS_CACHE_TTL_SECONDS = 300.0
+_SYMBOLS_CACHE: Dict[str, Any] = {
+    "expires_at": 0.0,
+    "symbols": [],
+}
 
 # ====================== RATE LIMITING ======================
 _last_request_time = 0
@@ -340,27 +345,238 @@ def _signed_request(
     raise RuntimeError("Unexpected signed request flow termination")
 
 # ====================== PUBLIC ENDPOINTS ======================
+def normalize_symbol(symbol: str) -> str:
+    """Normaliza pares para o formato BASE-QUOTE usado pela KuCoin."""
+    raw = (symbol or "").strip().upper()
+    if not raw:
+        return ""
+
+    for separator in ("/", "_", " "):
+        raw = raw.replace(separator, "-")
+
+    parts = [part for part in raw.split("-") if part]
+    if len(parts) >= 2:
+        return f"{parts[0]}-{parts[1]}"
+    return parts[0] if parts else ""
+
+
+@retry_on_failure(max_retries=2)
+def get_symbols(refresh: bool = False, include_disabled: bool = False) -> List[Dict[str, Any]]:
+    """Lista símbolos negociáveis da KuCoin com cache curto."""
+    now = time.time()
+    cached_symbols = _SYMBOLS_CACHE.get("symbols", [])
+    if (
+        not refresh
+        and cached_symbols
+        and float(_SYMBOLS_CACHE.get("expires_at", 0.0) or 0.0) > now
+    ):
+        if include_disabled:
+            return list(cached_symbols)
+        return [item for item in cached_symbols if bool(item.get("enableTrading", True))]
+
+    url = f"{KUCOIN_BASE}/api/v2/symbols"
+    try:
+        rate_limit()
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        raw_items = r.json().get("data", [])
+        parsed: List[Dict[str, Any]] = []
+        for item in raw_items:
+            symbol = normalize_symbol(str(item.get("symbol") or ""))
+            if not symbol:
+                continue
+
+            parsed.append(
+                {
+                    **item,
+                    "symbol": symbol,
+                    "baseCurrency": str(item.get("baseCurrency") or "").upper(),
+                    "quoteCurrency": str(item.get("quoteCurrency") or "").upper(),
+                    "enableTrading": bool(item.get("enableTrading", False)),
+                }
+            )
+
+        _SYMBOLS_CACHE["symbols"] = parsed
+        _SYMBOLS_CACHE["expires_at"] = now + _SYMBOLS_CACHE_TTL_SECONDS
+        if include_disabled:
+            return list(parsed)
+        return [item for item in parsed if bool(item.get("enableTrading", True))]
+    except Exception as e:
+        logger.warning(f"⚠️ Error getting symbols: {e}")
+        if include_disabled:
+            return list(cached_symbols)
+        return [item for item in cached_symbols if bool(item.get("enableTrading", True))]
+
+
+def resolve_symbol(
+    query: str,
+    default_quote: str = "USDT",
+    preferred_quotes: Optional[List[str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve consulta livre para um par listado na KuCoin."""
+    normalized = normalize_symbol(query)
+    if not normalized:
+        return None
+
+    symbols = get_symbols()
+    if not symbols:
+        return None
+
+    by_symbol = {str(item.get("symbol") or ""): item for item in symbols}
+    direct_match = by_symbol.get(normalized)
+    if direct_match:
+        return {**direct_match, "matchedBy": "symbol"}
+
+    if "-" in normalized:
+        return None
+
+    base_asset = normalized
+    quote_order: List[str] = []
+    for quote in [default_quote, *(preferred_quotes or []), "USDT", "BRL", "USD", "USDC", "BTC", "ETH", "EUR"]:
+        quote_up = str(quote or "").upper()
+        if quote_up and quote_up not in quote_order:
+            quote_order.append(quote_up)
+
+    candidates = [
+        item for item in symbols
+        if str(item.get("baseCurrency") or "").upper() == base_asset
+    ]
+    if candidates:
+        def _candidate_sort(item: Dict[str, Any]) -> tuple[int, str]:
+            quote = str(item.get("quoteCurrency") or "").upper()
+            try:
+                rank = quote_order.index(quote)
+            except ValueError:
+                rank = len(quote_order)
+            return rank, str(item.get("symbol") or "")
+
+        best = sorted(candidates, key=_candidate_sort)[0]
+        return {**best, "matchedBy": "baseCurrency"}
+
+    inverse_candidates = [
+        item for item in symbols
+        if str(item.get("quoteCurrency") or "").upper() == base_asset
+    ]
+    if inverse_candidates:
+        best = sorted(
+            inverse_candidates,
+            key=lambda item: str(item.get("symbol") or ""),
+        )[0]
+        return {**best, "matchedBy": "quoteCurrency"}
+
+    return None
+
+
+def search_symbols(query: str, limit: int = 5) -> List[Dict[str, Any]]:
+    """Busca pares próximos quando a consulta não resolve diretamente."""
+    needle = normalize_symbol(query)
+    if not needle:
+        return []
+
+    compact = needle.replace("-", "")
+    matches: List[Dict[str, Any]] = []
+    for item in get_symbols():
+        symbol = str(item.get("symbol") or "")
+        base = str(item.get("baseCurrency") or "")
+        quote = str(item.get("quoteCurrency") or "")
+        haystacks = (
+            symbol,
+            base,
+            quote,
+            symbol.replace("-", ""),
+        )
+        if any(compact in candidate for candidate in haystacks):
+            matches.append(item)
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+@retry_on_failure(max_retries=2)
+def get_ticker(symbol: str) -> Dict[str, Any]:
+    """Obtém snapshot level1 de um par."""
+    normalized = normalize_symbol(symbol)
+    if not normalized:
+        return {}
+
+    url = f"{KUCOIN_BASE}/api/v1/market/orderbook/level1?symbol={normalized}"
+    try:
+        rate_limit()
+        r = requests.get(url, timeout=5)
+        r.raise_for_status()
+        payload = r.json()
+        data = payload.get("data") or {}
+        if not data:
+            return {}
+
+        def _to_float(value: Any) -> float:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return 0.0
+
+        return {
+            "symbol": normalized,
+            "price": _to_float(data.get("price")),
+            "bestBid": _to_float(data.get("bestBid")),
+            "bestAsk": _to_float(data.get("bestAsk")),
+            "size": _to_float(data.get("size")),
+            "time": int(data.get("time") or 0),
+            "sequence": str(data.get("sequence") or ""),
+        }
+    except Exception as e:
+        logger.warning(f"⚠️ Error getting ticker: {e}")
+        return {}
+
+
+def get_quote_snapshot(
+    query: str,
+    default_quote: str = "USDT",
+    preferred_quotes: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Resolve uma moeda/par e retorna snapshot pronto para exibição."""
+    match = resolve_symbol(
+        query,
+        default_quote=default_quote,
+        preferred_quotes=preferred_quotes,
+    )
+    if not match:
+        return {}
+
+    ticker = get_ticker(str(match.get("symbol") or ""))
+    if not ticker:
+        return {}
+
+    return {
+        **match,
+        **ticker,
+        "requested": (query or "").strip(),
+    }
+
+
 @retry_on_failure(max_retries=2)
 def get_price(symbol: str = "BTC-USDT") -> Optional[float]:
     """Obtém preço atual de um par"""
-    url = f"{KUCOIN_BASE}/api/v1/market/orderbook/level1?symbol={symbol}"
     try:
-        rate_limit()
-        r = requests.get(url, timeout=3)
-        r.raise_for_status()
-        data = r.json().get("data", {})
-        if data:
-            bid = float(data.get("bestBid", 0))
-            ask = float(data.get("bestAsk", 0))
-            return (bid + ask) / 2 if bid and ask else None
+        ticker = get_ticker(symbol)
+        if ticker:
+            bid = float(ticker.get("bestBid") or 0.0)
+            ask = float(ticker.get("bestAsk") or 0.0)
+            if bid and ask:
+                return (bid + ask) / 2
+            price = float(ticker.get("price") or 0.0)
+            return price or None
     except Exception as e:
         logger.warning(f"⚠️ Error getting price: {e}")
     return None
 
 def get_price_fast(symbol: str = "BTC-USDT", timeout: float = 1.5) -> Optional[float]:
     """Versão ultra-rápida sem retry"""
-    url = f"{KUCOIN_BASE}/api/v1/market/orderbook/level1?symbol={symbol}"
     try:
+        normalized = normalize_symbol(symbol)
+        if not normalized:
+            return None
+        url = f"{KUCOIN_BASE}/api/v1/market/orderbook/level1?symbol={normalized}"
         r = requests.get(url, timeout=timeout)
         if r.status_code == 200:
             data = r.json().get("data", {})

--- a/btc_trading_agent/telegram_trading.py
+++ b/btc_trading_agent/telegram_trading.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Integração leve de trading para o bot do Telegram."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
+
+TRADING_COMMANDS = [
+    "/btc",
+    "/trades",
+    "/performance",
+    "/signal",
+    "/trading",
+    "/cotacao",
+]
+
+DEFAULT_STATUS_SYMBOL = os.getenv("TRADING_STATUS_SYMBOL", "BTC-USDT").upper()
+DEFAULT_QUOTE = os.getenv("TRADING_DEFAULT_QUOTE", "USDT").upper()
+DEFAULT_PERFORMANCE_DAYS = int(os.getenv("TRADING_PERFORMANCE_DAYS", "7"))
+LOCAL_TZ = ZoneInfo(os.getenv("TRADING_TIMEZONE", "America/Sao_Paulo"))
+QUOTE_STOPWORDS = {
+    "A", "AS", "COTACAO", "COTACAO?", "COTAÇÃO", "CONSULTAR", "DA", "DAS", "DE",
+    "DO", "DOS", "KUCOIN", "ME", "MOEDA", "MOSTRA", "MOSTRE", "NA", "NO", "O",
+    "OS", "PAR", "PARES", "PRECO", "PREÇO", "QUAL", "QUOTE", "VALOR", "VER",
+}
+
+
+def get_trading_help() -> str:
+    """Ajuda resumida do agent trading no Telegram."""
+    return (
+        "📈 *Trading Agent*\n\n"
+        "/btc - Status resumido do BTC\n"
+        "/trades [limite] - Últimos trades gravados\n"
+        "/performance - Performance recente\n"
+        "/signal - Último sinal registrado\n"
+        "/cotacao [moeda|par] - Cotação na KuCoin\n"
+        "/trading [pergunta] - Consulta livre\n\n"
+        "*Exemplos de cotação:*\n"
+        "• /cotacao AKT\n"
+        "• /cotacao AKT-BRL\n"
+        "• /cotacao BTC/USDT"
+    )
+
+
+def _escape_markdown(text: Any) -> str:
+    raw = str(text or "")
+    for token in ("\\", "_", "*", "`", "["):
+        raw = raw.replace(token, f"\\{token}")
+    return raw
+
+
+def _format_timestamp_ms(timestamp_ms: int | float | None) -> str:
+    try:
+        ts_int = int(timestamp_ms or 0)
+    except (TypeError, ValueError):
+        return "n/d"
+    if ts_int <= 0:
+        return "n/d"
+    return datetime.fromtimestamp(ts_int / 1000, tz=LOCAL_TZ).strftime("%d/%m/%Y %H:%M:%S %Z")
+
+
+def _format_timestamp_seconds(timestamp_seconds: int | float | None) -> str:
+    try:
+        ts_value = float(timestamp_seconds or 0.0)
+    except (TypeError, ValueError):
+        return "n/d"
+    if ts_value <= 0:
+        return "n/d"
+    return datetime.fromtimestamp(ts_value, tz=LOCAL_TZ).strftime("%d/%m %H:%M")
+
+
+def _format_price(value: Any) -> str:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "n/d"
+    if numeric == 0:
+        return "0"
+    if abs(numeric) >= 1000:
+        return f"{numeric:,.2f}"
+    if abs(numeric) >= 1:
+        return f"{numeric:,.4f}"
+    return f"{numeric:,.6f}"
+
+
+def _format_quantity(value: Any) -> str:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "n/d"
+    if numeric == 0:
+        return "0"
+    return f"{numeric:,.8f}".rstrip("0").rstrip(".")
+
+
+def _load_kucoin_api_module():
+    try:
+        return importlib.import_module("btc_trading_agent.kucoin_api")
+    except ImportError:
+        return importlib.import_module("kucoin_api")
+
+
+def _load_training_db_module():
+    try:
+        return importlib.import_module("btc_trading_agent.training_db")
+    except ImportError:
+        return importlib.import_module("training_db")
+
+
+class TelegramTradingClient:
+    """Cliente enxuto para consultas do agent trading via Telegram."""
+
+    def __init__(self, base_dir: Optional[Path] = None) -> None:
+        self.base_dir = base_dir or Path(__file__).parent
+        self.default_status_symbol = DEFAULT_STATUS_SYMBOL
+        self.default_quote = DEFAULT_QUOTE
+        self.default_performance_days = DEFAULT_PERFORMANCE_DAYS
+        self._db = None
+        self._db_error: Optional[str] = None
+
+    def _get_db(self):
+        if self._db is not None:
+            return self._db
+        if self._db_error:
+            return None
+        try:
+            training_db = _load_training_db_module()
+            self._db = training_db.TrainingDatabase()
+            return self._db
+        except Exception as exc:
+            self._db_error = str(exc)
+            return None
+
+    def _extract_quote_query(self, text: str) -> str:
+        raw = (text or "").strip()
+        if not raw:
+            return ""
+
+        normalized = (
+            unicodedata.normalize("NFKD", raw)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+
+        pair_match = re.search(r"([A-Za-z0-9]{2,12})\s*[-/_]\s*([A-Za-z0-9]{2,12})", normalized)
+        if pair_match:
+            return f"{pair_match.group(1)}-{pair_match.group(2)}".upper()
+
+        tokens = re.findall(r"[A-Za-z0-9]{2,12}", normalized.upper())
+        for token in tokens:
+            if token not in QUOTE_STOPWORDS:
+                return token
+        return ""
+
+    async def get_quote(self, query: str) -> str:
+        requested = (query or "").strip()
+        if not requested:
+            return (
+                "❓ Use: /cotacao [moeda ou par]\n\n"
+                "Exemplos:\n"
+                "• /cotacao AKT\n"
+                "• /cotacao AKT-BRL\n"
+                "• /cotacao BTC/USDT"
+            )
+
+        kucoin_api = _load_kucoin_api_module()
+        snapshot = kucoin_api.get_quote_snapshot(
+            requested,
+            default_quote=self.default_quote,
+            preferred_quotes=["BRL", "USDT", "USDC"],
+        )
+        if not snapshot:
+            suggestions = kucoin_api.search_symbols(requested, limit=5)
+            if suggestions:
+                hint = ", ".join(
+                    f"`{item.get('symbol')}`"
+                    for item in suggestions
+                    if item.get("symbol")
+                )
+                return (
+                    f"❌ Não encontrei a cotação de *{_escape_markdown(requested)}* na KuCoin.\n"
+                    f"Talvez você queira: {hint}"
+                )
+            return (
+                f"❌ Não encontrei a cotação de *{_escape_markdown(requested)}* na KuCoin.\n"
+                "Tente um ticker como `AKT`, `BTC-USDT` ou `USDT-BRL`."
+            )
+
+        symbol = str(snapshot.get("symbol") or "")
+        base = str(snapshot.get("baseCurrency") or "").upper()
+        quote = str(snapshot.get("quoteCurrency") or "").upper()
+        matched_by = str(snapshot.get("matchedBy") or "symbol")
+        resolved_note = ""
+        normalized_requested = kucoin_api.normalize_symbol(requested)
+        if normalized_requested != symbol and matched_by == "baseCurrency":
+            resolved_note = f"\nPar resolvido automaticamente: `{symbol}`"
+        elif normalized_requested != symbol and matched_by == "quoteCurrency":
+            resolved_note = f"\nPar encontrado pelo quote: `{symbol}`"
+
+        return (
+            f"💱 *KuCoin* `{symbol}`\n"
+            f"Preço: `{_format_price(snapshot.get('price'))} {quote}`\n"
+            f"Bid/Ask: `{_format_price(snapshot.get('bestBid'))}` / `{_format_price(snapshot.get('bestAsk'))}`\n"
+            f"Último lote: `{_format_quantity(snapshot.get('size'))} {base or 'base'}`\n"
+            f"Atualizado: `{_format_timestamp_ms(snapshot.get('time'))}`"
+            f"{resolved_note}"
+        )
+
+    async def get_status(self) -> str:
+        kucoin_api = _load_kucoin_api_module()
+        symbol = self.default_status_symbol
+        price = kucoin_api.get_price(symbol)
+        db = self._get_db()
+        performance = {}
+        latest_trade: dict[str, Any] | None = None
+        if db is not None:
+            try:
+                performance = db.calculate_performance(symbol, days=self.default_performance_days)
+                recent_trades = db.get_recent_trades(symbol=symbol, limit=1, include_dry=True)
+                latest_trade = recent_trades[0] if recent_trades else None
+            except Exception as exc:
+                if not self._db_error:
+                    self._db_error = str(exc)
+
+        lines = [
+            f"📈 *Status Trading* `{symbol}`",
+            f"Preço KuCoin: `{_format_price(price)} USDT`" if price is not None else "Preço KuCoin: `indisponível`",
+        ]
+        if performance:
+            lines.extend(
+                [
+                    f"Trades {self.default_performance_days}d: `{int(performance.get('total_trades', 0) or 0)}`",
+                    f"Win rate: `{float(performance.get('win_rate', 0.0) or 0.0):.1%}`",
+                    f"PnL: `{float(performance.get('total_pnl', 0.0) or 0.0):.4f} USDT`",
+                ]
+            )
+        else:
+            lines.append("Métricas históricas: `indisponíveis`")
+
+        if latest_trade:
+            lines.append(
+                "Último trade: "
+                f"`{str(latest_trade.get('side') or '').upper()}` "
+                f"@ `{_format_price(latest_trade.get('price'))}` "
+                f"em `{_format_timestamp_seconds(latest_trade.get('timestamp'))}`"
+            )
+        elif self._db_error:
+            lines.append(f"Banco de trades: `{_escape_markdown(self._db_error[:120])}`")
+
+        return "\n".join(lines)
+
+    async def get_trades(self, limit: int = 5) -> str:
+        db = self._get_db()
+        if db is None:
+            detail = f" `{_escape_markdown(self._db_error[:120])}`" if self._db_error else ""
+            return f"⚠️ Banco de trades indisponível.{detail}"
+
+        rows = db.get_recent_trades(
+            symbol=self.default_status_symbol,
+            limit=max(1, min(int(limit or 5), 20)),
+            include_dry=True,
+        )
+        if not rows:
+            return f"📭 Nenhum trade recente encontrado para `{self.default_status_symbol}`."
+
+        lines = [f"🧾 *Últimos trades* `{self.default_status_symbol}`"]
+        for trade in rows:
+            pnl = trade.get("pnl")
+            pnl_text = ""
+            if pnl is not None and str(pnl).strip():
+                try:
+                    pnl_text = f" | pnl `{float(pnl):.4f}`"
+                except (TypeError, ValueError):
+                    pnl_text = f" | pnl `{_escape_markdown(pnl)}`"
+            lines.append(
+                f"• `{_format_timestamp_seconds(trade.get('timestamp'))}` "
+                f"`{str(trade.get('side') or '').upper()}` "
+                f"`{_format_quantity(trade.get('size'))}` @ `{_format_price(trade.get('price'))}`"
+                f"{pnl_text}"
+            )
+        return "\n".join(lines)
+
+    async def get_performance(self) -> str:
+        db = self._get_db()
+        if db is None:
+            detail = f" `{_escape_markdown(self._db_error[:120])}`" if self._db_error else ""
+            return f"⚠️ Banco de performance indisponível.{detail}"
+
+        stats = db.calculate_performance(self.default_status_symbol, days=self.default_performance_days)
+        return (
+            f"📊 *Performance* `{self.default_status_symbol}`\n"
+            f"Janela: `{self.default_performance_days} dias`\n"
+            f"Trades: `{int(stats.get('total_trades', 0) or 0)}`\n"
+            f"Trades vencedores: `{int(stats.get('winning_trades', 0) or 0)}`\n"
+            f"Win rate: `{float(stats.get('win_rate', 0.0) or 0.0):.1%}`\n"
+            f"PnL total: `{float(stats.get('total_pnl', 0.0) or 0.0):.4f} USDT`\n"
+            f"PnL médio: `{float(stats.get('avg_pnl', 0.0) or 0.0):.4f} USDT`"
+        )
+
+    async def get_signal(self) -> str:
+        db = self._get_db()
+        if db is None:
+            detail = f" `{_escape_markdown(self._db_error[:120])}`" if self._db_error else ""
+            return f"⚠️ Banco de sinais indisponível.{detail}"
+
+        decisions = db.get_recent_decisions(symbol=self.default_status_symbol, limit=1)
+        if not decisions:
+            return f"📭 Nenhum sinal recente encontrado para `{self.default_status_symbol}`."
+
+        signal = decisions[0]
+        reason = _escape_markdown(str(signal.get("reason") or "Sem justificativa"))
+        return (
+            f"🧠 *Último sinal* `{self.default_status_symbol}`\n"
+            f"Ação: `{str(signal.get('action') or '').upper()}`\n"
+            f"Confiança: `{float(signal.get('confidence', 0.0) or 0.0):.1%}`\n"
+            f"Preço: `{_format_price(signal.get('price'))}`\n"
+            f"Executado: `{'sim' if signal.get('executed') else 'não'}`\n"
+            f"Horário: `{_format_timestamp_seconds(signal.get('timestamp'))}`\n"
+            f"Motivo: {reason}"
+        )
+
+    async def ask_question(self, question: str) -> str:
+        text = (question or "").strip()
+        if not text:
+            return get_trading_help()
+
+        lowered = text.lower()
+        quote_query = self._extract_quote_query(text)
+        if quote_query and any(
+            keyword in lowered for keyword in ("cotacao", "cotação", "preco", "preço", "quote", "valor")
+        ):
+            return await self.get_quote(quote_query)
+        if quote_query and re.fullmatch(r"[A-Za-z0-9]{2,12}(?:[-/_ ][A-Za-z0-9]{2,12})?", text.strip()):
+            return await self.get_quote(quote_query)
+        if "trade" in lowered:
+            return await self.get_trades(5)
+        if "performance" in lowered or "pnl" in lowered:
+            return await self.get_performance()
+        if "signal" in lowered or "sinal" in lowered:
+            return await self.get_signal()
+        if "status" in lowered:
+            return await self.get_status()
+        return (
+            "❓ Consulta de trading não reconhecida.\n\n"
+            f"{get_trading_help()}"
+        )

--- a/scripts/misc/telegram_bot.py
+++ b/scripts/misc/telegram_bot.py
@@ -1873,6 +1873,7 @@ class TelegramBot:
 /trades - Últimos trades
 /performance - Win rate, PnL
 /signal - Sinal atual
+/cotacao [moeda|par] - Cotação KuCoin
 /trading [pergunta] - Perguntas livres
 
 *🌐 Busca Web:*
@@ -2748,6 +2749,8 @@ class TelegramBot:
                     response = await trading_client.get_performance()
                 elif cmd == "/signal":
                     response = await trading_client.get_signal()
+                elif cmd == "/cotacao":
+                    response = await trading_client.get_quote(args)
                 elif cmd == "/trading":
                     if not args:
                         response = get_trading_help()
@@ -3400,6 +3403,14 @@ class TelegramBot:
             # === Calendário e Gmail ===
             {"command": "calendar", "description": "📅 Comandos do calendário"},
             {"command": "gmail", "description": "📧 Comandos do Gmail"},
+
+            # === Trading ===
+            {"command": "btc", "description": "📈 Status do agent BTC"},
+            {"command": "trades", "description": "🧾 Últimos trades do agent"},
+            {"command": "performance", "description": "📊 Win rate e PnL"},
+            {"command": "signal", "description": "🧠 Último sinal do agent"},
+            {"command": "cotacao", "description": "💱 Cotação KuCoin de qualquer moeda"},
+            {"command": "trading", "description": "🤖 Pergunta livre ao agent trading"},
             
             # === Mídia ===
             {"command": "photo", "description": "📷 Enviar foto por URL"},

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1873,6 +1873,7 @@ class TelegramBot:
 /trades - Últimos trades
 /performance - Win rate, PnL
 /signal - Sinal atual
+/cotacao [moeda|par] - Cotação KuCoin
 /trading [pergunta] - Perguntas livres
 
 *🌐 Busca Web:*
@@ -2748,6 +2749,8 @@ class TelegramBot:
                     response = await trading_client.get_performance()
                 elif cmd == "/signal":
                     response = await trading_client.get_signal()
+                elif cmd == "/cotacao":
+                    response = await trading_client.get_quote(args)
                 elif cmd == "/trading":
                     if not args:
                         response = get_trading_help()
@@ -3400,6 +3403,14 @@ class TelegramBot:
             # === Calendário e Gmail ===
             {"command": "calendar", "description": "📅 Comandos do calendário"},
             {"command": "gmail", "description": "📧 Comandos do Gmail"},
+
+            # === Trading ===
+            {"command": "btc", "description": "📈 Status do agent BTC"},
+            {"command": "trades", "description": "🧾 Últimos trades do agent"},
+            {"command": "performance", "description": "📊 Win rate e PnL"},
+            {"command": "signal", "description": "🧠 Último sinal do agent"},
+            {"command": "cotacao", "description": "💱 Cotação KuCoin de qualquer moeda"},
+            {"command": "trading", "description": "🤖 Pergunta livre ao agent trading"},
             
             # === Mídia ===
             {"command": "photo", "description": "📷 Enviar foto por URL"},

--- a/tests/test_kucoin_api.py
+++ b/tests/test_kucoin_api.py
@@ -115,7 +115,7 @@ class TestBuildHeaders:
         with patch("kucoin_api._server_time", return_value=int(fixed_ts_ms)):
             headers = kucoin_api._build_headers("GET", "/api/v1/endpoint")
 
-        assert headers["KC-API-TIMESTAMP"] == fixed_ts_ms
+        assert abs(int(headers["KC-API-TIMESTAMP"]) - int(fixed_ts_ms)) <= 1
 
     def test_usa_timestamp_explicito_quando_informado(self) -> None:
         headers = kucoin_api._build_headers(
@@ -897,3 +897,111 @@ class TestGetTradeFees:
             result = kucoin_api.get_trade_fees("BTC-USDT,ETH-USDT")
 
         assert result == []
+
+
+class TestSymbolLookup:
+    """Testes para resolução de símbolos livres da KuCoin."""
+
+    def test_resolve_symbol_prefere_quote_pedido(self) -> None:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": [
+                {
+                    "symbol": "AKT-USDT",
+                    "baseCurrency": "AKT",
+                    "quoteCurrency": "USDT",
+                    "enableTrading": True,
+                },
+                {
+                    "symbol": "AKT-BRL",
+                    "baseCurrency": "AKT",
+                    "quoteCurrency": "BRL",
+                    "enableTrading": True,
+                },
+            ],
+        }
+        with (
+            patch.object(kucoin_api, "_SYMBOLS_CACHE", {"expires_at": 0.0, "symbols": []}),
+            patch("kucoin_api.rate_limit"),
+            patch("kucoin_api.requests.get", return_value=resp),
+        ):
+            result = kucoin_api.resolve_symbol("akt", default_quote="BRL")
+
+        assert result is not None
+        assert result["symbol"] == "AKT-BRL"
+        assert result["matchedBy"] == "baseCurrency"
+
+    def test_get_quote_snapshot_agrega_resolucao_e_ticker(self) -> None:
+        symbols_resp = MagicMock()
+        symbols_resp.status_code = 200
+        symbols_resp.json.return_value = {
+            "data": [
+                {
+                    "symbol": "AKT-USDT",
+                    "baseCurrency": "AKT",
+                    "quoteCurrency": "USDT",
+                    "enableTrading": True,
+                }
+            ],
+        }
+        ticker_resp = MagicMock()
+        ticker_resp.status_code = 200
+        ticker_resp.json.return_value = {
+            "data": {
+                "price": "0.8372",
+                "bestBid": "0.8371",
+                "bestAsk": "0.8373",
+                "size": "120.5",
+                "time": 1700000000123,
+                "sequence": "12345",
+            }
+        }
+
+        def fake_get(url: str, timeout: float = 0) -> MagicMock:
+            if url.endswith("/api/v2/symbols"):
+                return symbols_resp
+            if "level1?symbol=AKT-USDT" in url:
+                return ticker_resp
+            raise AssertionError(f"URL inesperada: {url}")
+
+        with (
+            patch.object(kucoin_api, "_SYMBOLS_CACHE", {"expires_at": 0.0, "symbols": []}),
+            patch("kucoin_api.rate_limit"),
+            patch("kucoin_api.requests.get", side_effect=fake_get),
+        ):
+            result = kucoin_api.get_quote_snapshot("akt")
+
+        assert result["symbol"] == "AKT-USDT"
+        assert result["price"] == 0.8372
+        assert result["bestBid"] == 0.8371
+        assert result["bestAsk"] == 0.8373
+        assert result["matchedBy"] == "baseCurrency"
+
+    def test_search_symbols_retorna_matches_parciais(self) -> None:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": [
+                {
+                    "symbol": "USDT-BRL",
+                    "baseCurrency": "USDT",
+                    "quoteCurrency": "BRL",
+                    "enableTrading": True,
+                },
+                {
+                    "symbol": "BTC-USDT",
+                    "baseCurrency": "BTC",
+                    "quoteCurrency": "USDT",
+                    "enableTrading": True,
+                },
+            ],
+        }
+        with (
+            patch.object(kucoin_api, "_SYMBOLS_CACHE", {"expires_at": 0.0, "symbols": []}),
+            patch("kucoin_api.rate_limit"),
+            patch("kucoin_api.requests.get", return_value=resp),
+        ):
+            result = kucoin_api.search_symbols("brl", limit=3)
+
+        assert [item["symbol"] for item in result] == ["USDT-BRL"]

--- a/tests/test_telegram_trading.py
+++ b/tests/test_telegram_trading.py
@@ -1,0 +1,125 @@
+"""Testes unitários do módulo de trading do Telegram."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import telegram_bot
+from telegram_bot import TelegramBot
+
+from btc_trading_agent import telegram_trading
+from btc_trading_agent.telegram_trading import TelegramTradingClient
+
+
+class FakeTelegramAPI:
+    """API fake mínima para validar o dispatch do bot."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+        self.actions: list[str] = []
+
+    async def send_message(
+        self,
+        chat_id: int,
+        text: str,
+        reply_to_message_id: int | None = None,
+    ) -> dict[str, Any]:
+        self.messages.append(text)
+        return {"ok": True, "result": {"message_id": 1}}
+
+    async def send_chat_action(self, chat_id: int, action: str = "typing") -> dict[str, Any]:
+        self.actions.append(action)
+        return {"ok": True, "result": True}
+
+
+class FakeTradingClient:
+    """Cliente fake para inspecionar o roteamento do comando /cotacao."""
+
+    def __init__(self) -> None:
+        self.quote_queries: list[str] = []
+
+    async def get_quote(self, query: str) -> str:
+        self.quote_queries.append(query)
+        return "cotacao fake"
+
+
+def test_get_trading_help_menciona_cotacao() -> None:
+    help_text = telegram_trading.get_trading_help()
+
+    assert "/cotacao" in help_text
+    assert "AKT-BRL" in help_text
+
+
+def test_get_quote_formata_snapshot_da_kucoin(monkeypatch) -> None:
+    client = TelegramTradingClient()
+    fake_kucoin = SimpleNamespace(
+        get_quote_snapshot=lambda query, default_quote="USDT", preferred_quotes=None: {
+            "symbol": "AKT-USDT",
+            "baseCurrency": "AKT",
+            "quoteCurrency": "USDT",
+            "matchedBy": "baseCurrency",
+            "price": 0.8372,
+            "bestBid": 0.8371,
+            "bestAsk": 0.8373,
+            "size": 120.5,
+            "time": 1700000000123,
+        },
+        search_symbols=lambda query, limit=5: [],
+        normalize_symbol=lambda query: str(query).strip().upper(),
+    )
+    monkeypatch.setattr(telegram_trading, "_load_kucoin_api_module", lambda: fake_kucoin)
+
+    response = asyncio.run(client.get_quote("akt"))
+
+    assert "AKT-USDT" in response
+    assert "0.8372" in response
+    assert "Bid/Ask" in response
+
+
+def test_ask_question_detecta_consulta_de_cotacao() -> None:
+    client = TelegramTradingClient()
+    called: dict[str, str] = {}
+
+    async def fake_get_quote(query: str) -> str:
+        called["query"] = query
+        return "ok"
+
+    client.get_quote = fake_get_quote  # type: ignore[method-assign]
+
+    response = asyncio.run(client.ask_question("qual a cotação de akt na kucoin?"))
+
+    assert response == "ok"
+    assert called["query"] == "AKT"
+
+
+def test_handle_command_cotacao_usa_trading_client(monkeypatch) -> None:
+    bot = TelegramBot.__new__(TelegramBot)
+    fake_api = FakeTelegramAPI()
+    fake_trading = FakeTradingClient()
+    bot.api = fake_api
+
+    monkeypatch.setattr(telegram_bot, "TRADING_AVAILABLE", True)
+    monkeypatch.setattr(
+        telegram_bot,
+        "TRADING_COMMANDS",
+        ["/btc", "/trades", "/performance", "/signal", "/trading", "/cotacao"],
+    )
+    monkeypatch.setattr(telegram_bot, "trading_client", fake_trading)
+
+    message = {
+        "chat": {"id": 10},
+        "from": {"id": 20},
+        "message_id": 30,
+        "text": "/cotacao AKT",
+    }
+
+    asyncio.run(bot.handle_command(message))
+
+    assert fake_api.actions == ["typing"]
+    assert fake_trading.quote_queries == ["AKT"]
+    assert fake_api.messages[-1] == "cotacao fake"


### PR DESCRIPTION
## What changed
- adds a new `btc_trading_agent.telegram_trading` module so the Telegram bot can actually enable the trading command set instead of falling back to `TRADING_AVAILABLE=false`
- adds `/cotacao` for KuCoin quote lookup by ticker or pair, including automatic pair resolution such as `AKT -> AKT-USDT`
- exposes KuCoin symbol discovery, symbol resolution, and ticker snapshot helpers in `btc_trading_agent/kucoin_api.py`
- updates both Telegram bot entrypoints to advertise and route the new trading quote command
- adds unit coverage for KuCoin symbol lookup and Telegram trading command routing

## Why
The bot already tried to import `btc_trading_agent.telegram_trading`, but that module did not exist. As a result, trading commands were effectively disabled in Telegram. The new `/cotacao` command also satisfies the request to query any KuCoin currency directly from the trading agent.

## Impact
- Telegram users can now query `/cotacao AKT`, `/cotacao AKT-BRL`, `/cotacao BTC/USDT`, etc.
- the trading help text and registered bot commands now expose the quote lookup path
- the KuCoin helper layer can resolve free-form asset queries into valid exchange pairs

## Validation
- `python3 -m py_compile btc_trading_agent/kucoin_api.py btc_trading_agent/telegram_trading.py telegram_bot.py scripts/misc/telegram_bot.py tests/test_kucoin_api.py tests/test_telegram_trading.py`
- `python3 -m pytest tests/test_kucoin_api.py tests/test_telegram_trading.py`
