### PR TITLE
feat(trading): mensagens do agente em grupo Telegram exclusivo

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T21:25:21.034514+00:00",
+  "generated_at": "2026-07-03T21:44:57.368719+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T21:25:21.034514+00:00`
+- Generated at: `2026-07-03T21:44:57.368719+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `159`

--- a/systemd/trading-daily-report.service
+++ b/systemd/trading-daily-report.service
@@ -13,8 +13,10 @@ EnvironmentFile=/etc/default/eddie-common
 Environment=PYTHONUNBUFFERED=1
 Environment=OLLAMA_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADING_MODEL=trading-analyst:latest
-Environment=TELEGRAM_CHAT_ID=948686300
-ExecStart=/usr/bin/python3 /home/homelab/myClaude/scripts/trading_daily_report.py
+# Grupo exclusivo "BTC Trade Agent" (2026-07-03). Definido no ExecStart via
+# env porque EnvironmentFile (eddie-common traz o chat privado) sobrepõe
+# qualquer Environment= da unit.
+ExecStart=/usr/bin/env TELEGRAM_CHAT_ID=-1004434951297 /usr/bin/python3 /home/homelab/myClaude/scripts/trading_daily_report.py
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Pedido: notificações do trading agent em canal exclusivo em vez do chat privado.

- Grupo **BTC Trade Agent** (`-1004434951297`; o ID inicial `-5517772551` migrou no upgrade para supergrupo)
- `TRADING_TELEGRAM_CHAT_ID` atualizado nos envfiles dos 3 perfis (host); `TRADING_TELEGRAM_THREAD_ID=94271` removido (tópico órfão apontado para chat privado — nunca funcionou)
- Relatório diário das 10h também no grupo — chat fixado via `/usr/bin/env` no `ExecStart` (EnvironmentFile do eddie-common sobrepõe `Environment=`)
- Testado: mensagem de teste + relatório entregues no grupo; agentes reiniciados e saudáveis (guardrails ativos, posições preservadas, sem deadlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)