### PR TITLE
fix(trading): advisory lock na migração de schema (deadlock no startup)

### DIFF
--- a/btc_trading_agent/training_db.py
+++ b/btc_trading_agent/training_db.py
@@ -215,6 +215,10 @@ class TrainingDatabase:
         """Garante que o schema e tabelas existem"""
         with self._get_conn() as conn:
             cur = conn.cursor()
+            # Serializa a migração entre agentes que sobem simultaneamente
+            # (deploy reinicia os 3 profiles juntos → DeadlockDetected nos
+            # ALTER TABLE concorrentes). Lock liberado no commit/rollback.
+            cur.execute("SELECT pg_advisory_xact_lock(hashtext('btc_ensure_schema'))")
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
 
             cur.execute(f"""

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T12:49:19.094150+00:00",
+  "generated_at": "2026-07-03T13:14:27.577961+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T12:49:19.094150+00:00`
+- Generated at: `2026-07-03T13:14:27.577961+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `158`


### PR DESCRIPTION
Deploy reinicia os 3 profiles simultaneamente e cada um roda `PROFILE_MIGRATION_SQL` em `_ensure_schema()`; os `ALTER TABLE` concorrentes causaram `DeadlockDetected` no aggressive durante o deploy de hoje (auto-recuperado via systemd restart). `pg_advisory_xact_lock` serializa a migração entre agentes.

Testes: 33 verdes (cenario3, kucoin_postgres_sync, exporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)