### PR TITLE
ci(ltfs): remover deploy na NAS do eddie-auto-dev

### DIFF
--- a/.github/workflows/deploy-ltfs-recovery-runtime.yml
+++ b/.github/workflows/deploy-ltfs-recovery-runtime.yml
@@ -46,110 +46,14 @@ jobs:
             tests/test_tape_orchestrator.py \
             -q --tb=short
 
-  deploy-nas:
-    name: Deploy no NAS
-    needs: test
-    runs-on:
-      - self-hosted
-      - Linux
-      - nas
-    timeout-minutes: 10
-
-    steps:
-      - name: Baixar sources do commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          WORKDIR="$(mktemp -d)"
-          curl -fsSL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/tarball/${GITHUB_SHA}" \
-            | tar -xz --strip-components=1 -C "$WORKDIR"
-          echo "WORKDIR=$WORKDIR" >> "$GITHUB_ENV"
-
-      - name: Guardrail de deploy no NAS
-        env:
-          NAS_GH_DEPLOY_TOKEN: ${{ secrets.NAS_GH_DEPLOY_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${NAS_GH_DEPLOY_TOKEN:-}" ]; then
-            echo "Secret NAS_GH_DEPLOY_TOKEN ausente. Deploy bloqueado." >&2
-            exit 1
-          fi
-
-          tar -C "$WORKDIR" -cf - \
-            tools/ltfs_recovery.py \
-            tools/tape_manager.py \
-            tools/ltfs-lto6-start \
-            tools/ltfs-lto6-stop \
-            systemd/ltfs-lto6.service \
-            systemd/ltfs-lto6-selfheal-escalator.service \
-            systemd/ltfs-lto6.service.d/80-selfheal-on-failure.conf \
-            systemd/ltfs-deep-recovery.service \
-            systemd/ltfs-boot-reconcile.service \
-            systemd/lto6-selfheal.service \
-            | ssh -o BatchMode=yes -o StrictHostKeyChecking=no homelab@192.168.15.2 \
-                "ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@192.168.15.4 'mkdir -p /tmp/ltfs-gh-deploy && tar -xf - -C /tmp/ltfs-gh-deploy'"
-
-          printf -v TOKEN_Q '%q' "$NAS_GH_DEPLOY_TOKEN"
-          printf -v REPO_Q '%q' "$GITHUB_REPOSITORY"
-          printf -v RUN_Q '%q' "$GITHUB_RUN_ID"
-          printf -v ACTOR_Q '%q' "$GITHUB_ACTOR"
-
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=no homelab@192.168.15.2 \
-            "ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@192.168.15.4 '
-              export GH_DEPLOY_TOKEN=${TOKEN_Q}
-              export GH_DEPLOY_REPOSITORY=${REPO_Q}
-              export GH_DEPLOY_RUN_ID=${RUN_Q}
-              export GH_DEPLOY_ACTOR=${ACTOR_Q}
-              /usr/local/sbin/nas-gh-deploy-guard deploy-ltfs-recovery-runtime
-            '"
-
-      - name: Instalar script e units LTFS
-        run: |
-          set -euo pipefail
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=no homelab@192.168.15.2 \
-            "ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@192.168.15.4 '
-              install -D -m 0755 /tmp/ltfs-gh-deploy/tools/ltfs_recovery.py /usr/local/tools/ltfs_recovery.py
-              install -D -m 0755 /tmp/ltfs-gh-deploy/tools/ltfs_recovery.py /var/db/ltfs-tools/ltfs_recovery.py
-              install -D -m 0755 /tmp/ltfs-gh-deploy/tools/tape_manager.py /usr/local/bin/tape-manager
-              install -D -m 0755 /tmp/ltfs-gh-deploy/tools/ltfs-lto6-start /usr/local/sbin/ltfs-fc-stable-start
-              install -D -m 0755 /tmp/ltfs-gh-deploy/tools/ltfs-lto6-stop /usr/local/sbin/ltfs-lto6-stop
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/ltfs-lto6.service /etc/systemd/system/ltfs-lto6.service
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/ltfs-lto6-selfheal-escalator.service /etc/systemd/system/ltfs-lto6-selfheal-escalator.service
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/ltfs-lto6.service.d/80-selfheal-on-failure.conf /etc/systemd/system/ltfs-lto6.service.d/80-selfheal-on-failure.conf
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/ltfs-deep-recovery.service /etc/systemd/system/ltfs-deep-recovery.service
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/ltfs-boot-reconcile.service /etc/systemd/system/ltfs-boot-reconcile.service
-              install -D -m 0644 /tmp/ltfs-gh-deploy/systemd/lto6-selfheal.service /etc/systemd/system/lto6-selfheal.service
-              rm -f /etc/systemd/system/ltfs-cache-flush.service.d/70-rearm-timer-on-exit.conf
-              systemctl daemon-reload
-              systemctl enable ltfs-boot-reconcile.service
-              systemctl reset-failed ltfs-lto6.service ltfs-deep-recovery.service lto6-selfheal.service ltfs-cache-flush.service ltfs-lto6-selfheal-escalator.service || true
-            '"
-
-      - name: Validar binário instalado
-        run: |
-          set -euo pipefail
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=no homelab@192.168.15.2 \
-            "ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@192.168.15.4 '
-              python3 /usr/local/tools/ltfs_recovery.py --help >/dev/null
-              /usr/local/bin/tape-manager --help >/dev/null
-              test -x /usr/local/sbin/ltfs-fc-stable-start
-              test -x /usr/local/sbin/ltfs-lto6-stop
-              systemctl cat lto6-selfheal.service >/dev/null
-              systemctl cat ltfs-deep-recovery.service >/dev/null
-              systemctl cat ltfs-lto6-selfheal-escalator.service >/dev/null
-            '"
-
+  # Deploy na NAS movido para o repo truenas-lto6-app (workflow deploy-host-assets)
   deploy-homelab:
     name: Deploy no Homelab
     needs: test
     runs-on:
       - self-hosted
       - Linux
-      - nas
+      - homelab
     timeout-minutes: 10
 
     steps:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,18 +1,20 @@
 {
-  "generated_at": "2026-07-02T22:44:01.458927+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/389fb9a1-3a39-40ca-8380-632f0738fbf8/scratchpad/pr-ltfs",
+  "generated_at": "2026-07-02T22:54:11.051235+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/389fb9a1-3a39-40ca-8380-632f0738fbf8/scratchpad/wt-nodeploy",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
     "repo_services": 156,
-    "critical_services": 156,
+    "critical_services": 65,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 16,
-      "storage": 122
+      "operations": 88,
+      "storage": 31,
+      "trading": 3
     }
   },
   "netbox_devices": [
@@ -310,339 +312,707 @@
     },
     {
       "name": "glpi",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "glpi-db",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mail-db",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mail-server",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-backend",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-db",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-dovecot",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-frontend",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-postfix",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-redis",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "mailu-roundcube",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "netbox",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "netbox-postgres",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "netbox-redis",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "netbox-redis-cache",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "netbox-worker",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "nginx",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "ntopng",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "ntopng-redis",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "opensearch-dashboards",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "opensearch-node1",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "postgres",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.email-simple.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "printshare",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "deploy/printshare/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "roundcube",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "wikijs",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "wikijs-db",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "compose",
       "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "akash-sweep.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/akash-sweep.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "akash-sweep.timer",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/akash-sweep.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "approval-gateway.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/approval-gateway.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "auto_validate.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "deploy/auto_validate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "autonomous_remediator.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "tools/systemd/autonomous_remediator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "bn-acervo-agent.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/bn-acervo-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "check_projects.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/check_projects.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "check_projects.timer",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/check_projects.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "chromecast-ambilight.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/chromecast-ambilight.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "clear-agent@.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/clear-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "clear-trading-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/clear-trading-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "coordinator.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "crypto-agent@.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/crypto-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "diretor.service",
-      "domain": "storage",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/diretor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-calendar.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-calendar.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-expurgo.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-expurgo.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-telegram-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-telegram-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-tray-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/eddie-tray-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-whatsapp-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-whatsapp-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "final-boot-status-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "gdrive-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/gdrive-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "github-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/github-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "homelab-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-drain.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-drain.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-recover.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-recover.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-smb-proof-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "notebook-power-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-coordinator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu-coordinator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/ollama-gpu-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu1.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu1.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "pandaplus-telegram-bridge.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/pandaplus-telegram-bridge.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "post-boot-check.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/post-boot-check.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "printshare.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/printshare/printshare.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "review-service.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/review-service.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "secrets_agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/secrets_agent/secrets_agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "server-error-alert.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/homelab/server-error-alert.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "specialized_agents-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "workstation-win11l-http@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/workstation-win11l-http@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "workstation-win11l-rdp@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/workstation-win11l-rdp@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "x-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/x_agent/x-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "disk-clean.service",
@@ -665,78 +1035,6 @@
       "domain": "storage",
       "kind": "systemd",
       "source": "tools/homelab/disk-spindown.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-calendar.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/eddie-calendar.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-expurgo.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/eddie-expurgo.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-telegram-bot.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/eddie-telegram-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-tray-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/systemd/eddie-tray-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-whatsapp-bot.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/eddie-whatsapp-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "final-boot-status-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/systemd/final-boot-status-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "gdrive-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/systemd/gdrive-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "github-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/github-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-dashboard.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-dashboard.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -793,22 +1091,6 @@
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/homelab-tape-logrotate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "journal-ingestor.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "journal-ingestor.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -909,22 +1191,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "lto6-checkpoint-drain.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-drain.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-checkpoint-recover.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-recover.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "lto6-drain-backups.service",
       "domain": "storage",
       "kind": "systemd",
@@ -937,254 +1203,6 @@
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/lto6-drain-backups.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-smb-proof-selfheal.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-api.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-api.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "notebook-power-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/notebook-power-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-coordinator.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu-coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-selfheal.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/ollama-gpu-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu1.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "pandaplus-telegram-bridge.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/pandaplus-telegram-bridge.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "post-boot-check.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/post-boot-check.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "printshare.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "deploy/printshare/printshare.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "python-training.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/python-training.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "python-training.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/python-training.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "review-service.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/systemd/review-service.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "secrets_agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/secrets_agent/secrets_agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "server-error-alert.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "deploy/homelab/server-error-alert.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "specialized_agents-dashboard.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/specialized_agents-dashboard.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1245,44 +1263,28 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "tuya-token-renewer.service",
-      "domain": "storage",
+      "name": "candle-collector.service",
+      "domain": "trading",
       "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "source": "systemd/candle-collector.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
-      "name": "tuya-token-renewer.timer",
-      "domain": "storage",
+      "name": "candle-collector.timer",
+      "domain": "trading",
       "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "source": "systemd/candle-collector.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
-      "name": "workstation-win11l-http@.service",
-      "domain": "storage",
+      "name": "clear-trading-agent.service",
+      "domain": "trading",
       "kind": "systemd",
-      "source": "systemd/workstation-win11l-http@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "workstation-win11l-rdp@.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/workstation-win11l-rdp@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "x-agent.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/x_agent/x-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "source": "systemd/clear-trading-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     }
   ],
   "mvp_focus": {
@@ -1532,300 +1534,6 @@
         "critical": true
       },
       {
-        "name": "glpi",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "glpi-db",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-db",
-        "domain": "storage",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-server",
-        "domain": "storage",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-backend",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-db",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-dovecot",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-frontend",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-postfix",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-redis",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-roundcube",
-        "domain": "storage",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-postgres",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis-cache",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-worker",
-        "domain": "storage",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "nginx",
-        "domain": "storage",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng",
-        "domain": "storage",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng-redis",
-        "domain": "storage",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-dashboards",
-        "domain": "storage",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-node1",
-        "domain": "storage",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "postgres",
-        "domain": "storage",
-        "source": "docker/docker-compose.email-simple.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "printshare",
-        "domain": "storage",
-        "source": "deploy/printshare/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "roundcube",
-        "domain": "storage",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs",
-        "domain": "storage",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs-db",
-        "domain": "storage",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.service",
-        "domain": "storage",
-        "source": "systemd/akash-sweep.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.timer",
-        "domain": "storage",
-        "source": "systemd/akash-sweep.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "approval-gateway.service",
-        "domain": "storage",
-        "source": "systemd/approval-gateway.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "auto_validate.service",
-        "domain": "storage",
-        "source": "deploy/auto_validate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "autonomous_remediator.service",
-        "domain": "storage",
-        "source": "tools/systemd/autonomous_remediator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "bn-acervo-agent.service",
-        "domain": "storage",
-        "source": "systemd/bn-acervo-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.service",
-        "domain": "storage",
-        "source": "systemd/candle-collector.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.timer",
-        "domain": "storage",
-        "source": "systemd/candle-collector.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.service",
-        "domain": "storage",
-        "source": "systemd/check_projects.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.timer",
-        "domain": "storage",
-        "source": "systemd/check_projects.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "chromecast-ambilight.service",
-        "domain": "storage",
-        "source": "systemd/chromecast-ambilight.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-agent@.service",
-        "domain": "storage",
-        "source": "systemd/clear-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-trading-agent.service",
-        "domain": "storage",
-        "source": "systemd/clear-trading-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "coordinator.service",
-        "domain": "storage",
-        "source": "systemd/coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "crypto-agent@.service",
-        "domain": "storage",
-        "source": "systemd/crypto-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "diretor.service",
-        "domain": "storage",
-        "source": "systemd/diretor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "disk-clean.service",
         "domain": "storage",
         "source": "systemd/disk-clean.service",
@@ -1843,69 +1551,6 @@
         "name": "disk-spindown.service",
         "domain": "storage",
         "source": "tools/homelab/disk-spindown.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-calendar.service",
-        "domain": "storage",
-        "source": "systemd/eddie-calendar.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-expurgo.service",
-        "domain": "storage",
-        "source": "systemd/eddie-expurgo.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-telegram-bot.service",
-        "domain": "storage",
-        "source": "systemd/eddie-telegram-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-tray-agent.service",
-        "domain": "storage",
-        "source": "tools/systemd/eddie-tray-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-whatsapp-bot.service",
-        "domain": "storage",
-        "source": "systemd/eddie-whatsapp-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "final-boot-status-agent.service",
-        "domain": "storage",
-        "source": "tools/systemd/final-boot-status-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "gdrive-agent.service",
-        "domain": "storage",
-        "source": "tools/systemd/gdrive-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "github-agent.service",
-        "domain": "storage",
-        "source": "systemd/github-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-dashboard.service",
-        "domain": "storage",
-        "source": "systemd/homelab-dashboard.service",
         "kind": "systemd",
         "critical": true
       },
