### PR TITLE
docs(trading): status da migração de subcontas concluída

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T02:18:28.933926+00:00",
+  "generated_at": "2026-07-04T02:31:57.253733+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T02:18:28.933926+00:00`
+- Generated at: `2026-07-04T02:31:57.253733+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/docs/TRADING_SUBACCOUNTS_MIGRATION.md
+++ b/docs/TRADING_SUBACCOUNTS_MIGRATION.md
@@ -32,7 +32,17 @@ Transferências de 50 USDT executadas em 2026-07-03 via
 `kucoin/homelab`). Ou seja, por perfil basta o envfile apontar para o secret
 da subconta.
 
-## Passos restantes (bloqueado por ação do usuário)
+## Status (2026-07-03 ~23h30)
+
+- ✅ **aggressive** migrado para `sub:BTCAgressive` ($100; sem posição aberta no momento da troca — migração limpa).
+- ✅ **conservative** migrado para `sub:BTCConservative` ($50 + 0.00015964 BTC transferido antes da troca; posição restaurada 1:1, sem falso depósito externo).
+- ✅ Exporters reiniciados — métricas `exchange_usdt_balance` refletem as subcontas.
+- ⏳ **shadow** permanece no master (sem subconta; ficou com ~$10 USDT + BTC das posições dele).
+- ⏳ **ETH** aguarda Fase A do plano de ativação (subcontas já fundeadas e credenciais validadas).
+- Credenciais: 4×(api_key, api_secret, passphrase) no Secrets Agent com sync Authentik confirmado; passphrases recuperadas do Bitwarden do usuário (ver memória `feedback-bw-gmail-otp-flow`).
+- ⚠️ Os envfiles ainda contêm as credenciais do master inline (fallback); com `KUCOIN_SECRET_NAMES` ativo elas não são usadas — remover em limpeza futura.
+
+## Passos originais (histórico — executados acima)
 
 1. **Usuário**: criar API key em cada subconta (KuCoin → API Management →
    subconta → permissões *General* + *Spot Trading*; mesma whitelist de IP do


### PR DESCRIPTION
Migração dos perfis BTC para subcontas concluída (aggressive → sub:BTCAgressive $100; conservative → sub:BTCConservative $50 + posição de 0.00015964 BTC transferida e restaurada 1:1). Exporters atualizados. Shadow permanece no master; ETH aguarda Fase A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)