### PR TITLE
feat(ollama): trading-analyst protegido de eviction no coordinator

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-04T17:40:04.658094+00:00",
+  "generated_at": "2026-07-04T18:01:37.431350+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T17:40:04.658094+00:00`
+- Generated at: `2026-07-04T18:01:37.431350+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `161`

--- a/tools/ollama_gpu_coordinator.py
+++ b/tools/ollama_gpu_coordinator.py
@@ -60,6 +60,14 @@ STALE_AFTER_SEC = float(os.environ.get(
 ))
 # Cap de acúmulo de chunks de streaming para preview (bytes)
 STREAM_PREVIEW_CAP = int(os.environ.get("GPU_COORD_STREAM_PREVIEW_CAP", str(256 * 1024)))
+# Modelos protegidos de eviction mesmo ociosos (prefixo do nome, csv).
+# trading-analyst é o maior modelo da GPU0 e seria o 1º da fila de despejo;
+# reload de 5GB custaria 30-60s no próximo plano de qualquer perfil.
+PROTECTED_MODELS = tuple(
+    p.strip() for p in os.environ.get(
+        "GPU_COORD_PROTECTED_MODELS", "trading-analyst"
+    ).split(",") if p.strip()
+)
 
 # VRAM estimativas por padrão de nome (MB) — usado quando o modelo não está na VRAM
 _VRAM_ESTIMATES: list[tuple[str, int]] = [
@@ -272,6 +280,8 @@ class EndpointState:
                 if self._model_active.get(name, 0) > 0:
                     continue
                 if any(name.endswith(s) for s in (":gpu0", ":gpu1", ":nas")):
+                    continue
+                if any(name.startswith(p) for p in PROTECTED_MODELS):
                     continue
                 result.append((vram, name))
         return sorted(result, reverse=True)


### PR DESCRIPTION
Follow-up da análise de impacto do ETH nas GPUs: o coordinator já gerencia afinidade + eviction sob pressão (<2GB livres), mas a fila despeja o MAIOR modelo ocioso primeiro — e o `trading-analyst` (5,1GB, sem sufixo de pinning) era o primeiro candidato. Nova env `GPU_COORD_PROTECTED_MODELS` (default `trading-analyst`) o exclui da fila; phi4-mini (2,7GB) e llama3.2 (1,6GB) viram os candidatos naturais. Deployado com drop-in systemd; coordinator reiniciado e roteamento validado (gpu0 e gpu1 pinned OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)