@@ -1955,20 +1600,6 @@
         "name": "homelab-tape-logrotate.timer",
         "domain": "storage",
         "source": "systemd/homelab-tape-logrotate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "journal-ingestor.service",
-        "domain": "storage",
-        "source": "systemd/journal-ingestor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "journal-ingestor.timer",
-        "domain": "storage",
-        "source": "systemd/journal-ingestor.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2057,20 +1688,6 @@
         "critical": true
       },
       {
-        "name": "lto6-checkpoint-drain.service",
-        "domain": "storage",
-        "source": "systemd/lto6-checkpoint-drain.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-checkpoint-recover.service",
-        "domain": "storage",
-        "source": "systemd/lto6-checkpoint-recover.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "lto6-drain-backups.service",
         "domain": "storage",
         "source": "systemd/lto6-drain-backups.service",
@@ -2081,223 +1698,6 @@
         "name": "lto6-drain-backups.timer",
         "domain": "storage",
         "source": "systemd/lto6-drain-backups.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.service",
-        "domain": "storage",
-        "source": "systemd/lto6-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.timer",
-        "domain": "storage",
-        "source": "systemd/lto6-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-smb-proof-selfheal.service",
-        "domain": "storage",
-        "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-api.service",
-        "domain": "storage",
-        "source": "systemd/marketing-api.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.service",
-        "domain": "storage",
-        "source": "systemd/marketing-daily-report.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.timer",
-        "domain": "storage",
-        "source": "systemd/marketing-daily-report.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.service",
-        "domain": "storage",
-        "source": "systemd/marketing-email-drip.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.timer",
-        "domain": "storage",
-        "source": "systemd/marketing-email-drip.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.service",
-        "domain": "storage",
-        "source": "systemd/marketing-x-posts.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.timer",
-        "domain": "storage",
-        "source": "systemd/marketing-x-posts.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "notebook-power-agent.service",
-        "domain": "storage",
-        "source": "systemd/notebook-power-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.service",
-        "domain": "storage",
-        "source": "systemd/ollama-finetune.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.timer",
-        "domain": "storage",
-        "source": "systemd/ollama-finetune.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-coordinator.service",
-        "domain": "storage",
-        "source": "systemd/ollama-gpu-coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-selfheal.service",
-        "domain": "storage",
-        "source": "tools/ollama-gpu-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu1.service",
-        "domain": "storage",
-        "source": "systemd/ollama-gpu1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.service",
-        "domain": "storage",
-        "source": "systemd/ollama-warmup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.timer",
-        "domain": "storage",
-        "source": "systemd/ollama-warmup.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "pandaplus-telegram-bridge.service",
-        "domain": "storage",
-        "source": "systemd/pandaplus-telegram-bridge.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "post-boot-check.service",
-        "domain": "storage",
-        "source": "systemd/post-boot-check.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "printshare.service",
-        "domain": "storage",
-        "source": "deploy/printshare/printshare.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "python-training.service",
-        "domain": "storage",
-        "source": "systemd/python-training.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "python-training.timer",
-        "domain": "storage",
-        "source": "systemd/python-training.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.service",
-        "domain": "storage",
-        "source": "systemd/rag-reindex.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.timer",
-        "domain": "storage",
-        "source": "systemd/rag-reindex.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "review-service.service",
-        "domain": "storage",
-        "source": "tools/systemd/review-service.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.service",
-        "domain": "storage",
-        "source": "systemd/rpa4all-validation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.timer",
-        "domain": "storage",
-        "source": "systemd/rpa4all-validation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "secrets_agent.service",
-        "domain": "storage",
-        "source": "tools/secrets_agent/secrets_agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "server-error-alert.service",
-        "domain": "storage",
-        "source": "deploy/homelab/server-error-alert.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "specialized_agents-dashboard.service",
-        "domain": "storage",
-        "source": "systemd/specialized_agents-dashboard.service",
         "kind": "systemd",
         "critical": true
       },
