### PR TITLE
fix(exporter): today_open usa fechamento de ontem como referência

### DIFF
--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Dict, Optional
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from profile_rules import validate_profile_for_symbol
+from position_reconstruction import reconstruct_open_buys, summarize_open_buys
 
 try:
     import psycopg2
@@ -238,17 +239,22 @@ class MetricsCollector:
             cur.execute("""
                 WITH bounds AS (
                     SELECT
-                        EXTRACT(EPOCH FROM date_trunc('day', NOW()))              AS today_start,
-                        EXTRACT(EPOCH FROM date_trunc('day', NOW() - INTERVAL '1 day')) AS yday_start
+                        EXTRACT(EPOCH FROM date_trunc('day', NOW()))                        AS today_start,
+                        EXTRACT(EPOCH FROM date_trunc('day', NOW() - INTERVAL '1 day'))     AS yday_start,
+                        EXTRACT(EPOCH FROM date_trunc('day', NOW() - INTERVAL '2 days'))    AS d2_start
                 )
                 SELECT
-                    (SELECT equity_usdt FROM btc.exchange_snapshots
-                     WHERE timestamp >= b.today_start ORDER BY timestamp ASC  LIMIT 1) AS today_open,
-                    (SELECT equity_usdt FROM btc.exchange_snapshots
-                     ORDER BY timestamp DESC LIMIT 1)                               AS today_close,
+                    -- today_open = fechamento de ontem (último snapshot antes de hoje),
+                    -- evita distorção quando o exporter ficou offline parte do dia
                     (SELECT equity_usdt FROM btc.exchange_snapshots
                      WHERE timestamp >= b.yday_start AND timestamp < b.today_start
-                     ORDER BY timestamp ASC  LIMIT 1)                               AS yday_open,
+                     ORDER BY timestamp DESC LIMIT 1)                               AS today_open,
+                    (SELECT equity_usdt FROM btc.exchange_snapshots
+                     ORDER BY timestamp DESC LIMIT 1)                               AS today_close,
+                    -- yday_open = fechamento de anteontem
+                    (SELECT equity_usdt FROM btc.exchange_snapshots
+                     WHERE timestamp >= b.d2_start AND timestamp < b.yday_start
+                     ORDER BY timestamp DESC LIMIT 1)                               AS yday_open,
                     (SELECT equity_usdt FROM btc.exchange_snapshots
                      WHERE timestamp >= b.yday_start AND timestamp < b.today_start
                      ORDER BY timestamp DESC LIMIT 1)                               AS yday_close

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-22T19:03:34.759617+00:00",
+  "generated_at": "2026-06-22T19:48:10.085839+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-06-22T19:03:34.759617+00:00`
+- Generated at: `2026-06-22T19:48:10.085839+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `145`


### PR DESCRIPTION
## Summary
- `equity_change_today` mostrava negativo mesmo com trades positivos porque o `today_open` usava o primeiro snapshot disponível do dia — que era às 16:53 UTC (quando o exporter foi corrigido), não à meia-noite
- Fix: usar o último snapshot de ontem (previous close) como `today_open`, igual ao padrão das exchanges
- Mesmo fix aplicado ao `yday_open`: usa fechamento de anteontem como referência

## Test plan
- [ ] Painel "Hoje" no Grafana mostra variação positiva coerente com trades do dia
- [ ] Painel "Ontem" mostra variação do dia anterior corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)