### PR TITLE
fix(trading): exporter multi-símbolo — saldo da moeda-base, não BTC fixo

### DIFF
--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -174,8 +174,9 @@ class MetricsCollector:
         """
         try:
             from kucoin_api import get_balance
+            base_currency = (self.symbol or "BTC-USDT").split("-")[0].upper()
             usdt = get_balance("USDT")
-            btc = get_balance("BTC")
+            btc = get_balance(base_currency)
             return {"usdt": usdt, "btc": btc, "success": True}
         except Exception as e:
             print(f"⚠️ Falha ao buscar saldos da exchange: {e}")

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T10:54:59.887622+00:00",
+  "generated_at": "2026-07-04T11:01:33.016373+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T10:54:59.887622+00:00`
+- Generated at: `2026-07-04T11:01:33.016373+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`


### PR DESCRIPTION
Encontrado ao analisar 'por que o ETH não negocia': o exporter buscava `get_balance(\"BTC\")` hardcoded e, no agente ETH, misturava saldo BTC do master com preço do ETH → `unrealized_pnl` fantasma de ~$9,24 e `equity` errada. Agora usa a moeda-base do símbolo. 6 testes verdes; deployado e verificado (métricas ETH coerentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)