### PR TITLE
fix(grafana): painel Saldo Exchange R$ — conversão BRL e escopo de contas

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T14:09:21.863828+00:00",
+  "generated_at": "2026-07-03T14:23:50.628628+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T14:09:21.863828+00:00`
+- Generated at: `2026-07-03T14:23:50.628628+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `158`

--- a/grafana/dashboards/btc_trading_monitor.json
+++ b/grafana/dashboards/btc_trading_monitor.json
@@ -2322,7 +2322,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
       },
-      "description": "Saldo disponível na conta trade convertido para BRL a partir do último snapshot sincronizado da exchange.",
+      "description": "Saldo total disponível na KuCoin convertido para BRL, somando as contas main e trade da conta master (subcontas não são sincronizadas). Taxa BRL do último snapshot.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2379,11 +2379,11 @@
       "targets": [
         {
           "format": "table",
-          "rawSql": "WITH latest_sync AS (\n  SELECT MAX(synced_at) AS synced_at\n  FROM btc.exchange_balance_snapshots\n  WHERE account_type = 'trade'\n), latest_balances AS (\n  SELECT currency, available, price_usdt\n  FROM btc.exchange_balance_snapshots ebs\n  JOIN latest_sync ls ON ebs.synced_at = ls.synced_at\n  WHERE ebs.account_type = 'trade' AND ebs.available > 0\n), brl_rate AS (\n  SELECT COALESCE(\n    MAX(CASE WHEN currency = 'BRL' THEN NULLIF(price_usdt, 0) END),\n    1\n  ) AS brl_price_usdt\n  FROM latest_balances\n)\nSELECT ROUND(COALESCE(SUM(\n  CASE\n    WHEN lb.currency = 'BRL' THEN lb.available\n    WHEN br.brl_price_usdt IS NULL OR br.brl_price_usdt = 0 THEN 0\n    ELSE (lb.available * COALESCE(lb.price_usdt, CASE WHEN lb.currency = 'USDT' THEN 1 END, 0)) / br.brl_price_usdt\n  END\n), 0)::numeric, 2) AS value\nFROM latest_balances lb\nCROSS JOIN brl_rate br",
+          "rawSql": "WITH latest_sync AS (\n  SELECT MAX(synced_at) AS synced_at\n  FROM btc.exchange_balance_snapshots\n), latest_balances AS (\n  SELECT account_type, currency, available, price_usdt\n  FROM btc.exchange_balance_snapshots ebs\n  JOIN latest_sync ls ON ebs.synced_at = ls.synced_at\n  WHERE ebs.available > 0\n), brl_rate AS (\n  SELECT MAX(CASE WHEN currency = 'BRL' THEN NULLIF(price_usdt, 0) END) AS brl_price_usdt\n  FROM latest_balances\n)\nSELECT ROUND(COALESCE(SUM(\n  CASE\n    WHEN lb.currency = 'BRL' THEN lb.available\n    WHEN br.brl_price_usdt IS NULL OR br.brl_price_usdt = 0 THEN 0\n    ELSE (lb.available * COALESCE(lb.price_usdt, CASE WHEN lb.currency = 'USDT' THEN 1 END, 0)) / br.brl_price_usdt\n  END\n), 0)::numeric, 2) AS value\nFROM latest_balances lb\nCROSS JOIN brl_rate br",
           "refId": "A"
         }
       ],
-      "title": "💸 Disponível para Saque (R$)",
+      "title": "💸 Saldo Exchange em R$ (main+trade)",
       "type": "stat"
     },
     {


### PR DESCRIPTION
Pergunta do usuário: "este painel está somando as subcontas?" — resposta: não, e havia bug pior.

- **Subcontas KuCoin não são sincronizadas** — `btc.exchange_balance_snapshots` só tem `main` e `trade` da conta master (documentado na descrição do painel)
- **Bug de conversão**: a taxa BRL era buscada só nas linhas `trade` (sem BRL) → fallback 1 → painel exibia **US$ 516,57 rotulado como R$**. Correto: **R$ 2.787,88**
- Query corrigida (taxa do snapshot completo, soma main+trade) e painel renomeado para "💸 Saldo Exchange em R$ (main+trade)"
- Já deployado e ingerido pelo Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)