### PR TITLE
fix(trading): timer do kucoin-postgres-sync morto desde a queda de energia

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-07-03T21:44:57.368719+00:00",
+  "generated_at": "2026-07-03T21:47:59.314805+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 159,
+    "repo_services": 161,
     "critical_services": 66,
     "domains": {
       "identity": 4,
@@ -14,7 +14,7 @@
       "network": 16,
       "operations": 88,
       "storage": 32,
-      "trading": 5
+      "trading": 7
     }
   },
   "netbox_devices": [
@@ -1291,6 +1291,22 @@
       "domain": "trading",
       "kind": "systemd",
       "source": "systemd/clear-trading-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T21:44:57.368719+00:00`
+- Generated at: `2026-07-03T21:47:59.314805+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `159`
+- Repo services discovered: `161`
 - Critical services flagged for MVP: `66`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -15,7 +15,7 @@
 - `network`: 16
 - `operations`: 88
 - `storage`: 32
-- `trading`: 5
+- `trading`: 7
 
 ## NetBox seed candidates
 

--- a/systemd/kucoin-postgres-sync.service
+++ b/systemd/kucoin-postgres-sync.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=KuCoin → PostgreSQL balance/fills sync (one-shot)
+After=network.target postgresql.service secrets_agent.service
+Wants=secrets_agent.service
+
+[Service]
+Type=oneshot
+User=btc-trading
+Group=btc-trading
+WorkingDirectory=/apps/crypto-trader/trading/btc_trading_agent
+
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PYTHONUNBUFFERED=1
+Environment=BTC_AGENT_DIR=/apps/crypto-trader/trading/btc_trading_agent
+EnvironmentFile=-/apps/crypto-trader/envfiles/trading-database.env
+
+ExecStart=/usr/bin/python3 /apps/crypto-trader/trading/scripts/kucoin_postgres_sync.py
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=kucoin-postgres-sync
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/apps/crypto-trader

--- a/systemd/kucoin-postgres-sync.timer
+++ b/systemd/kucoin-postgres-sync.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=KuCoin → PostgreSQL sync — a cada 15 minutos
+
+[Timer]
+# OnCalendar em vez de OnUnitActiveSec: após a queda de energia de
+# 2026-07-02 o timer ficou "elapsed" sem próxima execução (OnUnitActiveSec
+# só re-arma relativo à última ativação; se a cadeia quebra, morre).
+OnCalendar=*:00/15
+Persistent=true
+Unit=kucoin-postgres-sync.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
O `kucoin-postgres-sync.timer` (snapshots de saldo a cada 15 min) estava **elapsed sem próxima execução** desde o boot pós-queda de energia de 2026-07-02 — `OnUnitActiveSec` não re-armou. Snapshots caíram de ~95/dia para ~1/h, esparsificando o gráfico de Evolução Patrimonial e o balanço do relatório diário.

- Timer reescrito com `OnCalendar=*:00/15` (re-arma por relógio, imune ao problema)
- `.service` e `.timer` agora versionados no repo (só existiam no host)
- Aplicado em produção: sync rodou agora, próxima execução 19:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)