### PR TITLE
feat(trading): comunicado de venda com valor investido e PnL

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -192,8 +192,12 @@ def _format_market_order_notification(
     size: float | None = None,
     order_id: str | None = None,
     error: str | None = None,
+    notify_extra: Dict[str, float] | None = None,
 ) -> str:
-    """Monta mensagem Telegram para execução de ordem de mercado."""
+    """Monta mensagem Telegram para execução de ordem de mercado.
+
+    notify_extra (opcional, para SELL): invested, proceeds, pnl, pnl_pct.
+    """
     action = side.upper()
     icon = "🟢" if action == "BUY" else "🔴" if action == "SELL" else "📤"
     status = "EXECUTADA" if not error else "FALHOU"
@@ -207,6 +211,15 @@ def _format_market_order_notification(
         lines.append(f"• Valor: `{float(funds):.2f} USDT`")
     if size is not None:
         lines.append(f"• Quantidade: `{float(size):.8f}`")
+    extra = notify_extra or {}
+    if extra.get("invested") is not None:
+        lines.append(f"• Valor investido: `{float(extra['invested']):.2f} USDT`")
+    if extra.get("proceeds") is not None:
+        lines.append(f"• Valor da venda: `{float(extra['proceeds']):.2f} USDT`")
+    if extra.get("pnl") is not None:
+        pnl = float(extra["pnl"])
+        pct = float(extra.get("pnl_pct") or 0.0)
+        lines.append(f"• PnL líquido: `{pnl:+.4f} USDT ({pct:+.2f}%)`")
     if order_id:
         lines.append(f"• Order ID: `{order_id}`")
     if error:
@@ -949,8 +962,13 @@ def _floor_to_increment(value: float, increment: str) -> str:
 
 @retry_on_failure(max_retries=3)
 def place_market_order(symbol: str, side: str, funds: float = None,
-                       size: float = None) -> Dict[str, Any]:
-    """Executa ordem de mercado"""
+                       size: float = None,
+                       notify_extra: Dict[str, float] = None) -> Dict[str, Any]:
+    """Executa ordem de mercado.
+
+    notify_extra: contexto opcional para a notificação Telegram
+    (invested, proceeds, pnl, pnl_pct) — usado nos SELLs.
+    """
     validate_credentials()
 
     endpoint = "/api/v1/orders"
@@ -988,6 +1006,7 @@ def place_market_order(symbol: str, side: str, funds: float = None,
                 funds=funds,
                 size=size,
                 error=error_msg,
+                notify_extra=notify_extra,
             )
         )
         return {"success": False, "error": error_msg, "raw": result}
@@ -1001,6 +1020,7 @@ def place_market_order(symbol: str, side: str, funds: float = None,
             funds=funds,
             size=size,
             order_id=order_id,
+            notify_extra=notify_extra,
         )
     )
 

--- a/btc_trading_agent/position_manager_mixin.py
+++ b/btc_trading_agent/position_manager_mixin.py
@@ -221,7 +221,15 @@ class PositionManagerMixin:
                         entry_idx + 1, f"{size:.6f}", price, pnl, pnl_pct, reason,
                     )
                 else:
-                    result = place_market_order(self.symbol, "sell", size=size)
+                    result = place_market_order(
+                        self.symbol, "sell", size=size,
+                        notify_extra={
+                            "invested": entry_price * size,
+                            "proceeds": price * size,
+                            "pnl": pnl,
+                            "pnl_pct": pnl_pct,
+                        },
+                    )
                     if not result.get("success"):
                         logger.error("❌ Slot sell failed: %s", result)
                         err_code = str(

--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -4991,7 +4991,15 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                         logger.info(f"🔴 [DRY] SELL {size:.6f} BTC @ ${price:,.2f} "
                                   f"(PnL: ${pnl:.2f} / {pnl_pct:.2f}% net, fees=${sell_fee+buy_fee:.4f})")
                     else:
-                        result = place_market_order(self.symbol, "sell", size=size)
+                        result = place_market_order(
+                            self.symbol, "sell", size=size,
+                            notify_extra={
+                                "invested": self.state.entry_price * size,
+                                "proceeds": price * size,
+                                "pnl": pnl,
+                                "pnl_pct": pnl_pct,
+                            },
+                        )
                         if not result.get("success"):
                             logger.error(f"❌ Order failed: {result}")
                             self._block_trade(

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T17:21:55.486239+00:00",
+  "generated_at": "2026-07-04T17:40:04.658094+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T17:21:55.486239+00:00`
+- Generated at: `2026-07-04T17:40:04.658094+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`


### PR DESCRIPTION
Pedido: incluir valor investido e valores da venda no comunicado Telegram de SELL. `place_market_order` ganhou `notify_extra` e os dois caminhos de venda passam invested/proceeds/pnl/pnl_pct. Exemplo do novo formato validado; 66 testes verdes. Deployado — aguardando 'pode reiniciar' para valer nos agentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)