### PR TITLE
feat(trading): ETH-USDT Fase A — shadow/dry ativo

### DIFF
--- a/btc_trading_agent/config_ETH_USDT_shadow.json
+++ b/btc_trading_agent/config_ETH_USDT_shadow.json
@@ -1,0 +1,82 @@
+{
+  "enabled": true,
+  "dry_run": true,
+  "symbol": "ETH-USDT",
+  "profile": "shadow",
+  "poll_interval": 5,
+  "min_trade_interval": 600,
+  "min_confidence": 0.55,
+  "min_trade_amount": 10,
+  "max_position_pct": 1.0,
+  "max_positions": 4,
+  "stop_loss_pct": 0.02,
+  "take_profit_pct": 0.03,
+  "max_daily_trades": 8,
+  "max_daily_loss": 5,
+  "min_sell_pnl": 0.001,
+  "max_hold_minutes": 0,
+  "trading_hours": {
+    "enabled": false,
+    "start": "00:00",
+    "end": "23:59"
+  },
+  "notifications": {
+    "enabled": false,
+    "on_trade": false,
+    "on_signal": false,
+    "on_error": false
+  },
+  "risk_management": {
+    "enabled": true,
+    "max_drawdown_pct": 0.08,
+    "position_sizing": "fixed",
+    "kelly_fraction": 0.25,
+    "volatility_filter": true,
+    "min_volatility": 0.001,
+    "max_volatility": 0.12
+  },
+  "trailing_stop": {
+    "enabled": true,
+    "activation_pct": 0.01,
+    "trail_pct": 0.005
+  },
+  "strategy": {
+    "mode": "swing",
+    "use_trend_filter": false,
+    "use_volume_filter": true,
+    "rsi_oversold": 35,
+    "rsi_overbought": 65,
+    "min_spread_bps": 3
+  },
+  "live_mode": false,
+  "auto_stop_loss": {
+    "enabled": false,
+    "pct": 0.05
+  },
+  "auto_take_profit": {
+    "enabled": true,
+    "pct": 0.03,
+    "min_pct": 0.025
+  },
+  "min_net_profit": {
+    "usd": 0.1,
+    "pct": 0.001
+  },
+  "circuit_breaker": {
+    "enabled": true,
+    "min_win_rate_24h": 0.35,
+    "max_daily_loss_usd": 5
+  },
+  "kucoin_subaccount_name": "BTCAgressive",
+  "kucoin_require_dedicated_credentials": false,
+  "guardrails_active": true,
+  "guardrails_min_sell_pnl_pct": 0.01,
+  "guardrails_positive_only_sells": true,
+  "use_macd": true,
+  "use_ma_cross": true,
+  "_fase_a_notes": {
+    "origem": "clonado de config_BTC_USDT_shadow.json em 2026-07-03",
+    "modo": "Fase A do plano ETH — shadow/dry, sem dinheiro real",
+    "proximo": "Fase B: validar WR>=60% e PnL simulado liquido positivo por 1-2 semanas"
+  }
+}

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T02:31:57.253733+00:00",
+  "generated_at": "2026-07-04T02:40:42.467820+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T02:31:57.253733+00:00`
+- Generated at: `2026-07-04T02:40:42.467820+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -103,6 +103,16 @@ scrape_configs:
           profile: 'shadow'
           servidor: 'homelab'
 
+  - job_name: 'crypto-exporter-eth_usdt_shadow'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['172.17.0.1:9096']
+        labels:
+          coin: 'ETH-USDT'
+          instance: 'eth_usdt_shadow'
+          profile: 'shadow'
+          servidor: 'homelab'
+
   # ---------------------------------------------------------------------------
   # ollama-metrics — proxy Prometheus para os 3 endpoints Ollama do cluster GPU
   # Métricas: tokens, latência, modelos carregados, uso de VRAM por GPU


### PR DESCRIPTION
Fase A do plano de ativação ETH (autorizada): agente `crypto-agent@ETH_USDT_shadow` rodando em **DRY RUN** (config força `dry_run=true` mesmo com `--live` do template), exporter na porta 9096, scrape job no Prometheus e dashboard com `coin=ETH-USDT` populando. Sem dinheiro real — Fase B valida 1-2 semanas antes de qualquer live.

Verificado: agente ciclando e gerando sinais (ETH $1.747), Prometheus coletando `btc_trading_agent_running{coin=\"ETH-USDT\"}=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)