### PR TITLE
[codex] add AutoRPA Monitor landing

### DIFF
--- a/site/autorpa-monitor/app.js
+++ b/site/autorpa-monitor/app.js
@@ -1,0 +1,68 @@
+const currency = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  maximumFractionDigits: 0,
+});
+
+const savingsForm = document.querySelector("#savingsCalc");
+const hoursInput = document.querySelector("#hoursInput");
+const rateInput = document.querySelector("#rateInput");
+const calcResult = document.querySelector("#calcResult");
+const leadForm = document.querySelector("#leadForm");
+const formNote = document.querySelector("#formNote");
+const businessWhatsApp = "5511981193899";
+
+function updateSavings() {
+  const weeklyHours = Number(hoursInput.value || 0);
+  const hourlyRate = Number(rateInput.value || 0);
+  const monthlySavings = weeklyHours * hourlyRate * 4;
+  calcResult.value = `${currency.format(monthlySavings)}/mês`;
+}
+
+function sanitizePhone(value) {
+  return value.replace(/\D/g, "");
+}
+
+function buildLeadMessage(formData) {
+  return [
+    "Olá, quero um diagnóstico gratuito de automação.",
+    "",
+    `Nome: ${formData.get("name")}`,
+    `Empresa: ${formData.get("company")}`,
+    `WhatsApp: ${formData.get("phone")}`,
+    `Gargalo principal: ${formData.get("pain")}`,
+    "",
+    "Quero entender qual robô ou monitoramento pode ser implementado primeiro.",
+  ].join("\n");
+}
+
+hoursInput.addEventListener("input", updateSavings);
+rateInput.addEventListener("input", updateSavings);
+savingsForm.addEventListener("submit", (event) => event.preventDefault());
+
+leadForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(leadForm);
+  const message = buildLeadMessage(formData);
+  const phone = sanitizePhone(formData.get("phone") || "");
+
+  localStorage.setItem(
+    "autorpa:lastLead",
+    JSON.stringify({
+      name: formData.get("name"),
+      company: formData.get("company"),
+      phone,
+      pain: formData.get("pain"),
+      createdAt: new Date().toISOString(),
+    }),
+  );
+
+  formNote.classList.add("success");
+  formNote.textContent =
+    "Mensagem criada e lead salvo localmente. Abrindo WhatsApp comercial para envio manual.";
+
+  const encoded = encodeURIComponent(message);
+  window.open(`https://wa.me/${businessWhatsApp}?text=${encoded}`, "_blank", "noopener,noreferrer");
+});
+
+updateSavings();

