### PR TITLE
fix(grafana): renderMode=data e path correto no painel 55 (Business Text v6)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-20T12:13:53.089060+00:00",
+  "generated_at": "2026-06-20T12:29:27.265261+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-06-20T12:13:53.089060+00:00`
+- Generated at: `2026-06-20T12:29:27.265261+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `146`

--- a/grafana/dashboards/storj-node-monitor.json
+++ b/grafana/dashboards/storj-node-monitor.json
@@ -1133,20 +1133,10 @@
       "options": {
         "defaultContent": "Aguardando dados...",
         "everyRow": false,
-        "content": "## Cronograma de Held-back Storj\n\n| Período | Retenção | Est. R$/mês | Status |\n|---------|----------|-------------|--------|\n| Meses 1-3 | **75%** | R$ {{data.[0].fields.[0].values.[0]}} | ⬅️ Atual |\n| Meses 4-6 | 50% | R$ {{data.[1].fields.[0].values.[0]}} | |\n| Meses 7-9 | 25% | R$ {{data.[2].fields.[0].values.[0]}} | |\n| Meses 10-15 | 0% | R$ {{data.[3].fields.[0].values.[0]}} | |\n| Mês 15 | 🎉 Devolução 50% | — | |\n\n> 💡 Valores líquidos estimados (bruto × taxa retenção × USD/BRL live)\n\n**Wallet:** `0x4787...7d24` · **Rede:** zkSync Era (L2)"
+        "content": "## Cronograma de Held-back Storj\n\n| Período | Retenção | Est. R$/mês | Status |\n|---------|----------|-------------|--------|\n| Meses 1-3 | **75%** | R$ {{data.[0].[0].Value}} | ⬅️ Atual |\n| Meses 4-6 | 50% | R$ {{data.[1].[0].Value}} | |\n| Meses 7-9 | 25% | R$ {{data.[2].[0].Value}} | |\n| Meses 10-15 | 0% | R$ {{data.[3].[0].Value}} | |\n| Mês 15 | 🎉 Devolução 50% | — | |\n\n> 💡 Valores líquidos estimados (bruto × taxa retenção × USD/BRL live)\n\n**Wallet:** `0x4787...7d24` · **Rede:** zkSync Era (L2)",
+        "renderMode": "data"
       },
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "last"
-            ],
-            "mode": "reduceFields",
-            "fields": ""
-          }
-        }
-      ]
+      "transformations": []
     },
     {
       "collapsed": false,

--- a/monitoring/grafana/provisioning/dashboards/storage/storj-node-monitor.json
+++ b/monitoring/grafana/provisioning/dashboards/storage/storj-node-monitor.json
@@ -1133,20 +1133,10 @@
       "options": {
         "defaultContent": "Aguardando dados...",
         "everyRow": false,
-        "content": "## Cronograma de Held-back Storj\n\n| Período | Retenção | Est. R$/mês | Status |\n|---------|----------|-------------|--------|\n| Meses 1-3 | **75%** | R$ {{data.[0].fields.[0].values.[0]}} | ⬅️ Atual |\n| Meses 4-6 | 50% | R$ {{data.[1].fields.[0].values.[0]}} | |\n| Meses 7-9 | 25% | R$ {{data.[2].fields.[0].values.[0]}} | |\n| Meses 10-15 | 0% | R$ {{data.[3].fields.[0].values.[0]}} | |\n| Mês 15 | 🎉 Devolução 50% | — | |\n\n> 💡 Valores líquidos estimados (bruto × taxa retenção × USD/BRL live)\n\n**Wallet:** `0x4787...7d24` · **Rede:** zkSync Era (L2)"
+        "content": "## Cronograma de Held-back Storj\n\n| Período | Retenção | Est. R$/mês | Status |\n|---------|----------|-------------|--------|\n| Meses 1-3 | **75%** | R$ {{data.[0].[0].Value}} | ⬅️ Atual |\n| Meses 4-6 | 50% | R$ {{data.[1].[0].Value}} | |\n| Meses 7-9 | 25% | R$ {{data.[2].[0].Value}} | |\n| Meses 10-15 | 0% | R$ {{data.[3].[0].Value}} | |\n| Mês 15 | 🎉 Devolução 50% | — | |\n\n> 💡 Valores líquidos estimados (bruto × taxa retenção × USD/BRL live)\n\n**Wallet:** `0x4787...7d24` · **Rede:** zkSync Era (L2)",
+        "renderMode": "data"
       },
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": [
-              "last"
-            ],
-            "mode": "reduceFields",
-            "fields": ""
-          }
-        }
-      ]
+      "transformations": []
     },
     {
       "collapsed": false,


### PR DESCRIPTION
## Root Cause (investigado no source do plugin)

Business Text **v6.2.0** não expõe `data` como array de DataFrames. O plugin converte cada DataFrame em array de objetos de linha onde as chaves são os nomes dos campos:

```
data = [
  [{Value: 45.11}],   // frame A (liq_25 — 25% retenção)
  [{Value: 90.22}],   // frame B (liq_50 — 50% retenção)  
  [{Value: 135.83}],  // frame C (liq_75 — 75% retenção)
  [{Value: 180.42}],  // frame D (liq_100 — 100% retenção)
]
```

Isso só acontece com `renderMode: "data"` (Zr.DATA no source). Sem esse modo, `data` recebe apenas o primeiro DataFrame selecionado.

## Mudanças

- `renderMode: "data"` adicionado às opções do painel 55
- Template corrigido de `data.[0].fields.[0].values.[0]` → `data.[0].[0].Value`
- Transformação Reduce removida (não necessária)
- Arquivo duplicado raiz `storj-node-monitor.json` desabilitado no host (conflito de UID que mascarava todas as correções anteriores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)