@@ -2347,41 +1747,6 @@
         "name": "tape-safe-eject.service",
         "domain": "storage",
         "source": "systemd/tape-safe-eject.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.service",
-        "domain": "storage",
-        "source": "systemd/tuya-token-renewer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.timer",
-        "domain": "storage",
-        "source": "systemd/tuya-token-renewer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "workstation-win11l-http@.service",
-        "domain": "storage",
-        "source": "systemd/workstation-win11l-http@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "workstation-win11l-rdp@.service",
-        "domain": "storage",
-        "source": "systemd/workstation-win11l-rdp@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "x-agent.service",
-        "domain": "storage",
-        "source": "tools/x_agent/x-agent.service",
         "kind": "systemd",
         "critical": true
       }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-02T22:44:01.458927+00:00`
+- Generated at: `2026-07-02T22:54:11.051235+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `156`
-- Critical services flagged for MVP: `156`
+- Critical services flagged for MVP: `65`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -13,7 +13,9 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 16
-- `storage`: 122
+- `operations`: 88
+- `storage`: 31
+- `trading`: 3
 
 ## NetBox seed candidates
 
@@ -55,12 +57,12 @@
 - `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
 - `rpa4all-vpn-ddns.service` (network, systemd) from `deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service`
 - `wireguard-nat.service` (network, systemd) from `deploy/vpn/wireguard-nat.service`
-- `glpi` (storage, compose) from `deploy/cmdb/docker-compose.yml`
-- `glpi-db` (storage, compose) from `deploy/cmdb/docker-compose.yml`
-- `mail-db` (storage, compose) from `docker/docker-compose.simple-mail.yml`
-- `mail-server` (storage, compose) from `docker/docker-compose.simple-mail.yml`
-- `mailu-backend` (storage, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-db` (storage, compose) from `docker/docker-compose.mailu.yml`
+- `disk-clean.service` (storage, systemd) from `systemd/disk-clean.service`
+- `disk-clean.timer` (storage, systemd) from `systemd/disk-clean.timer`
+- `disk-spindown.service` (storage, systemd) from `tools/homelab/disk-spindown.service`
+- `homelab-disk-backup.service` (storage, systemd) from `tools/backup/homelab-disk-backup.service`
+- `homelab-tape-log-drain-nextcloud.service` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.service`
+- `homelab-tape-log-drain-nextcloud.timer` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.timer`
 
 ## Serviços anotados manualmente
 


### PR DESCRIPTION
O eddie-auto-dev não deve efetuar deploy na NAS — essa responsabilidade agora é do [truenas-lto6-app PR #2](https://github.com/eddiejdi/truenas-lto6-app/pull/2) (workflow `deploy-host-assets.yml` → dataset persistente + bootstrap).

Este workflow passa a apenas: rodar os testes LTFS + deploy no homelab (label do runner corrigido de `nas` — que não existe mais — para `homelab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)