### PR TITLE
feat(trading): frota completa em modo real (6 perfis BTC+ETH)

### DIFF
--- a/btc_trading_agent/config_ETH_USDT_aggressive.json
+++ b/btc_trading_agent/config_ETH_USDT_aggressive.json
@@ -2,17 +2,16 @@
   "enabled": true,
   "dry_run": false,
   "symbol": "ETH-USDT",
-  "profile": "shadow",
   "poll_interval": 5,
   "min_trade_interval": 600,
   "min_confidence": 0.55,
   "min_trade_amount": 10,
   "max_position_pct": 1.0,
-  "max_positions": 4,
-  "stop_loss_pct": 0.02,
-  "take_profit_pct": 0.03,
-  "max_daily_trades": 8,
-  "max_daily_loss": 5,
+  "dca_valley_bounce_pct": 0.003,
+  "stop_loss_pct": 0.05,
+  "take_profit_pct": 0.015,
+  "max_daily_trades": 20,
+  "max_daily_loss": 10,
   "min_sell_pnl": 0.001,
   "max_hold_minutes": 0,
   "trading_hours": {
@@ -21,10 +20,12 @@
     "end": "23:59"
   },
   "notifications": {
-    "enabled": false,
-    "on_trade": false,
+    "enabled": true,
+    "telegram_chat_id": "",
+    "whatsapp_chat_id": "5511981193899@c.us",
+    "on_trade": true,
     "on_signal": false,
-    "on_error": false
+    "on_error": true
   },
   "risk_management": {
     "enabled": true,
@@ -44,8 +45,8 @@
     "mode": "swing",
     "use_trend_filter": false,
     "use_volume_filter": true,
-    "rsi_oversold": 35,
-    "rsi_overbought": 65,
+    "rsi_oversold": 25,
+    "rsi_overbought": 40,
     "min_spread_bps": 3
   },
   "live_mode": true,
@@ -55,8 +56,8 @@
   },
   "auto_take_profit": {
     "enabled": true,
-    "pct": 0.03,
-    "min_pct": 0.025
+    "pct": 0.015,
+    "min_pct": 0.013
   },
   "min_net_profit": {
     "usd": 0.1,
@@ -64,19 +65,17 @@
   },
   "circuit_breaker": {
     "enabled": true,
-    "min_win_rate_24h": 0.35,
-    "max_daily_loss_usd": 5
+    "min_win_rate_24h": 0.25,
+    "max_daily_loss_usd": 15
   },
-  "kucoin_subaccount_name": "BTCAgressive",
-  "kucoin_require_dedicated_credentials": false,
+  "profile": "aggressive",
   "guardrails_active": true,
-  "guardrails_min_sell_pnl_pct": 0.01,
+  "guardrails_min_sell_pnl_pct": 0.003,
   "guardrails_positive_only_sells": true,
-  "use_macd": true,
-  "use_ma_cross": true,
-  "_fase_a_notes": {
-    "origem": "clonado de config_BTC_USDT_shadow.json em 2026-07-03",
-    "modo": "LIVE desde 2026-07-04 por ordem do usuario (todos os perfis em modo real)",
-    "proximo": "Fase B: validar WR>=60% e PnL simulado liquido positivo por 1-2 semanas"
+  "rebuy_lock_enabled": false,
+  "_eth_live_notes": {
+    "origem": "clonado de config_BTC_USDT_aggressive.json em 2026-07-04",
+    "conta": "subconta sub:ETHAgressive via KUCOIN_SECRET_NAMES",
+    "autorizacao": "usuario: subir todos os perfis em MODO REAL (2026-07-04)"
   }
 }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T11:07:06.261071+00:00",
+  "generated_at": "2026-07-04T11:11:33.762538+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T11:07:06.261071+00:00`
+- Generated at: `2026-07-04T11:11:33.762538+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -123,6 +123,16 @@ scrape_configs:
           profile: 'conservative'
           servidor: 'homelab'
 
+  - job_name: 'crypto-exporter-eth_usdt_aggressive'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['172.17.0.1:9098']
+        labels:
+          coin: 'ETH-USDT'
+          instance: 'eth_usdt_aggressive'
+          profile: 'aggressive'
+          servidor: 'homelab'
+
   # ---------------------------------------------------------------------------
   # ollama-metrics — proxy Prometheus para os 3 endpoints Ollama do cluster GPU
   # Métricas: tokens, latência, modelos carregados, uso de VRAM por GPU


### PR DESCRIPTION
Ordem do usuário: todos os perfis em MODO REAL.

- **ETH_USDT_aggressive** (novo): live na subconta `sub:ETHAgressive` ($50), exporter 9098 + scrape job
- **ETH_USDT_shadow**: flip dry→live (mesmo padrão A/B do shadow BTC, conta master)
- Estado final: **6/6 perfis live** — BTC e ETH × conservative/aggressive/shadow, todos com guardrails positive-only (nunca vender no prejuízo)
- Verificado: `live_mode=1` nas 6 portas de métricas, 0 erros nos primeiros minutos, credenciais por subconta corretas
- Conformidade: autorização explícita do usuário, regressão verde (15 testes config + suítes), dry_run=False confirmado nos logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)