### PR TITLE
feat(trading): subcontas KuCoin, credencial via Authentik, política de saída e plano ETH

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -746,6 +746,40 @@ def get_balances(account_type: str = "trade") -> List[Dict[str, Any]]:
         for a in accounts if a.get("type") == account_type
     ]
 
+def get_sub_account_balances() -> List[Dict[str, Any]]:
+    """Obtém saldos de todas as subcontas da conta master.
+
+    Retorna lista plana com um item por (subconta, tipo, moeda):
+    {sub_name, account_type, currency, balance, available, holds}.
+    Lista vazia se não houver subcontas.
+    """
+    r = _signed_request("GET", "/api/v1/sub-accounts", timeout=10)
+    if r.status_code != 200:
+        raise RuntimeError(f"API error: {r.status_code}")
+
+    data = r.json().get("data") or []
+    # v1 retorna lista; formatos paginados usam {"items": [...]}
+    subs = data.get("items", []) if isinstance(data, dict) else data
+    out: List[Dict[str, Any]] = []
+    for sub in subs:
+        name = sub.get("subName") or sub.get("subUserId") or "sub"
+        for bucket, acc_type in (
+            ("mainAccounts", "main"),
+            ("tradeAccounts", "trade"),
+            ("marginAccounts", "margin"),
+        ):
+            for a in sub.get(bucket) or []:
+                out.append({
+                    "sub_name": name,
+                    "account_type": acc_type,
+                    "currency": a.get("currency"),
+                    "balance": float(a.get("balance", 0)),
+                    "available": float(a.get("available", 0)),
+                    "holds": float(a.get("holds", 0)),
+                })
+    return out
+
+
 def get_balance(currency: str = "USDT") -> float:
     """Obtém saldo específico da conta TRADE."""
     balances = get_balances(account_type="trade")

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T21:47:59.314805+00:00",
+  "generated_at": "2026-07-03T21:59:15.383750+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T21:47:59.314805+00:00`
+- Generated at: `2026-07-03T21:59:15.383750+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/docs/TRADING_AGENT_REVIEW_2026-07-03.md
+++ b/docs/TRADING_AGENT_REVIEW_2026-07-03.md
@@ -111,16 +111,27 @@ Agora, a partir de `btc.exchange_balance_snapshots` (~15 min): **Conta Main**,
 - Shadow reiniciou 2× em 2026-07-02 porque o Postgres não estava pronto no boot
   pós-queda de energia; o retry do systemd resolveu.
 
-## 5. Pendências (decisão do usuário)
+## 5. Pendências — resolução (atualizado no fim de 2026-07-03)
 
-1. **Stop loss desligado no conservative** (`auto_stop_loss.enabled: false` com
-   `stop_loss_pct: 0.03` definido) — PnL negativo com WR alto indica perdas
-   assimétricas; habilitar ou justificar.
-2. **Credencial do DB inline no unit systemd** (`systemctl cat crypto-agent@...`
-   expõe `DATABASE_URL`) — mover para envfile com permissão 600.
-3. **Sincronizar subcontas KuCoin** no `kucoin_postgres_sync` se os saldos delas
-   devem aparecer no dashboard.
-4. **Snapshots esparsos em 2026-07-03** (5 até 10:53 vs ~95/dia) — verificar
-   cadência do sync se o gráfico patrimonial ficar com buracos.
-5. `trading_agent.py` com 5.857 linhas — extrair `_generate_ai_plan` (~600 linhas)
-   para módulo próprio; 70 blocos `except Exception` genéricos.
+1. **Stop loss** — decisão do usuário: *"deve ser o mínimo de lucro acima dos
+   custos (positivo)"* → nunca realizar prejuízo. Já era o comportamento
+   vigente (`guardrails_positive_only_sells` + `min_sell_pnl_pct 0.3%` >
+   taxas 0.2%); `auto_stop_loss` fica **desabilitado por design**.
+2. **Credencial do DB** — movida para o Secrets Agent/Authentik
+   (`shared/database_url`, field `url`; item `secret-shared-database-url-url`
+   no Authentik). Linha `Environment=DATABASE_URL=` removida do drop-in
+   `crypto-agent@.service.d/common.conf` (host e repo); o agente resolve via
+   `secrets_helper.get_database_url()` (testado ponta-a-ponta). Vale a partir
+   do próximo restart dos agentes. **Ainda inline no drop-in**:
+   `TELEGRAM_BOT_TOKEN` — candidato à mesma migração.
+3. **Subcontas KuCoin** — implementado: `get_sub_account_balances()` em
+   `kucoin_api.py` + snapshot com `account_type="sub:<nome>"` no
+   `kucoin_postgres_sync`. Subconta **sub:BTCAgressive** detectada e já
+   aparece no gráfico patrimonial (formato longo, linhas dinâmicas por conta),
+   no total e no relatório diário.
+4. **Snapshots esparsos** — root cause: `kucoin-postgres-sync.timer` morto
+   desde o boot de 2026-07-02 (`OnUnitActiveSec` não re-armou); corrigido com
+   `OnCalendar=*:00/15` (PR #194) e units versionadas.
+5. **Modularização** — aprovada; plano faseado em
+   `docs/TRADING_ETH_ACTIVATION_PLAN.md` (seção 2), junto com o plano de
+   ativação de ETH-USDT (shadow → validação → live).

--- a/docs/TRADING_ETH_ACTIVATION_PLAN.md
+++ b/docs/TRADING_ETH_ACTIVATION_PLAN.md
@@ -1,0 +1,103 @@
+# Plano de Ativação — Negociação ETH-USDT
+
+Planejado em 2026-07-03 a pedido do usuário. Pré-requisito: modularização mínima
+do `trading_agent.py` (seção 2), porque ativar um segundo símbolo multiplica o
+custo de manutenção do monolito.
+
+## 0. Decisões já tomadas (contexto)
+
+- **Política de saída (definida 2026-07-03)**: nunca realizar prejuízo — o piso
+  de venda é o lucro mínimo acima dos custos. Implementação vigente:
+  `guardrails_positive_only_sells: true` + `guardrails_min_sell_pnl_pct: 0.003`
+  (0,3% ≥ taxa round-trip de 0,2% + margem). `auto_stop_loss` permanece
+  **desabilitado por design** (o `stop_loss_pct: 0.03` da config é ignorado).
+  A mesma política se aplica ao ETH.
+- Shadow live no BTC é intencional (A/B test MACD vs baseline).
+- Mensagens de trading vão para o grupo Telegram "BTC Trade Agent"
+  (`-1004434951297`) — avaliar renomear para "Trade Agent" ao incluir ETH.
+
+## 1. O que já é multi-símbolo (verificado no código)
+
+| Componente | Status |
+|---|---|
+| `trading_agent.py` | `--config config_<PAR>_<perfil>.json` define `symbol`; `DEFAULT_SYMBOL` é só fallback |
+| `crypto-agent@.service` | template `%I` → `COIN_CONFIG_FILE=config_%I.json` + `envfiles/%I.env` — instância nova = config + envfile |
+| Schema `btc.*` | tabelas têm coluna `symbol` (o nome do schema é legado, não limita) |
+| Dashboard | variável `$coin` já lista ETH-USDT; queries filtram por `coin` |
+| MCP trading_* | parâmetro `symbol` em todas as tools |
+| KuCoin API | endpoints por símbolo; `get_price_fast("ETH-USDT")` funciona hoje |
+
+## 2. Pré-requisito: modularização do trading_agent.py (aprovada 2026-07-03)
+
+5.857 linhas hoje. Extrações em ordem de risco crescente, uma por PR, com a
+suíte de regressão passando em cada passo e sem mudança de comportamento:
+
+1. **`ai_planner.py`** — `_generate_ai_plan`, `_parse_ai_plan_controls`,
+   `_sanitize_ai_plan`, `_build_fallback_ai_plan`, `_save_ai_plan`,
+   `_cleanup_garbage_plans` (~900 linhas; só depende de db/ollama/estado).
+2. **`ai_controls.py`** — `_generate_ai_trade_controls/_window`, parsers e
+   saves correspondentes (~700 linhas).
+3. **`market_context.py`** — `_analyze_signal_context`, `_get_buy_*`,
+   `_get_sell_*`, profit-guard (~600 linhas).
+4. O núcleo (`_run_loop`, `_execute_trade`, `_check_can_trade`) fica em
+   `trading_agent.py` (~2.000 linhas ao final).
+
+Critério de aceite por etapa: `pytest tests/test_btc_*` verde + 24h de shadow
+sem divergência de decisão vs baseline (comparar `btc.decisions`).
+
+## 3. Fases de ativação do ETH
+
+### Fase A — Shadow/dry (sem dinheiro; ~30 min de trabalho)
+1. `config_ETH_USDT_shadow.json`: clonar do shadow BTC com
+   `symbol: "ETH-USDT"`, `dry_run: true`, `min_trade_amount: 10`,
+   guardrails idênticos (positive-only sells).
+2. `envfiles/ETH_USDT_shadow.env`: `TRADING_TELEGRAM_CHAT_ID=-1004434951297`.
+3. `systemctl enable --now crypto-agent@ETH_USDT_shadow` (dry — não requer
+   aprovação de trading real).
+4. Exporter: `crypto-exporter@ETH_USDT_shadow` na porta **9096** + scrape job
+   `servidor: homelab, coin: ETH-USDT` no prometheus.yml.
+5. Validar: decisões em `btc.decisions symbol='ETH-USDT'`, candles ETH
+   coletados, dashboard com `$coin=ETH-USDT` populando.
+
+### Fase B — Validação (1–2 semanas)
+- Win rate shadow ≥ 60% e PnL simulado positivo líquido de taxas.
+- Volatilidade ETH ≈ 1,5–2× BTC: revisar `max_volatility` (0.08→0.12?) e
+  `dca_valley_bounce_pct`.
+- Conferir se o modelo `trading-analyst` gera planos coerentes para ETH
+  (prompts usam o símbolo da config — sem hardcode de BTC detectado, mas
+  validar saída real).
+
+### Fase C — Live conservador (requer aprovação explícita + revisão)
+1. Gate da política de deploy: regressão completa + confirmação do usuário.
+2. `config_ETH_USDT_conservative.json`: `dry_run: false`,
+   `min_trade_amount: 10`, alocação inicial pequena (ex.: 15% do capital
+   trade — hoje ~$84 dos ~$560), `max_positions` reduzido (ex.: 4).
+3. Capital: decidir origem — conta trade compartilhada com BTC (mais simples;
+   `_get_active_symbol_profiles` já rateia exposição entre perfis live) ou
+   subconta dedicada (isolamento melhor; exige credencial da subconta no
+   secrets agent e testes do fluxo de transferência).
+4. Ativar e acompanhar 48h com relatório diário incluindo ETH (o script
+   é por-símbolo: adicionar loop de símbolos no `trading_daily_report.py`).
+
+### Fase D — Perfil aggressive ETH (opcional, após 30 dias de histórico)
+
+## 4. Riscos e mitigação
+
+- **Capital compartilhado**: BTC e ETH disputam o mesmo saldo trade — o rateio
+  por perfil existe, mas foi testado só com 1 símbolo; Fase A/B valida com
+  dry antes de arriscar.
+- **GPU/Ollama**: cada perfil novo adiciona chamadas ao trading-analyst;
+  monitorar latência do coordinator (11437) com 4+ perfis.
+- **Schema**: `btc.candles` é UNIQUE(timestamp, symbol, ktype) — ok; volume de
+  candles dobra (~2× storage, hoje irrelevante).
+- **Exporter/Prometheus**: nunca reutilizar porta de outro perfil (lição:
+  séries duplicadas silenciosas).
+
+## 5. Estimativa
+
+| Fase | Esforço | Dependência |
+|---|---|---|
+| Modularização 1 (ai_planner) | 1 sessão | — |
+| Fase A shadow ETH | 30 min | nenhuma (pode preceder a modularização) |
+| Fase B validação | 1–2 semanas corridas | Fase A |
+| Fase C live | 1 sessão + aprovação | Fase B + política de deploy |

--- a/grafana/dashboards/btc_trading_monitor.json
+++ b/grafana/dashboards/btc_trading_monitor.json
@@ -1959,7 +1959,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
       },
-      "description": "Patrimônio em USDT por conta KuCoin (main, trade, total) e por moeda (BTC convertido, USDT). Fonte: btc.exchange_balance_snapshots (~15 min). Subcontas não são sincronizadas.",
+      "description": "Patrimônio em USDT por conta KuCoin (main, trade e subcontas sub:*, dinâmico) e por moeda (BTC convertido, USDT), com Total destacado. Fonte: btc.exchange_balance_snapshots (~15 min).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2101,7 +2101,7 @@
           },
           "editorMode": "code",
           "format": "time_series",
-          "rawSql": "SELECT\n  synced_at AS time,\n  SUM(balance * COALESCE(price_usdt, CASE WHEN currency = 'USDT' THEN 1 ELSE 0 END))\n    FILTER (WHERE account_type = 'main') AS \"Conta Main\",\n  SUM(balance * COALESCE(price_usdt, CASE WHEN currency = 'USDT' THEN 1 ELSE 0 END))\n    FILTER (WHERE account_type = 'trade') AS \"Conta Trade\",\n  SUM(balance * price_usdt) FILTER (WHERE currency = 'BTC') AS \"BTC (em USDT)\",\n  SUM(balance) FILTER (WHERE currency = 'USDT') AS \"USDT\",\n  SUM(balance * COALESCE(price_usdt, CASE WHEN currency = 'USDT' THEN 1 ELSE 0 END)) AS \"Total\"\nFROM btc.exchange_balance_snapshots\nWHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1\nORDER BY 1",
+          "rawSql": "WITH snap AS (\n  SELECT synced_at, account_type, currency,\n         balance * COALESCE(price_usdt, CASE WHEN currency = 'USDT' THEN 1 ELSE 0 END) AS usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT synced_at AS time, 'Conta ' || account_type AS metric, SUM(usdt) AS value FROM snap GROUP BY 1, 2\nUNION ALL\nSELECT synced_at, 'Total', SUM(usdt) FROM snap GROUP BY 1\nUNION ALL\nSELECT synced_at, 'BTC (em USDT)', SUM(usdt) FROM snap WHERE currency = 'BTC' GROUP BY 1\nUNION ALL\nSELECT synced_at, 'USDT', SUM(usdt) FROM snap WHERE currency = 'USDT' GROUP BY 1\nORDER BY 1",
           "refId": "A",
           "sql": {
             "columns": [],

--- a/scripts/kucoin_postgres_sync.py
+++ b/scripts/kucoin_postgres_sync.py
@@ -169,6 +169,34 @@ def _snapshot_balances(conn) -> int:
                     ),
                 )
                 counts += 1
+
+        # Subcontas KuCoin (account_type = "sub:<nome>"); best-effort — a
+        # chave master pode não ter permissão ou não existirem subcontas.
+        try:
+            sub_balances = kucoin_api.get_sub_account_balances()
+        except Exception as exc:
+            logging.getLogger(__name__).warning("Sub-account snapshot skipped: %s", exc)
+            sub_balances = []
+        for balance in sub_balances:
+            if balance.get("balance", 0) <= 0 and balance.get("available", 0) <= 0:
+                continue
+            cur.execute(
+                f"""
+                INSERT INTO {SCHEMA}.exchange_balance_snapshots
+                    (account_type, currency, balance, available, holds, price_usdt, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    f"sub:{balance['sub_name']}",
+                    balance["currency"],
+                    _safe_float(balance["balance"]),
+                    _safe_float(balance["available"]),
+                    _safe_float(balance["holds"]),
+                    price_in_usdt(balance["currency"]),
+                    json.dumps({"source": "kucoin_sync", "sub_account_type": balance["account_type"]}),
+                ),
+            )
+            counts += 1
         cur.execute(
             f"""
             INSERT INTO {SCHEMA}.exchange_sync_state (sync_key, synced_at, metadata, updated_at)

--- a/systemd/crypto-agent@.service.d/common.conf
+++ b/systemd/crypto-agent@.service.d/common.conf
@@ -1,7 +1,8 @@
 [Service]
 # Centralizado: edite /etc/crypto-agent/models.env para trocar modelos
 EnvironmentFile=/etc/crypto-agent/models.env
-Environment=DATABASE_URL=postgresql://postgres:PASSWORD@localhost:5433/btc_trading
+# DATABASE_URL removido (2026-07-03): resolvido via Secrets Agent/Authentik
+# (shared/database_url, field=url) pelo secrets_helper.get_database_url()
 Environment=SECRETS_AGENT_API_KEY=<from_bitwarden>
 Environment=TELEGRAM_BOT_TOKEN=<from_bitwarden>
 Environment=ADMIN_CHAT_ID=<your_telegram_chat_id>


### PR DESCRIPTION
Executa as 4 decisões do usuário + plano ETH:

1. **Política de saída**: nunca realizar prejuízo — formalizado que `auto_stop_loss` fica desabilitado por design; o piso é `guardrails_min_sell_pnl_pct 0.3%` (> taxas 0.2%), já vigente.
2. **Credencial do DB via Authentik**: `shared/database_url` no Secrets Agent (sync Authentik OK); linha inline removida do drop-in `crypto-agent@`; resolução testada ponta-a-ponta como usuário `btc-trading`. Vale no próximo restart. (`TELEGRAM_BOT_TOKEN` inline é o próximo candidato.)
3. **Subcontas KuCoin**: `get_sub_account_balances()` + snapshots `sub:<nome>`; **sub:BTCAgressive** detectada em produção; painel Evolução Patrimonial reescrito em formato longo (linha por conta, dinâmico); relatório diário inclui automaticamente.
4. **Modularização aprovada**: plano faseado (ai_planner → ai_controls → market_context) em `docs/TRADING_ETH_ACTIVATION_PLAN.md`.
5. **Plano ETH-USDT**: fases A (shadow/dry) → B (validação 1-2 semanas) → C (live conservador com aprovação) → D (aggressive), com riscos e estimativas.

Testes: 80 verdes (kucoin_postgres_sync, kucoin_api). Sync rodado em produção com sucesso (balance_rows=6, incluindo subconta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)