### PR TITLE
feat(grafana): linha Total PnL no painel PnL no Período

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-22T19:48:10.085839+00:00",
+  "generated_at": "2026-06-22T19:51:08.734801+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-06-22T19:48:10.085839+00:00`
+- Generated at: `2026-06-22T19:51:08.734801+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `145`

--- a/grafana/dashboards/btc_trading_monitor.json
+++ b/grafana/dashboards/btc_trading_monitor.json
@@ -680,7 +680,41 @@
           },
           "unit": "currencyUSD"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total PnL"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "⚡ Total"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -739,6 +773,17 @@
           "rawQuery": true,
           "rawSql": "WITH bucketed AS (\n  SELECT\n    to_timestamp($__unixEpochGroup(timestamp, $__interval)) AS \"time\",\n    COALESCE(SUM(pnl), 0)::numeric(12,4) AS pnl_delta\n  FROM btc.trades\n  WHERE symbol = '$coin'\n    AND dry_run = false\n    AND profile = 'shadow'\n    AND 'shadow' IN (${profile:sqlstring})\n    AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\n  GROUP BY 1\n),\npoints AS (\n  SELECT to_timestamp($__unixEpochFrom()) AS \"time\", 0::numeric(12,4) AS pnl_delta, 0 AS sort_key\n  UNION ALL SELECT \"time\", pnl_delta, 1 AS sort_key FROM bucketed\n  UNION ALL SELECT to_timestamp($__unixEpochTo()) AS \"time\", 0::numeric(12,4) AS pnl_delta, 2 AS sort_key\n)\nSELECT \"time\",\n  SUM(pnl_delta) OVER (ORDER BY \"time\", sort_key)::numeric(12,4) AS \"Shadow PnL\"\nFROM points ORDER BY 1, sort_key",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "WITH bucketed AS (\n  SELECT\n    to_timestamp($__unixEpochGroup(timestamp, $__interval)) AS \"time\",\n    COALESCE(SUM(pnl), 0)::numeric(12,4) AS pnl_delta\n  FROM btc.trades\n  WHERE symbol = '$coin'\n    AND dry_run = false\n    AND profile IN (${profile:sqlstring})\n    AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\n  GROUP BY 1\n),\npoints AS (\n  SELECT to_timestamp($__unixEpochFrom()) AS \"time\", 0::numeric(12,4) AS pnl_delta, 0 AS sort_key\n  UNION ALL SELECT \"time\", pnl_delta, 1 AS sort_key FROM bucketed\n  UNION ALL SELECT to_timestamp($__unixEpochTo()) AS \"time\", 0::numeric(12,4) AS pnl_delta, 2 AS sort_key\n)\nSELECT \"time\",\n  SUM(pnl_delta) OVER (ORDER BY \"time\", sort_key)::numeric(12,4) AS \"Total PnL\"\nFROM points ORDER BY 1, sort_key",
+          "refId": "D"
         }
       ],
       "title": "📊 PnL no Período",


### PR DESCRIPTION
## Summary
- Adiciona linha **⚡ Total** ao painel 11 (PnL no Período) somando o PnL acumulado de todos os perfis selecionados via `$profile`
- Linha destacada: amarelo, 3px de espessura, sem fill
- Respeita o filtro `$profile` — se desselecionar um perfil, o total se ajusta

## Test plan
- [ ] Com 3 perfis selecionados: ver 4 linhas (conservative + aggressive + shadow + Total)
- [ ] Desmarcar um perfil: Total deve diminuir
- [ ] Verificar que Total corresponde à soma visual das outras linhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)