--- a/site/autorpa-monitor/index.html
+++ b/site/autorpa-monitor/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>AutoRPA Monitor | Automação e alertas para pequenas empresas</title>
+    <meta
+      name="description"
+      content="Automação RPA, monitoramento de sistemas e alertas Telegram/WhatsApp para pequenas empresas. Diagnóstico gratuito."
+    >
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="AutoRPA Monitor">
+        <span class="brand-mark">A</span>
+        <span>AutoRPA Monitor</span>
+      </a>
+      <nav class="nav" aria-label="Navegação principal">
+        <a href="#servicos">Serviços</a>
+        <a href="#pacotes">Pacotes</a>
+        <a href="#diagnostico">Diagnóstico</a>
+      </nav>
+      <a class="header-cta" href="#diagnostico">Diagnóstico gratuito</a>
+    </header>
+
+    <main id="top">
+      <section class="hero">
+        <div class="hero-copy">
+          <h1>Automação que corta trabalho manual e avisa antes do problema virar prejuízo</h1>
+          <p>
+            Robôs em JavaScript/Python para tarefas repetitivas, monitoramento de sites e sistemas,
+            alertas no Telegram ou WhatsApp e relatórios prontos para decisão.
+          </p>
+          <div class="hero-actions">
+            <a class="btn primary" href="#diagnostico">Diagnóstico gratuito</a>
+            <a class="btn secondary" href="#pacotes">Ver pacotes</a>
+          </div>
+          <dl class="hero-proof">
+            <div>
+              <dt>20 min</dt>
+              <dd>para mapear gargalos</dd>
+            </div>
+            <div>
+              <dt>R$ 99/mês</dt>
+              <dd>pacote inicial</dd>
+            </div>
+            <div>
+              <dt>24/7</dt>
+              <dd>alertas automáticos</dd>
+            </div>
+          </dl>
+        </div>
+
+        <aside class="monitor-card" aria-label="Prévia do painel de monitoramento">
+          <div class="monitor-topbar">
+            <span>Sistemas monitorados</span>
+            <strong>online</strong>
+          </div>
+          <div class="status-grid">
+            <article>
+              <span class="dot ok"></span>
+              <p>Loja virtual</p>
+              <strong>OK</strong>
+            </article>
+            <article>
+              <span class="dot ok"></span>
+              <p>Emissão NF-e</p>
+              <strong>OK</strong>
+            </article>
+            <article>
+              <span class="dot warn"></span>
+              <p>Portal fornecedor</p>
+              <strong>Lento</strong>
+            </article>
+          </div>
+          <div class="chart" aria-hidden="true">
+            <span style="height: 28%"></span>
+            <span style="height: 48%"></span>
+            <span style="height: 38%"></span>
+            <span style="height: 68%"></span>
+            <span style="height: 54%"></span>
+            <span style="height: 76%"></span>
+            <span style="height: 58%"></span>
+            <span style="height: 84%"></span>
+          </div>
+          <div class="alert-preview">
+            <span>Telegram</span>
+            <p>Pedido parado há 18 min. Robô tentou reprocessar e abriu alerta.</p>
+          </div>
+        </aside>
+      </section>
+
+      <section id="servicos" class="section">
+        <div class="section-heading">
+          <h2>O que dá para vender rápido</h2>
+          <p>Serviços pequenos, claros e cobrados por entrega ou mensalidade.</p>
+        </div>
+        <div class="service-grid">
+          <article class="service-card">
+            <span>01</span>
+            <h3>Robôs de NF-e, XML e PDF</h3>
+            <p>Baixa anexos, extrai dados, renomeia arquivos e gera planilhas sem digitação manual.</p>
+          </article>
+          <article class="service-card">
+            <span>02</span>
+            <h3>Monitoramento com alerta</h3>
+            <p>Verifica site, API, login, fila, planilha ou portal e avisa quando algo quebra.</p>
+          </article>
+          <article class="service-card">
+            <span>03</span>
+            <h3>Planilhas e e-mails automáticos</h3>
+            <p>Concilia dados, envia cobranças, monta relatórios e reduz rotinas repetitivas.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="calculator section" aria-labelledby="calc-title">
+        <div>
+          <h2 id="calc-title">Calcule uma economia simples</h2>
+          <p>
+            Use como argumento comercial: se o cliente perde horas toda semana,
+            um robô pequeno já se paga.
+          </p>
+        </div>
+        <form class="calc-box" id="savingsCalc">
+          <label>
+            Horas manuais por semana
+            <input id="hoursInput" type="number" min="1" max="80" value="8">
+          </label>
+          <label>
+            Custo por hora
+            <input id="rateInput" type="number" min="10" max="500" value="35">
+          </label>
+          <output class="calc-result" id="calcResult">R$ 1.120/mês</output>
+        </form>
+      </section>
+
+      <section id="pacotes" class="section">
+        <div class="section-heading">
+          <h2>Pacotes a partir de R$ 99/mês</h2>
+          <p>Preços simples para começar conversa e fechar o primeiro contrato.</p>
+        </div>
+        <div class="pricing-grid">
+          <article class="price-card">
+            <h3>Monitor</h3>
+            <p class="price">R$ 99<span>/mês</span></p>
+            <ul>
+              <li>Até 3 verificações</li>
+              <li>Alerta Telegram</li>
+              <li>Relatório mensal</li>
+            </ul>
+          </article>
+          <article class="price-card featured">
+            <h3>RPA Essencial</h3>
+            <p class="price">R$ 490<span>/setup</span></p>
+            <ul>
+              <li>1 robô de rotina</li>
+              <li>Entrega com vídeo de uso</li>
+              <li>Manutenção opcional</li>
+            </ul>
+          </article>
+          <article class="price-card">
+            <h3>Operação</h3>
+            <p class="price">R$ 299<span>/mês</span></p>
+            <ul>
+              <li>Monitoramento + RPA</li>
+              <li>Fila de melhorias</li>
+              <li>Suporte prioritário</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="diagnostico" class="lead-section">
+        <div class="lead-copy">
+          <h2>Receba uma proposta de automação</h2>
+          <p>
+            Preencha os campos e o frontend monta uma mensagem pronta para WhatsApp.
+            Nesta etapa não há backend: é uma página vendável para validar demanda.
+          </p>
+        </div>
+        <form class="lead-form" id="leadForm">
+          <label>
+            Nome
+            <input name="name" autocomplete="name" required placeholder="Seu nome">
+          </label>
+          <label>
+            Empresa
+            <input name="company" autocomplete="organization" required placeholder="Nome da empresa">
+          </label>
+          <label>
+            WhatsApp
+            <input name="phone" autocomplete="tel" required placeholder="(00) 00000-0000">
+          </label>
+          <label>
+            O que mais consome tempo?
+            <select name="pain">
+              <option>Notas, XML ou PDFs</option>
+              <option>Monitorar site ou sistema</option>
+              <option>Planilhas e relatórios</option>
+              <option>Cadastro em sistema legado</option>
+            </select>
+          </label>
+          <button class="btn primary" type="submit">Gerar mensagem</button>
+          <p class="form-note" id="formNote">Nenhum dado sai do navegador nesta versão.</p>
+        </form>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>AutoRPA Monitor</span>
+      <p>Automação legítima, monitoramento real e alerta acionável. Sem tráfego falso, sem clique artificial.</p>
+    </footer>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/site/autorpa-monitor/styles.css
+++ b/site/autorpa-monitor/styles.css
@@ -1,0 +1,522 @@
+:root {
+  --bg: #ffffff;
+  --text: #17202a;
+  --muted: #607080;
+  --line: #dfe7ee;
+  --soft: #f4f8fb;
+  --panel: #ffffff;
+  --accent: #169b62;
+  --accent-dark: #0c6c43;
+  --warn: #c78914;
+  --ink: #0f1720;
+  --shadow: 0 24px 70px rgba(16, 32, 44, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 72px;
+  padding: 0 48px;
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(18px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.brand-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  color: #fff;
+  background: var(--accent);
+  border-radius: 8px;
+}
+
+.nav {
+  display: flex;
+  gap: 24px;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.header-cta,
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.header-cta,
+.btn.primary {
+  color: #fff;
+  background: var(--accent);
+  box-shadow: 0 12px 26px rgba(22, 155, 98, 0.22);
+}
+
+.btn.secondary {
+  color: var(--ink);
+  background: #fff;
+  border-color: var(--line);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 470px;
+  gap: 48px;
+  align-items: center;
+  max-width: 1180px;
+  min-height: calc(100vh - 72px);
+  margin: 0 auto;
+  padding: 72px 32px 84px;
+}
+
+.hero-copy h1 {
+  max-width: 780px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(38px, 5vw, 64px);
+  line-height: 1.02;
+  font-weight: 820;
+}
+
+.hero-copy p {
+  max-width: 650px;
+  margin: 26px 0 0;
+  color: var(--muted);
+  font-size: 19px;
+  line-height: 1.65;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.hero-proof {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  max-width: 630px;
+  margin: 42px 0 0;
+}
+
+.hero-proof div {
+  padding: 18px;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.hero-proof dt {
+  color: var(--ink);
+  font-size: 24px;
+  font-weight: 800;
+}
+
+.hero-proof dd {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.monitor-card {
+  padding: 22px;
+  background: #101820;
+  border: 1px solid #243240;
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.monitor-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #c6d2dd;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.monitor-topbar strong {
+  color: #77d69f;
+}
+
+.status-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.status-grid article {
+  display: grid;
+  grid-template-columns: 12px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px;
+  color: #eaf1f5;
+  background: #17232d;
+  border: 1px solid #263746;
+  border-radius: 8px;
+}
+
+.status-grid p {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.status-grid strong {
+  color: #8be0aa;
+  font-size: 13px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.dot.ok {
+  background: #65d889;
+}
+
+.dot.warn {
+  background: var(--warn);
+}
+
+.chart {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+  height: 160px;
+  margin-top: 18px;
+  padding: 16px;
+  background: linear-gradient(180deg, #14212b 0%, #111b23 100%);
+  border: 1px solid #263746;
+  border-radius: 8px;
+}
+
+.chart span {
+  flex: 1;
+  background: linear-gradient(180deg, #79dfa1 0%, #1d8d5a 100%);
+  border-radius: 4px 4px 0 0;
+}
+
+.alert-preview {
+  margin-top: 18px;
+  padding: 16px;
+  color: #dce6ee;
+  background: rgba(199, 137, 20, 0.16);
+  border: 1px solid rgba(199, 137, 20, 0.42);
+  border-radius: 8px;
+}
+
+.alert-preview span {
+  color: #ffd47a;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.alert-preview p {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.section {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 84px 32px;
+}
+
+.section-heading {
+  max-width: 680px;
+  margin-bottom: 34px;
+}
+
+h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1.08;
+  font-weight: 820;
+}
+
+.section-heading p,
+.calculator p,
+.lead-copy p {
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.service-grid,
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.service-card,
+.price-card,
+.lead-form,
+.calc-box {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 0 16px 38px rgba(16, 32, 44, 0.07);
+}
+
+.service-card {
+  padding: 26px;
+}
+
+.service-card span {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 850;
+}
+
+.service-card h3,
+.price-card h3 {
+  margin: 16px 0 10px;
+  color: var(--ink);
+  font-size: 22px;
+}
+
+.service-card p,
+.price-card li {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.calculator {
+  display: grid;
+  grid-template-columns: 1fr 430px;
+  gap: 44px;
+  align-items: center;
+  background: var(--soft);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  max-width: none;
+  padding-inline: max(32px, calc((100vw - 1180px) / 2 + 32px));
+}
+
+.calc-box {
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 44px;
+  padding: 0 13px;
+  color: var(--ink);
+  background: #fff;
+  border: 1px solid #cfdbe5;
+  border-radius: 8px;
+  font: inherit;
+  font-size: 14px;
+}
+
+input:focus,
+select:focus {
+  outline: 3px solid rgba(22, 155, 98, 0.16);
+  border-color: var(--accent);
+}
+
+.calc-result {
+  display: block;
+  padding-top: 10px;
+  color: var(--accent-dark);
+  font-size: 34px;
+  font-weight: 850;
+}
+
+.price-card {
+  padding: 28px;
+}
+
+.price-card.featured {
+  border-color: rgba(22, 155, 98, 0.45);
+  box-shadow: 0 24px 70px rgba(22, 155, 98, 0.12);
+}
+
+.price {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 38px;
+  font-weight: 850;
+}
+
+.price span {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.price-card ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.lead-section {
+  display: grid;
+  grid-template-columns: 1fr 460px;
+  gap: 46px;
+  align-items: start;
+  max-width: 1180px;
+  margin: 0 auto 84px;
+  padding: 84px 32px;
+  background: #fff;
+}
+
+.lead-form {
+  display: grid;
+  gap: 16px;
+  padding: 26px;
+}
+
+.form-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.form-note.success {
+  color: var(--accent-dark);
+  font-weight: 750;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px 48px;
+  color: #d7e0e6;
+  background: var(--ink);
+}
+
+.footer span {
+  font-weight: 850;
+}
+
+.footer p {
+  margin: 0;
+  color: #9fb0bd;
+  font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .site-header {
+    padding: 0 20px;
+  }
+
+  .nav {
+    display: none;
+  }
+
+  .hero,
+  .calculator,
+  .lead-section {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+    padding-top: 48px;
+  }
+
+  .monitor-card {
+    max-width: 520px;
+  }
+
+  .service-grid,
+  .pricing-grid,
+  .hero-proof {
+    grid-template-columns: 1fr;
+  }
+
+  .footer {
+    display: block;
+    padding: 26px 24px;
+  }
+
+  .footer p {
+    margin-top: 8px;
+  }
+}
+
+@media (max-width: 560px) {
+  .header-cta {
+    display: none;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero,
+  .section,
+  .lead-section {
+    padding-inline: 20px;
+  }
+
+  .calculator {
+    padding-inline: 20px;
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -45,6 +45,7 @@
           <p>O RPA4ALL integra automações, agentes de IA, observabilidade e governança para reduzir custos operacionais
             e aumentar a previsibilidade. Tudo em uma plataforma modular, pronta para escalar.</p>
           <div class="hero-actions">
+            <a class="btn primary" href="/autorpa-monitor/">AutoRPA Monitor</a>
             <a class="btn primary" href="https://openwebui.rpa4all.com/" target="_blank" rel="noopener">Abrir Open
               WebUI</a>
             <a class="btn ghost" href="https://www.rpa4all.com/grafana/" target="_blank" rel="noopener">Ver


### PR DESCRIPTION
## O que mudou

- Adiciona a landing page estática `site/autorpa-monitor/` para o AutoRPA Monitor.
- Inclui calculadora simples de economia e formulário que gera mensagem para WhatsApp.
- Adiciona CTA na home principal apontando para `/autorpa-monitor/`.

## Impacto

A página pode ser servida pelo site estático atual em `rpa4all.com` e ajuda a validar demanda por automação/RPA e monitoramento.

## Validação

- `python3` HTMLParser em `site/index.html` e `site/autorpa-monitor/index.html`.
- `node --check site/autorpa-monitor/app.js`.
- Publicação manual já validada em `https://www.rpa4all.com/autorpa-monitor/`.