### PR TITLE
fix(trading): SELL de ETH rejeitado por incremento + notificações silenciosas

### DIFF
--- a/.github/workflows/deploy-btc-trading-profiles.yml
+++ b/.github/workflows/deploy-btc-trading-profiles.yml
@@ -28,7 +28,7 @@ on:
       - 'grafana/exporters/rss_sentiment_exporter.py'
       - 'grafana/exporters/requirements.txt'
       - 'grafana/btc_trading_dashboard_v3_prometheus.json'
-      - 'grafana/dashboards/btc_trading_monitor.json'
+      - 'grafana/dashboards/btc-trading-monitor.json'
       - 'systemd/rss-sentiment-exporter.service'
       - 'systemd/ollama-gpu-coordinator.service'
       - 'tools/ollama_gpu_coordinator.py'

--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -151,11 +151,26 @@ def _send_telegram_alert(message: str) -> None:
         payload = {"chat_id": chat_id, "text": message, "parse_mode": "Markdown"}
         if thread_id:
             payload["message_thread_id"] = int(thread_id)
-        requests.post(
+        r = requests.post(
             f"https://api.telegram.org/bot{bot_token}/sendMessage",
             json=payload,
-            timeout=5,
+            timeout=10,
         )
+        if r.status_code != 200:
+            # Markdown inválido ou thread inexistente → retry texto puro
+            logger.warning(
+                "⚠️ Telegram alert HTTP %s: %s — retry sem parse_mode",
+                r.status_code, r.text[:120],
+            )
+            payload.pop("parse_mode", None)
+            payload.pop("message_thread_id", None)
+            r = requests.post(
+                f"https://api.telegram.org/bot{bot_token}/sendMessage",
+                json=payload,
+                timeout=10,
+            )
+            if r.status_code != 200:
+                logger.error("❌ Telegram alert falhou de vez: %s", r.text[:150])
         for _extra in _get_extra_telegram_chat_ids():
             try:
                 requests.post(
@@ -895,6 +910,43 @@ def sub_transfer(currency: str, amount: float, sub_user_id: str,
     return {"success": True, "orderId": order_id}
 
 
+_symbol_increment_cache: Dict[str, Dict[str, str]] = {}
+
+
+def get_symbol_increments(symbol: str) -> Dict[str, str]:
+    """Retorna baseIncrement/quoteIncrement do símbolo (cache por processo).
+
+    Fallback conservador (8 casas) se a API falhar — equivale ao
+    comportamento antigo, válido para BTC-USDT.
+    """
+    if symbol not in _symbol_increment_cache:
+        try:
+            r = requests.get(
+                f"{BASE_URL}/api/v2/symbols/{symbol}", timeout=8,
+            )
+            data = (r.json() or {}).get("data") or {}
+            _symbol_increment_cache[symbol] = {
+                "baseIncrement": data.get("baseIncrement") or "0.00000001",
+                "quoteIncrement": data.get("quoteIncrement") or "0.01",
+            }
+        except Exception as e:
+            logger.warning(f"⚠️ Falha ao obter increments de {symbol}: {e}")
+            return {"baseIncrement": "0.00000001", "quoteIncrement": "0.01"}
+    return _symbol_increment_cache[symbol]
+
+
+def _floor_to_increment(value: float, increment: str) -> str:
+    """Trunca value para múltiplo do increment, como string decimal exata.
+
+    KuCoin rejeita ordens com mais casas que o increment do símbolo
+    ('Order size increment invalid' — ex.: ETH-USDT usa 7 casas, não 8).
+    """
+    from decimal import Decimal, ROUND_DOWN
+    inc = Decimal(increment)
+    quantized = (Decimal(str(value)) / inc).to_integral_value(rounding=ROUND_DOWN) * inc
+    return format(quantized.normalize(), "f")
+
+
 @retry_on_failure(max_retries=3)
 def place_market_order(symbol: str, side: str, funds: float = None,
                        size: float = None) -> Dict[str, Any]:
@@ -911,10 +963,11 @@ def place_market_order(symbol: str, side: str, funds: float = None,
         "type": "market",
     }
 
+    increments = get_symbol_increments(symbol)
     if funds is not None:
         payload["funds"] = str(round(float(funds), 2))
     elif size is not None:
-        payload["size"] = str(round(float(size), 8))
+        payload["size"] = _floor_to_increment(float(size), increments["baseIncrement"])
     else:
         raise ValueError("Must specify 'funds' or 'size'")
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T12:32:54.178799+00:00",
+  "generated_at": "2026-07-04T12:50:22.999895+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T12:32:54.178799+00:00`
+- Generated at: `2026-07-04T12:50:22.999895+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -2459,7 +2459,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
       },
-      "description": "Variação do patrimônio total (equity) por dia calendário — equivalente ao PnL diário que a KuCoin exibe. Inclui posição aberta (não só trades fechados).",
+      "description": "Variação diária do patrimônio total em USDT: soma de todas as contas (main, trade e subcontas) do último snapshot de cada horário. Datas anteriores aos snapshots por conta usam a equity legada do master.",
       "fieldConfig": {
         "defaults": {
           "thresholds": {
@@ -2512,11 +2512,11 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH all_snapshots AS (\n    SELECT\n        synced_at AS ts,\n        SUM(CASE\n            WHEN currency = 'USDT' THEN balance\n            WHEN currency NOT IN ('USDT', 'BRL') THEN balance * COALESCE(price_usdt, 0)\n            ELSE 0\n        END) AS equity_usdt\n    FROM btc.exchange_balance_snapshots\n    WHERE account_type = 'trade'\n      AND $__timeFilter(synced_at)\n    GROUP BY synced_at\n\n    UNION ALL\n\n    SELECT\n        to_timestamp(timestamp) AS ts,\n        equity_usdt\n    FROM btc.exchange_snapshots\n    WHERE timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\n),\ndaily AS (\n    SELECT\n        ts::date::text AS day,\n        equity_usdt,\n        FIRST_VALUE(equity_usdt) OVER w AS day_open,\n        LAST_VALUE(equity_usdt)  OVER w AS day_close\n    FROM all_snapshots\n    WINDOW w AS (\n        PARTITION BY ts::date\n        ORDER BY ts\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    )\n)\nSELECT DISTINCT\n    day,\n    ROUND(((day_close - day_open) / NULLIF(day_open, 0) * 100)::numeric, 3) AS pnl_pct,\n    ROUND((day_close - day_open)::numeric, 2)                               AS pnl_usdt\nFROM daily\nORDER BY day ASC",
+          "rawSql": "WITH balance_equity AS (\n    SELECT\n        synced_at AS ts,\n        SUM(balance * COALESCE(price_usdt, CASE WHEN currency = 'USDT' THEN 1 ELSE 0 END)) AS equity_usdt\n    FROM btc.exchange_balance_snapshots\n    WHERE $__timeFilter(synced_at)\n    GROUP BY synced_at\n),\nlegacy AS (\n    -- equity antiga (exporter master) apenas para datas anteriores aos\n    -- snapshots por conta; depois da migração para subcontas ela é parcial\n    SELECT to_timestamp(timestamp) AS ts, equity_usdt\n    FROM btc.exchange_snapshots\n    WHERE timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\n      AND to_timestamp(timestamp) < (SELECT COALESCE(MIN(synced_at), 'infinity'::timestamptz)\n                                     FROM btc.exchange_balance_snapshots)\n),\nall_snapshots AS (\n    SELECT * FROM balance_equity\n    UNION ALL\n    SELECT * FROM legacy\n),\ndaily AS (\n    SELECT\n        ts::date::text AS day,\n        equity_usdt,\n        FIRST_VALUE(equity_usdt) OVER w AS day_open,\n        LAST_VALUE(equity_usdt)  OVER w AS day_close\n    FROM all_snapshots\n    WINDOW w AS (\n        PARTITION BY ts::date\n        ORDER BY ts\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    )\n)\nSELECT DISTINCT\n    day,\n    ROUND(((day_close - day_open) / NULLIF(day_open, 0) * 100)::numeric, 3) AS pnl_pct,\n    ROUND((day_close - day_open)::numeric, 2)                               AS pnl_usdt\nFROM daily\nORDER BY day ASC",
           "refId": "A"
         }
       ],
-      "title": "📅 Calendário de PnL Diário",
+      "title": "📅 Calendário de PnL Diário — equity global (todas as contas)",
       "type": "marcusolsson-dynamictext-panel"
     },
     {

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -22,7 +22,7 @@ CONSERVATIVE_SRC="${SOURCE_DIR}/config_BTC_USDT_conservative_optimized.json"
 AGGRESSIVE_SRC="${SOURCE_DIR}/config_BTC_USDT_aggressive_optimized.json"
 CONSERVATIVE_DST="${TARGET_DIR}/config_BTC_USDT_conservative.json"
 AGGRESSIVE_DST="${TARGET_DIR}/config_BTC_USDT_aggressive.json"
-BTC_DASHBOARD_SRC="${REPO_ROOT}/grafana/dashboards/btc_trading_monitor.json"
+BTC_DASHBOARD_SRC="${REPO_ROOT}/grafana/dashboards/btc-trading-monitor.json"
 BTC_DASHBOARD_DST="${GRAFANA_PROVISIONING_DIR}/btc-trading-monitor.json"
 BTC_DASHBOARD_DUPLICATE_PATHS=(
   "${GRAFANA_PROVISIONING_DIR}/btc_trading_monitor.json"

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -14,7 +14,7 @@ def _load_script() -> str:
 
 def test_script_syncs_btc_dashboard_to_canonical_remote_filename() -> None:
     content = _load_script()
-    assert 'BTC_DASHBOARD_SRC="${REPO_ROOT}/grafana/dashboards/btc_trading_monitor.json"' in content
+    assert 'BTC_DASHBOARD_SRC="${REPO_ROOT}/grafana/dashboards/btc-trading-monitor.json"' in content
     assert 'BTC_DASHBOARD_DST="${GRAFANA_PROVISIONING_DIR}/btc-trading-monitor.json"' in content
     assert "sync_btc_grafana_dashboard" in content
 

--- a/tests/test_deploy_btc_trading_profiles_workflow.py
+++ b/tests/test_deploy_btc_trading_profiles_workflow.py
@@ -32,7 +32,7 @@ def test_workflow_watches_slot_exit_runtime_files() -> None:
 def test_workflow_watches_dashboard_copies() -> None:
     content = _load_workflow()
     assert "grafana/btc_trading_dashboard_v3_prometheus.json" in content
-    assert "grafana/dashboards/btc_trading_monitor.json" in content
+    assert "grafana/dashboards/btc-trading-monitor.json" in content
 
 
 def test_workflow_validates_slot_based_tests_before_deploy() -> None:

--- a/tests/test_kucoin_api.py
+++ b/tests/test_kucoin_api.py
@@ -191,6 +191,7 @@ class TestTelegramAlerts:
             patch("kucoin_api._fetch_from_secrets_agent", side_effect=fake_secret),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
@@ -209,6 +210,7 @@ class TestTelegramAlerts:
             patch("kucoin_api._fetch_from_secrets_agent", side_effect=fake_secret),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
@@ -227,6 +229,7 @@ class TestTelegramAlerts:
             patch("kucoin_api._fetch_from_secrets_agent", side_effect=fake_secret),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
@@ -243,6 +246,7 @@ class TestTelegramAlerts:
             ),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
@@ -263,6 +267,7 @@ class TestTelegramAlerts:
             ),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
@@ -282,12 +287,35 @@ class TestTelegramAlerts:
             ),
             patch("kucoin_api.requests.post") as mock_post,
         ):
+            mock_post.return_value.status_code = 200
             kucoin_api._send_telegram_alert("teste")
 
         mock_post.assert_called_once()
         payload = mock_post.call_args.kwargs["json"]
         assert payload["chat_id"] == "-100777"
         assert payload["message_thread_id"] == 42
+
+    def test_send_telegram_alert_retry_sem_markdown_em_http_400(self) -> None:
+        with (
+            patch("kucoin_api._fetch_from_secrets_agent", return_value=None),
+            patch.dict(
+                "kucoin_api.os.environ",
+                {
+                    "TELEGRAM_BOT_TOKEN": "env-token",
+                    "TRADING_TELEGRAM_CHAT_ID": "-100777",
+                },
+                clear=False,
+            ),
+            patch("kucoin_api.requests.post") as mock_post,
+        ):
+            bad = type("R", (), {"status_code": 400, "text": "Bad Request: can't parse entities"})()
+            ok = type("R", (), {"status_code": 200, "text": "ok"})()
+            mock_post.side_effect = [bad, ok]
+            kucoin_api._send_telegram_alert("teste *quebrado")
+
+        assert mock_post.call_count == 2
+        retry_payload = mock_post.call_args.kwargs["json"]
+        assert "parse_mode" not in retry_payload
 
 
 class TestLoadCredentials:

--- a/tools/deploy_grafana.py
+++ b/tools/deploy_grafana.py
@@ -2,7 +2,7 @@
 """Deploy e consulta de dashboards Grafana via API.
 
 Uso:
-  python3 tools/deploy_grafana.py deploy --dashboard grafana/dashboards/btc_trading_monitor.json
+  python3 tools/deploy_grafana.py deploy --dashboard grafana/dashboards/btc-trading-monitor.json
   python3 tools/deploy_grafana.py export --uid btc-trading-monitor
   python3 tools/deploy_grafana.py query --uid btc-trading-monitor --panel 96
   python3 tools/deploy_grafana.py list


### PR DESCRIPTION
Incidente reportado pelo usuário: SELL ETH-USDT falhou com 'Order size increment invalid' e o BUY não notificou no Telegram.

1. **Incremento por símbolo**: size era `round(x, 8)` fixo; ETH-USDT aceita 7 casas (`baseIncrement 0.0000001`). Agora trunca ao increment real do símbolo (Decimal, cache da API). Testado: `0.00568403 → 0.0056840`; BTC inalterado.
2. **Notificações**: `_send_telegram_alert` ignorava a resposta HTTP — falhas 400/429 eram invisíveis. Agora loga e re-tenta sem parse_mode.
3. **Calendário de PnL** com equity global (todas as contas — pós-migração para subcontas o filtro 'trade' do master ignorava o capital real).
4. **Duplicata de uid no provisioning** (root cause dos deploys de dashboard travados): repo renomeado para `btc-trading-monitor.json` = uid, workflow preserva basename sem criar segundo arquivo.

58 testes verdes (kucoin_api, telegram, deploy profiles). ETH agents reiniciados com o fix; alerta de teste entregue no grupo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)