### PR TITLE
[codex] make AutoRPA Monitor copy objective

### DIFF
--- a/.github/workflows/deploy-to-homelab.yml
+++ b/.github/workflows/deploy-to-homelab.yml
@@ -86,6 +86,15 @@ jobs:
             cd /home/homelab/myClaude
             git fetch --prune --refmap= origin +refs/heads/main:refs/deploy/main
             git reset --hard refs/deploy/main
+            sudo mkdir -p /var/www/rpa4all.com
+            sudo rsync -az --delete site/ /var/www/rpa4all.com/
+            sudo chown -R www-data:www-data /var/www/rpa4all.com || true
+            if nginx -t >/dev/null 2>&1; then
+              sudo systemctl reload nginx || sudo nginx -s reload || true
+            else
+              echo "nginx config test failed; keeping previous site" >&2
+              exit 1
+            fi
           '
 
           ssh -o StrictHostKeyChecking=no homelab@192.168.15.2 '

--- a/site/autorpa-monitor/app.js
+++ b/site/autorpa-monitor/app.js
@@ -25,14 +25,14 @@ function sanitizePhone(value) {
 
 function buildLeadMessage(formData) {
   return [
-    "Olá, quero um diagnóstico gratuito de automação.",
+    "Olá, quero solicitar uma avaliação de automação.",
     "",
     `Nome: ${formData.get("name")}`,
     `Empresa: ${formData.get("company")}`,
     `WhatsApp: ${formData.get("phone")}`,
     `Gargalo principal: ${formData.get("pain")}`,
     "",
-    "Quero entender qual robô ou monitoramento pode ser implementado primeiro.",
+    "Quero avaliar qual rotina pode ser automatizada ou monitorada primeiro.",
   ].join("\n");
 }
 
@@ -59,10 +59,10 @@ leadForm.addEventListener("submit", (event) => {
 
   formNote.classList.add("success");
   formNote.textContent =
-    "Mensagem criada e lead salvo localmente. Abrindo WhatsApp comercial para envio manual.";
+    "Mensagem criada. Redirecionando para o WhatsApp nesta mesma aba.";
 
   const encoded = encodeURIComponent(message);
-  window.open(`https://wa.me/${businessWhatsApp}?text=${encoded}`, "_blank", "noopener,noreferrer");
+  window.location.href = `https://wa.me/${businessWhatsApp}?text=${encoded}`;
 });
 
 updateSavings();

--- a/site/autorpa-monitor/index.html
+++ b/site/autorpa-monitor/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>AutoRPA Monitor | Automação e alertas para pequenas empresas</title>
+    <title>AutoRPA Monitor | RPA, monitoramento e alertas para empresas</title>
     <meta
       name="description"
-      content="Automação RPA, monitoramento de sistemas e alertas Telegram/WhatsApp para pequenas empresas. Diagnóstico gratuito."
+      content="Serviço de RPA, monitoramento de sistemas, alertas Telegram/WhatsApp e relatórios operacionais para empresas."
     >
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -27,33 +27,33 @@
         <a href="#pacotes">Pacotes</a>
         <a href="#diagnostico">Diagnóstico</a>
       </nav>
-      <a class="header-cta" href="#diagnostico">Diagnóstico gratuito</a>
+      <a class="header-cta" href="#diagnostico">Solicitar avaliação</a>
     </header>
 
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <h1>Automação que corta trabalho manual e avisa antes do problema virar prejuízo</h1>
+          <h1>RPA, monitoramento e alertas para rotinas operacionais</h1>
           <p>
-            Robôs em JavaScript/Python para tarefas repetitivas, monitoramento de sites e sistemas,
-            alertas no Telegram ou WhatsApp e relatórios prontos para decisão.
+            Implementação de robôs em JavaScript ou Python para tarefas repetitivas,
+            verificação de sites e sistemas, alertas no Telegram ou WhatsApp e relatórios operacionais.
           </p>
           <div class="hero-actions">
-            <a class="btn primary" href="#diagnostico">Diagnóstico gratuito</a>
+            <a class="btn primary" href="#diagnostico">Solicitar avaliação</a>
             <a class="btn secondary" href="#pacotes">Ver pacotes</a>
           </div>
           <dl class="hero-proof">
             <div>
               <dt>20 min</dt>
-              <dd>para mapear gargalos</dd>
+              <dd>para triagem inicial</dd>
             </div>
             <div>
               <dt>R$ 99/mês</dt>
-              <dd>pacote inicial</dd>
+              <dd>monitoramento inicial</dd>
             </div>
             <div>
               <dt>24/7</dt>
-              <dd>alertas automáticos</dd>
+              <dd>verificações programadas</dd>
             </div>
           </dl>
         </div>
@@ -92,15 +92,15 @@
           </div>
           <div class="alert-preview">
             <span>Telegram</span>
-            <p>Pedido parado há 18 min. Robô tentou reprocessar e abriu alerta.</p>
+            <p>Fila sem atualização há 18 min. Alerta enviado para conferência manual.</p>
           </div>
         </aside>
       </section>
 
       <section id="servicos" class="section">
         <div class="section-heading">
-          <h2>O que dá para vender rápido</h2>
-          <p>Serviços pequenos, claros e cobrados por entrega ou mensalidade.</p>
+          <h2>Serviços disponíveis</h2>
+          <p>Escopos pequenos para implantação por entrega ou por mensalidade.</p>
         </div>
         <div class="service-grid">
           <article class="service-card">
@@ -123,10 +123,10 @@
 
       <section class="calculator section" aria-labelledby="calc-title">
         <div>
-          <h2 id="calc-title">Calcule uma economia simples</h2>
+          <h2 id="calc-title">Estimativa de horas manuais</h2>
           <p>
-            Use como argumento comercial: se o cliente perde horas toda semana,
-            um robô pequeno já se paga.
+            Informe o tempo gasto em uma rotina semanal para estimar o custo mensal
+            que pode ser reduzido com automação.
           </p>
         </div>
         <form class="calc-box" id="savingsCalc">
@@ -144,8 +144,8 @@
 
       <section id="pacotes" class="section">
         <div class="section-heading">
-          <h2>Pacotes a partir de R$ 99/mês</h2>
-          <p>Preços simples para começar conversa e fechar o primeiro contrato.</p>
+          <h2>Pacotes</h2>
+          <p>Valores de referência para definir o primeiro escopo de automação ou monitoramento.</p>
         </div>
         <div class="pricing-grid">
           <article class="price-card">
@@ -180,10 +180,10 @@
 
       <section id="diagnostico" class="lead-section">
         <div class="lead-copy">
-          <h2>Receba uma proposta de automação</h2>
+          <h2>Solicite avaliação do processo</h2>
           <p>
-            Preencha os campos e o frontend monta uma mensagem pronta para WhatsApp.
-            Nesta etapa não há backend: é uma página vendável para validar demanda.
+            Preencha os campos para gerar uma mensagem de WhatsApp com o processo
+            que deve ser avaliado.
           </p>
         </div>
         <form class="lead-form" id="leadForm">
@@ -208,15 +208,15 @@
               <option>Cadastro em sistema legado</option>
             </select>
           </label>
-          <button class="btn primary" type="submit">Gerar mensagem</button>
-          <p class="form-note" id="formNote">Nenhum dado sai do navegador nesta versão.</p>
+          <button class="btn primary" type="submit">Enviar pelo WhatsApp</button>
+          <p class="form-note" id="formNote">Os dados são usados apenas para montar a mensagem no WhatsApp.</p>
         </form>
       </section>
     </main>
 
     <footer class="footer">
       <span>AutoRPA Monitor</span>
-      <p>Automação legítima, monitoramento real e alerta acionável. Sem tráfego falso, sem clique artificial.</p>
+      <p>Automação de rotinas internas, monitoramento de disponibilidade e alertas operacionais.</p>
     </footer>
 
     <script src="./app.js"></script>


### PR DESCRIPTION
## O que mudou

- Torna o texto da landing AutoRPA Monitor mais objetivo e direto.
- Remove o uso de `window.open` no envio do WhatsApp; o formulário agora navega na mesma aba com `window.location.href`.
- Corrige o workflow `Deploy to Homelab` no caminho self-hosted para copiar `site/` para `/var/www/rpa4all.com` e recarregar o Nginx.

## Validação

- `python3` HTMLParser em `site/index.html` e `site/autorpa-monitor/index.html`.
- `node --check site/autorpa-monitor/app.js`.
- Produção publicada manualmente e validada em `https://www.rpa4all.com/autorpa-monitor/`.
- Chrome headless gerou screenshot de produção em `/tmp/autorpa-objective-desktop.png`.