### PR TITLE
fix(trading): SELL ETH ainda rejeitado (BASE_URL) + análise da IA falava Bitcoin para ETH

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -922,7 +922,7 @@ def get_symbol_increments(symbol: str) -> Dict[str, str]:
     if symbol not in _symbol_increment_cache:
         try:
             r = requests.get(
-                f"{BASE_URL}/api/v2/symbols/{symbol}", timeout=8,
+                f"{KUCOIN_BASE}/api/v2/symbols/{symbol}", timeout=8,
             )
             data = (r.json() or {}).get("data") or {}
             _symbol_increment_cache[symbol] = {

--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -2761,10 +2761,10 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                 news_prompt_block = "\n".join(lines) + "\n\n"
 
             prompt = (
-                f"Você é um analista de trading de BTC. Analise o estado atual e gere um "
+                f"Você é um analista de trading de {self._news_coin}. Analise o estado atual e gere um "
                 f"resumo dos PRÓXIMOS PASSOS da estratégia em português do Brasil.\n\n"
                 f"DADOS ATUAIS:\n"
-                f"- Preço BTC: ${market_state.price:,.2f}\n"
+                f"- Preço {self._news_coin}: ${market_state.price:,.2f}\n"
                 f"- RSI: {rsi:.1f} | Momentum: {momentum:.3f} | Volatilidade: {volatility:.4f}\n"
                 f"- Regime: {rag_stats['current_regime']} (confiança {rag_stats['regime_confidence']:.0%})\n"
                 f"- Orderbook: imbalance={market_state.orderbook_imbalance:.2f}, "
@@ -2832,19 +2832,19 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
             # Prompt compacto para modelos instruct pequenos (GPU1)
             # Usa vocabulário explícito de trading para passar no _sanitize_ai_plan
             _pos_str = (
-                f"Posição aberta do profile {profile}: {self.state.position:.6f} BTC, "
+                f"Posição aberta do profile {profile}: {self.state.position:.6f} {self._news_coin}, "
                 f"entry=${self.state.entry_price:,.2f}, "
                 f"PnL={current_net_pnl:+.4f} USDT"
                 if has_open_position else f"Profile {profile}: sem posição aberta"
             )
             prompt_fallback = (
-                f"Analise o mercado de Bitcoin (BTC/USDT) e descreva o que o agente de trading vai fazer.\n\n"
-                f"Dados: preço BTC=${market_state.price:,.2f}, RSI={rsi:.1f}, "
+                f"Analise o mercado de {self._news_coin} ({self.symbol}) e descreva o que o agente de trading vai fazer.\n\n"
+                f"Dados: preço {self._news_coin}=${market_state.price:,.2f}, RSI={rsi:.1f}, "
                 f"regime={rag_stats['current_regime']}, "
                 f"volatilidade={volatility:.4f}, momentum={momentum:.4f}.\n"
                 f"{_pos_str}. Saldo USDT=${usdt_bal:.2f}.\n\n"
                 f"Responda em 2 parágrafos em português:\n"
-                f"1. Análise do mercado BTC: tendência, risco, oportunidade de compra ou venda.\n"
+                f"1. Análise do mercado {self._news_coin}: tendência, risco, oportunidade de compra ou venda.\n"
                 f"2. Próxima ação: comprar, vender ou aguardar, com preço-alvo e stop-loss."
             )
 
@@ -2886,7 +2886,7 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                                         {
                                             "role": "system",
                                             "content": (
-                                                "Você é um analista de trading de Bitcoin. "
+                                                f"Você é um analista de trading de {self._news_coin}. "
                                                 "Responda SEMPRE em português do Brasil (PT-BR). "
                                                 "Seja direto e objetivo, sem markdown headers."
                                             ),
@@ -2929,7 +2929,7 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                                                 "model": model,
                                                 "messages": [
                                                     {"role": "system", "content": (
-                                                        "Você é um analista de trading de Bitcoin. "
+                                                        f"Você é um analista de trading de {self._news_coin}. "
                                                         "Responda SEMPRE em português do Brasil (PT-BR). "
                                                         "Seja direto e objetivo, sem markdown headers."
                                                     )},

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T12:50:22.999895+00:00",
+  "generated_at": "2026-07-04T17:11:39.187766+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T12:50:22.999895+00:00`
+- Generated at: `2026-07-04T17:11:39.187766+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`


### PR DESCRIPTION
Follow-up dos incidentes reportados:

1. **'Order size increment invalid' persistia**: o fix anterior referenciava `BASE_URL` (nome inexistente — o módulo usa `KUCOIN_BASE`), a exceção era engolida e o fallback de 8 casas reproduzia o erro. Agora o fetch funciona (`0.0000001` para ETH) e a ordem-teste da KuCoin aceita o size truncado.
2. **Análise da IA descrevia 'Bitcoin' com números do ETH**: prompts do AI plan (principal, fallback e 2 system prompts) tinham BTC/Bitcoin hardcoded — parametrizados pela moeda do símbolo.
3. **Notificações silenciosas**: frota toda reiniciada com o código que verifica a resposta HTTP do Telegram e re-tenta sem parse_mode (agentes BTC ainda rodavam a versão antiga que engolia 400/429).

Regressão: 66 testes verdes (kucoin_api 54, cenário3+valley 12; falha na execução combinada é a poluição sys.modules documentada). Frota 6/6 ativa pós-restart, 0 erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)