### PR TITLE
[codex] fix homelab site deploy nginx test

### DIFF
--- a/.github/workflows/deploy-to-homelab.yml
+++ b/.github/workflows/deploy-to-homelab.yml
@@ -89,7 +89,7 @@ jobs:
             sudo mkdir -p /var/www/rpa4all.com
             sudo rsync -az --delete site/ /var/www/rpa4all.com/
             sudo chown -R www-data:www-data /var/www/rpa4all.com || true
-            if nginx -t >/dev/null 2>&1; then
+            if sudo nginx -t >/dev/null 2>&1; then
               sudo systemctl reload nginx || sudo nginx -s reload || true
             else
               echo "nginx config test failed; keeping previous site" >&2


### PR DESCRIPTION
## O que mudou

- Corrige o workflow `Deploy to Homelab` para executar `nginx -t` com `sudo` no caminho self-hosted.

## Motivo

O deploy anterior copiou `site/` para `/var/www/rpa4all.com`, mas falhou no teste do Nginx porque `nginx -t` foi executado sem permissão suficiente.

## Validação

- Falha observada no run `27885484702`.
- Produção já validada manualmente em `https://www.rpa4all.com/autorpa-monitor/`.