### PR TITLE
fix(secrets): atualização de secret nunca sincronizava com Authentik

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T23:56:46.530687+00:00",
+  "generated_at": "2026-07-04T02:18:28.933926+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-03T23:56:46.530687+00:00`
+- Generated at: `2026-07-04T02:18:28.933926+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/tools/secrets_agent/secrets_agent.py
+++ b/tools/secrets_agent/secrets_agent.py
@@ -175,10 +175,12 @@ class AuthentikSecretManager:
         """Busca secret no Authentik por client_id exato."""
         client_id = self._client_id(name, field)
         try:
+            # search do Authentik indexa o campo name (icontains), não o
+            # client_id — buscar pelo nome e filtrar por client_id exato.
             r = self._http.get(
                 f"{self._base}/api/v3/providers/oauth2/",
                 headers=self._headers,
-                params={"search": client_id, "page_size": 20},
+                params={"search": name, "page_size": 20},
                 timeout=10,
             )
             if r.status_code != 200:
@@ -197,7 +199,7 @@ class AuthentikSecretManager:
             r = self._http.get(
                 f"{self._base}/api/v3/providers/oauth2/",
                 headers=self._headers,
-                params={"search": prefix, "page_size": 50},
+                params={"search": name, "page_size": 50},
                 timeout=10,
             )
             if r.status_code != 200:
@@ -228,7 +230,7 @@ class AuthentikSecretManager:
             r = self._http.get(
                 f"{self._base}/api/v3/providers/oauth2/",
                 headers=self._headers,
-                params={"search": client_id, "page_size": 10},
+                params={"search": payload.name, "page_size": 50},
                 timeout=10,
             )
             existing_pk = None
@@ -296,7 +298,7 @@ class AuthentikSecretManager:
             r = self._http.get(
                 f"{self._base}/api/v3/providers/oauth2/",
                 headers=self._headers,
-                params={"search": client_id, "page_size": 10},
+                params={"search": name, "page_size": 50},
                 timeout=10,
             )
             if r.status_code != 200:


### PR DESCRIPTION
Bug latente: o search da API de providers do Authentik só indexa `name`, mas o secrets agent buscava por `client_id` → 0 resultados → todo UPDATE caía no caminho de CREATE e falhava com 400 'provider already exists' (silencioso: LocalVault OK, Authentik desatualizado). Corrigido em `get_secret`, `get_secret_fields`, `upsert_secret` e `delete_secret` (busca por nome + filtro exato por client_id). 25 testes verdes; deployado e validado em produção (PATCH atualizou o provider e o valor confere no Authentik).

🤖 Generated with [Claude Code](https://claude.com/claude-code)