### PR TITLE
feat(trading): ETH-USDT live no perfil conservative (subconta)

### DIFF
--- a/btc_trading_agent/config_ETH_USDT_conservative.json
+++ b/btc_trading_agent/config_ETH_USDT_conservative.json
@@ -1,0 +1,88 @@
+{
+  "enabled": true,
+  "dry_run": false,
+  "symbol": "ETH-USDT",
+  "poll_interval": 5,
+  "min_trade_interval": 900,
+  "min_confidence": 0.6,
+  "min_trade_amount": 10,
+  "max_position_pct": 0.6,
+  "dca_valley_bounce_pct": 0.004,
+  "stop_loss_pct": 0.03,
+  "take_profit_pct": 0.02,
+  "max_daily_trades": 20,
+  "max_daily_loss": 5,
+  "min_sell_pnl": 0.001,
+  "max_hold_minutes": 0,
+  "trading_hours": {
+    "enabled": false,
+    "start": "00:00",
+    "end": "23:59"
+  },
+  "notifications": {
+    "enabled": true,
+    "telegram_chat_id": "",
+    "whatsapp_chat_id": "5511981193899@c.us",
+    "on_trade": true,
+    "on_signal": false,
+    "on_error": true
+  },
+  "risk_management": {
+    "enabled": true,
+    "max_drawdown_pct": 0.05,
+    "position_sizing": "fixed",
+    "kelly_fraction": 0.25,
+    "volatility_filter": true,
+    "min_volatility": 0.001,
+    "max_volatility": 0.12
+  },
+  "trailing_stop": {
+    "enabled": true,
+    "activation_pct": 0.01,
+    "trail_pct": 0.005
+  },
+  "strategy": {
+    "mode": "swing",
+    "use_trend_filter": false,
+    "use_volume_filter": true,
+    "rsi_oversold": 30,
+    "rsi_overbought": 70,
+    "min_spread_bps": 5
+  },
+  "live_mode": true,
+  "auto_stop_loss": {
+    "enabled": false,
+    "pct": 0.03
+  },
+  "auto_take_profit": {
+    "enabled": true,
+    "pct": 0.02,
+    "min_pct": 0.013
+  },
+  "min_net_profit": {
+    "usd": 0.1,
+    "pct": 0.001
+  },
+  "circuit_breaker": {
+    "enabled": true,
+    "min_win_rate_24h": 0.3,
+    "max_daily_loss_usd": 10
+  },
+  "profile": "conservative",
+  "_optimizer_notes": {
+    "source": "Phase 1 mini-optimizer 1min candles (54k candles, 41 days)",
+    "based_on": "P1 #2: +$4.28 (R$21.96), 51T, 75% WR, SL=3%, TP=2%, EMA13/50",
+    "hodl_benchmark": "+$22.30 (41d)",
+    "date": "2025-04-09"
+  },
+  "guardrails_min_sell_pnl_pct": 0.003,
+  "guardrails_active": true,
+  "guardrails_positive_only_sells": true,
+  "rebuy_lock_enabled": false,
+  "_eth_live_notes": {
+    "origem": "clonado de config_BTC_USDT_conservative.json em 2026-07-04",
+    "conta": "subconta sub:ETHConservative ($50) via KUCOIN_SECRET_NAMES",
+    "autorizacao": "usuario pediu saída do dry run em 2026-07-04",
+    "politica_saida": "guardrails positive-only (nunca vender no prejuízo)"
+  }
+}

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T11:01:33.016373+00:00",
+  "generated_at": "2026-07-04T11:07:06.261071+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T11:01:33.016373+00:00`
+- Generated at: `2026-07-04T11:07:06.261071+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -113,6 +113,16 @@ scrape_configs:
           profile: 'shadow'
           servidor: 'homelab'
 
+  - job_name: 'crypto-exporter-eth_usdt_conservative'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['172.17.0.1:9097']
+        labels:
+          coin: 'ETH-USDT'
+          instance: 'eth_usdt_conservative'
+          profile: 'conservative'
+          servidor: 'homelab'
+
   # ---------------------------------------------------------------------------
   # ollama-metrics — proxy Prometheus para os 3 endpoints Ollama do cluster GPU
   # Métricas: tokens, latência, modelos carregados, uso de VRAM por GPU


### PR DESCRIPTION
Usuário autorizou a saída do dry run. `crypto-agent@ETH_USDT_conservative` LIVE na subconta `sub:ETHConservative` ($50), guardrails positive-only herdados do BTC conservative, `max_volatility` 0.12. Primeira ordem real executada e notificada no grupo: BUY $10 @ $1.757,55 (`6a48e90c...`). Shadow ETH permanece dry em paralelo. Regressão: 15 testes verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)