### PR TITLE
feat(trading): transferências para subcontas + plano de migração de perfis

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -847,6 +847,54 @@ def inner_transfer(currency: str, amount: float,
     return {"success": True, "orderId": order_id}
 
 
+def sub_transfer(currency: str, amount: float, sub_user_id: str,
+                 direction: str = "OUT",
+                 account_type: str = "TRADE",
+                 sub_account_type: str = "TRADE") -> Dict[str, Any]:
+    """Transferência master ↔ subconta KuCoin.
+
+    Args:
+        currency: Moeda a transferir (ex: 'USDT').
+        amount: Quantidade.
+        sub_user_id: UID da subconta (ex: '257506830').
+        direction: 'OUT' (master→sub) ou 'IN' (sub→master).
+        account_type: Conta do master ('MAIN' ou 'TRADE').
+        sub_account_type: Conta da subconta ('MAIN' ou 'TRADE').
+
+    Returns:
+        Dict com 'success' e 'orderId' ou 'error'.
+    """
+    import uuid
+    validate_credentials()
+
+    endpoint = "/api/v2/accounts/sub-transfer"
+    payload = {
+        "clientOid": str(uuid.uuid4()),
+        "currency": currency,
+        "amount": str(round(amount, 8)),
+        "direction": direction,
+        "accountType": account_type,
+        "subAccountType": sub_account_type,
+        "subUserId": str(sub_user_id),
+    }
+    body_str = json.dumps(payload, separators=(",", ":"))
+
+    logger.info(
+        f"💸 Sub transfer: {amount:.8f} {currency} "
+        f"master({account_type}) {direction} sub {sub_user_id}({sub_account_type})"
+    )
+
+    r = _signed_request("POST", endpoint, body_str=body_str, timeout=10)
+    result = r.json()
+    if result.get("code") != "200000":
+        logger.error(f"❌ Sub transfer failed: {result}")
+        return {"success": False, "error": result.get("msg", "Unknown")}
+
+    order_id = (result.get("data") or {}).get("orderId", "")
+    logger.info(f"✅ Sub transfer OK: {order_id}")
+    return {"success": True, "orderId": order_id}
+
+
 @retry_on_failure(max_retries=3)
 def place_market_order(symbol: str, side: str, funds: float = None,
                        size: float = None) -> Dict[str, Any]:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T21:59:15.383750+00:00",
+  "generated_at": "2026-07-03T23:56:46.530687+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T21:59:15.383750+00:00`
+- Generated at: `2026-07-03T23:56:46.530687+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/docs/TRADING_SUBACCOUNTS_MIGRATION.md
+++ b/docs/TRADING_SUBACCOUNTS_MIGRATION.md
@@ -1,0 +1,62 @@
+# Migração dos perfis para subcontas KuCoin
+
+Iniciada em 2026-07-03. Objetivo: cada perfil de trading opera na própria
+subconta, com capital isolado.
+
+## Subcontas (criadas pelo usuário) e mapeamento
+
+| Subconta | UID (UI) | userId (API, para sub_transfer) | Perfil destino | Saldo inicial |
+|---|---|---|---|---|
+| BTCAgressive | 257506830 | 6a2fe102dc143e00017b48fe | `BTC_USDT_aggressive` | 100 USDT |
+| BTCConservative | 257507456 | 6a2fe6f634e4a40001c3a385 | `BTC_USDT_conservative` | 50 USDT |
+| ETHAgressive | 258149392 | 6a4849435769ca0001652fdf | `ETH_USDT_aggressive` (futuro) | 50 USDT |
+| ETHConservative | 258149464 | 6a484a6d5769ca000165306d | `ETH_USDT_conservative` (futuro) | 50 USDT |
+
+Transferências de 50 USDT executadas em 2026-07-03 via
+`kucoin_api.sub_transfer()` (master TRADE → sub TRADE), order IDs no journal.
+**Atenção:** o UID da interface não funciona no `sub-transfer` — usar o
+`userId` interno de `GET /api/v2/sub/user`.
+
+## Estado transitório (vigente)
+
+- Master trade ficou com ~0,36 USDT + ~0,01 BTC: os agentes BTC (que ainda
+  operam no master) **não conseguem abrir novas posições** (starvation), mas
+  vendem as posições abertas normalmente (política positive-only).
+- **Shadow não tem subconta** — decidir: criar `BTCShadow`, devolver USDT ao
+  master, ou pausar o A/B test.
+
+## Como o agente seleciona credenciais (já suportado)
+
+`secrets_helper._iter_kucoin_secret_names()` respeita o env
+`KUCOIN_SECRET_NAMES` (lista de secrets, checada antes do default
+`kucoin/homelab`). Ou seja, por perfil basta o envfile apontar para o secret
+da subconta.
+
+## Passos restantes (bloqueado por ação do usuário)
+
+1. **Usuário**: criar API key em cada subconta (KuCoin → API Management →
+   subconta → permissões *General* + *Spot Trading*; mesma whitelist de IP do
+   master) e fornecer key/secret/passphrase.
+2. Gravar no Secrets Agent (sincroniza com Authentik), um por subconta:
+   `kucoin/sub-btcagressive`, `kucoin/sub-btcconservative`,
+   `kucoin/sub-ethagressive`, `kucoin/sub-ethconservative` — campos
+   `api_key`, `api_secret`, `passphrase`.
+3. Por perfil, no envfile (`/apps/crypto-trader/envfiles/<perfil>.env`):
+   `KUCOIN_SECRET_NAMES=kucoin/sub-<subconta>`.
+4. **Migrar posição aberta antes de trocar a chave**: vender a posição no
+   master (ao atingir lucro mínimo) ou `sub_transfer` do BTC para a subconta;
+   caso contrário o agente perde acesso à posição (BTC fica no master e a
+   nova chave só enxerga a subconta).
+5. Reiniciar o perfil migrado (um de cada vez), rodar
+   `kucoin-postgres-sync` e conferir reconciliação (`position_diff`) e
+   `_detect_external_deposits` (o saldo da subconta não deve ser tratado como
+   depósito externo — validar no primeiro boot).
+6. Repetir por perfil. ETH segue o plano de ativação
+   (`TRADING_ETH_ACTIVATION_PLAN.md`) já nascendo na subconta.
+
+## Observabilidade
+
+- Snapshots por subconta ativos desde 2026-07-03 (`account_type="sub:<nome>"`
+  em `btc.exchange_balance_snapshots`, a cada 15 min).
+- Dashboard "Evolução Patrimonial por Conta" mostra uma linha por subconta
+  automaticamente; relatório diário das 10h idem.


### PR DESCRIPTION
Pedido: separar trading em subcontas KuCoin e transferir 50 USDT para cada.

- `sub_transfer()` implementado; **4/4 transferências executadas** (order IDs no journal). Armadilha documentada: o `sub-transfer` exige o `userId` interno de `/api/v2/sub/user`, não o UID da interface.
- Snapshots já mostram: sub:BTCAgressive $100, sub:BTCConservative/ETHAgressive/ETHConservative $50 cada; master trade ~$0,36.
- `docs/TRADING_SUBACCOUNTS_MIGRATION.md`: mapeamento subconta→perfil, seleção de credenciais via `KUCOIN_SECRET_NAMES` (já suportado pelo secrets_helper), migração de posições abertas antes da troca de chave, e estado transitório (agentes BTC sem capital para novas compras no master até a migração).
- Bloqueado por ação do usuário: criar as 4 API keys de subconta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)