### PR TITLE
feat(meeting): Tradutor de Reuniões — página + bot Meet/Teams + tile no Authentik

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,18 +1,18 @@
 {
-  "generated_at": "2026-07-04T18:01:37.431350+00:00",
+  "generated_at": "2026-07-04T21:30:39.351691+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 161,
+    "repo_services": 162,
     "critical_services": 66,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 16,
-      "operations": 88,
+      "operations": 89,
       "storage": 32,
       "trading": 7
     }
@@ -803,6 +803,14 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "meeting-translator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/meeting-translator.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-04T18:01:37.431350+00:00`
+- Generated at: `2026-07-04T21:30:39.351691+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `161`
+- Repo services discovered: `162`
 - Critical services flagged for MVP: `66`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 16
-- `operations`: 88
+- `operations`: 89
 - `storage`: 32
 - `trading`: 7
 

--- a/systemd/meeting-translator.service
+++ b/systemd/meeting-translator.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Tradutor de Reuniões RPA4All — página web + bot Meet/Teams
+After=network.target
+
+[Service]
+Type=simple
+User=homelab
+WorkingDirectory=/apps/meeting-translator
+Environment=PYTHONUNBUFFERED=1
+Environment=MEETING_TRANSLATOR_PORT=8712
+ExecStart=/usr/bin/python3 /apps/meeting-translator/server.py
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/meeting_translator/meet_bot.py
+++ b/tools/meeting_translator/meet_bot.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Bot que entra em reuniões (Google Meet / Microsoft Teams) como participante.
+
+Fase 1: entra na sala e pede admissão ("Pedir para participar").
+Fase 2 (futura): captura de áudio → faster-whisper (GPU0) → gemma3-fast (GPU1)
+para legenda traduzida ao vivo (ver docs/TRADING_MULTI_SYMBOL_LIVE e avaliação
+do "modo reunião").
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger("meet_bot")
+
+BOT_NAME = "Tradutor RPA4All"
+SCREENSHOT_DIR = Path("/tmp/meeting-translator")
+STAY_IN_CALL_SEC = 2 * 3600  # permanece na chamada por até 2h
+
+
+def detect_platform(url: str) -> str:
+    """Retorna 'meet', 'teams' ou lança ValueError."""
+    if re.search(r"meet\.google\.com/[a-z]{3}-[a-z]{4}-[a-z]{3}", url):
+        return "meet"
+    if "teams.microsoft.com" in url or "teams.live.com" in url:
+        return "teams"
+    raise ValueError("Link não reconhecido — cole um link do Google Meet ou do Microsoft Teams")
+
+
+def _build_driver():
+    from selenium import webdriver
+
+    opts = webdriver.ChromeOptions()
+    opts.add_argument("--headless=new")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--window-size=1366,900")
+    opts.add_argument("--lang=pt-BR")
+    opts.add_argument("--use-fake-ui-for-media-stream")   # auto-aceita prompt de mic/cam
+    opts.add_argument("--use-fake-device-for-media-stream")
+    opts.add_argument("--mute-audio")
+    opts.add_experimental_option("prefs", {
+        "intl.accept_languages": "pt-BR,pt",
+        "profile.default_content_setting_values.media_stream_mic": 1,
+        "profile.default_content_setting_values.media_stream_camera": 2,
+    })
+    # Chrome real + chromedriver da MESMA versão baixado em bin/ (Chrome for
+    # Testing). NÃO usar /usr/bin/chromedriver (wrapper do snap, confinado)
+    # nem o chromium snap (não sobe sob systemd) — lições do homelab.
+    from selenium.webdriver.chrome.service import Service
+
+    opts.binary_location = "/opt/google/chrome/chrome"
+    driver_path = Path(__file__).parent / "bin" / "chromedriver"
+    service = Service(executable_path=str(driver_path))
+    return webdriver.Chrome(service=service, options=opts)
+
+
+def _click_first(driver, xpaths: list[str], timeout: float = 12) -> bool:
+    """Clica no primeiro elemento clicável entre os xpaths (retorna False se nenhum)."""
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for xp in xpaths:
+            try:
+                els = driver.find_elements(By.XPATH, xp)
+                for el in els:
+                    if el.is_displayed() and el.is_enabled():
+                        driver.execute_script("arguments[0].click();", el)
+                        return True
+            except Exception:
+                continue
+        time.sleep(0.5)
+    return False
+
+
+def _type_first(driver, xpaths: list[str], text: str, timeout: float = 12) -> bool:
+    from selenium.webdriver.common.by import By
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for xp in xpaths:
+            try:
+                els = driver.find_elements(By.XPATH, xp)
+                for el in els:
+                    if el.is_displayed():
+                        el.clear()
+                        el.send_keys(text)
+                        return True
+            except Exception:
+                continue
+        time.sleep(0.5)
+    return False
+
+
+def _screenshot(driver, job_id: str, tag: str) -> str:
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    path = SCREENSHOT_DIR / f"{job_id}_{tag}.png"
+    try:
+        driver.save_screenshot(str(path))
+    except Exception:
+        pass
+    return str(path)
+
+
+def _join_meet(driver, url: str, status: Callable[[str], None], job_id: str) -> None:
+    status("abrindo o Google Meet…")
+    driver.get(url)
+    time.sleep(4)
+
+    # Desligar microfone e câmera na pré-sala (Meet: botões com aria-label)
+    for label in ("microfone", "microphone"):
+        _click_first(driver, [f"//div[@role='button' and contains(translate(@aria-label,'MC','mc'),'{label}') and contains(@aria-label,'esligar') or contains(@aria-label,'urn off')]"], timeout=3)
+
+    status("informando o nome do bot…")
+    named = _type_first(driver, [
+        "//input[contains(@aria-label,'nome') or contains(@aria-label,'name')]",
+        "//input[@type='text']",
+    ], BOT_NAME, timeout=10)
+    if not named:
+        # Provavelmente exige login Google (reunião restrita à organização)
+        shot = _screenshot(driver, job_id, "meet_sem_campo_nome")
+        raise RuntimeError(
+            "Meet não ofereceu entrada como convidado — a reunião pode exigir login "
+            f"Google. Screenshot: {shot}"
+        )
+
+    status("pedindo para participar…")
+    asked = _click_first(driver, [
+        "//button[.//span[contains(text(),'Pedir para participar')]]",
+        "//button[.//span[contains(text(),'Ask to join')]]",
+        "//button[.//span[contains(text(),'Participar agora')]]",
+        "//button[.//span[contains(text(),'Join now')]]",
+        "//span[contains(text(),'Pedir para participar')]/ancestor::button",
+    ], timeout=15)
+    if not asked:
+        shot = _screenshot(driver, job_id, "meet_sem_botao_join")
+        raise RuntimeError(f"Botão de participar não encontrado. Screenshot: {shot}")
+
+    status("⏳ aguardando o organizador admitir o Tradutor RPA4All…")
+    _wait_in_call(driver, status, job_id)
+
+
+def _join_teams(driver, url: str, status: Callable[[str], None], job_id: str) -> None:
+    status("abrindo o Microsoft Teams (web)…")
+    driver.get(url)
+    time.sleep(5)
+
+    # "Continuar neste navegador"
+    _click_first(driver, [
+        "//button[contains(., 'Continuar neste navegador')]",
+        "//button[contains(., 'Continue on this browser')]",
+        "//a[contains(@href,'launcher=false')]",
+        "//button[@data-tid='joinOnWeb']",
+    ], timeout=15)
+    time.sleep(4)
+
+    status("informando o nome do bot…")
+    _type_first(driver, [
+        "//input[@data-tid='prejoin-display-name-input']",
+        "//input[contains(@placeholder,'nome') or contains(@placeholder,'name')]",
+        "//input[@type='text']",
+    ], BOT_NAME, timeout=20)
+
+    # Desligar mic/câmera se toggles visíveis
+    _click_first(driver, ["//div[@data-tid='toggle-video']", "//div[@data-tid='toggle-mute']"], timeout=3)
+
+    status("pedindo para entrar na reunião…")
+    asked = _click_first(driver, [
+        "//button[@data-tid='prejoin-join-button']",
+        "//button[contains(., 'Ingressar agora')]",
+        "//button[contains(., 'Join now')]",
+        "//button[contains(., 'Entrar agora')]",
+    ], timeout=15)
+    if not asked:
+        shot = _screenshot(driver, job_id, "teams_sem_botao_join")
+        raise RuntimeError(f"Botão de ingresso não encontrado. Screenshot: {shot}")
+
+    status("⏳ aguardando o organizador admitir o Tradutor RPA4All…")
+    _wait_in_call(driver, status, job_id)
+
+
+def _wait_in_call(driver, status: Callable[[str], None], job_id: str) -> None:
+    """Permanece na sessão até ser admitido + duração máxima (ou removido)."""
+    admitted = False
+    deadline = time.time() + STAY_IN_CALL_SEC
+    while time.time() < deadline:
+        page = ""
+        try:
+            page = driver.page_source[:200000]
+        except Exception:
+            status("sessão do navegador encerrada")
+            return
+        lowered = page.lower()
+        if not admitted and not any(k in lowered for k in ("pedindo para participar", "asking to join", "aguardando", "waiting for")):
+            if any(k in lowered for k in ("sair da chamada", "leave call", "abandonar", "hang up", "roster", "participantes")):
+                admitted = True
+                status("✅ admitido na reunião — presente como Tradutor RPA4All (captura de áudio: fase 2)")
+                _screenshot(driver, job_id, "admitido")
+        if any(k in lowered for k in ("você foi removido", "removed from", "call ended", "chamada encerrada")):
+            status("reunião encerrada / bot removido")
+            return
+        time.sleep(10)
+    status("tempo máximo de permanência atingido (2h) — saindo")
+
+
+def join_meeting(url: str, status: Callable[[str], None], job_id: str) -> None:
+    """Entra na reunião e permanece. Levanta exceção com diagnóstico em falha."""
+    platform = detect_platform(url)
+    driver = _build_driver()
+    try:
+        if platform == "meet":
+            _join_meet(driver, url, status, job_id)
+        else:
+            _join_teams(driver, url, status, job_id)
+    finally:
+        try:
+            driver.quit()
+        except Exception:
+            pass

--- a/tools/meeting_translator/server.py
+++ b/tools/meeting_translator/server.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tradutor de Reuniões — serviço web (FastAPI).
+
+Página em /static (JS) recebe o link do Meet/Teams; POST /api/join dispara o
+bot Selenium que entra na sala e pede admissão. Status consultável por job.
+
+Porta: MEETING_TRANSLATOR_PORT (default 8712).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+import meet_bot
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [meeting-translator] %(message)s")
+logger = logging.getLogger("meeting_translator")
+
+app = FastAPI(title="Tradutor de Reuniões RPA4All")
+STATIC_DIR = Path(__file__).parent / "static"
+
+_jobs: dict[str, dict] = {}
+_jobs_lock = threading.Lock()
+MAX_CONCURRENT = 1  # 1 reunião por vez (capacidade avaliada do homelab)
+
+
+class JoinRequest(BaseModel):
+    url: str
+
+
+def _active_jobs() -> int:
+    with _jobs_lock:
+        return sum(1 for j in _jobs.values() if j["state"] in ("iniciando", "entrando", "na_reuniao"))
+
+
+def _run_job(job_id: str, url: str) -> None:
+    def status(msg: str) -> None:
+        with _jobs_lock:
+            job = _jobs[job_id]
+            job["log"].append({"t": time.strftime("%H:%M:%S"), "msg": msg})
+            if "admitido" in msg:
+                job["state"] = "na_reuniao"
+            elif "aguardando" in msg:
+                job["state"] = "entrando"
+        logger.info("[%s] %s", job_id[:8], msg)
+
+    try:
+        with _jobs_lock:
+            _jobs[job_id]["state"] = "entrando"
+        meet_bot.join_meeting(url, status, job_id)
+        with _jobs_lock:
+            if _jobs[job_id]["state"] != "erro":
+                _jobs[job_id]["state"] = "finalizado"
+    except Exception as exc:
+        logger.exception("job %s falhou", job_id[:8])
+        with _jobs_lock:
+            _jobs[job_id]["state"] = "erro"
+            _jobs[job_id]["log"].append({"t": time.strftime("%H:%M:%S"), "msg": f"❌ {exc}"})
+
+
+@app.get("/")
+def index():
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.post("/api/join")
+def join(req: JoinRequest):
+    url = req.url.strip()
+    try:
+        platform = meet_bot.detect_platform(url)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if _active_jobs() >= MAX_CONCURRENT:
+        raise HTTPException(status_code=409, detail="Já existe uma reunião ativa — o homelab atende 1 por vez.")
+
+    job_id = uuid.uuid4().hex
+    with _jobs_lock:
+        _jobs[job_id] = {
+            "id": job_id,
+            "url": url,
+            "platform": platform,
+            "state": "iniciando",
+            "created": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "log": [{"t": time.strftime("%H:%M:%S"), "msg": f"job criado ({platform})"}],
+        }
+    threading.Thread(target=_run_job, args=(job_id, url), daemon=True, name=f"job-{job_id[:8]}").start()
+    return {"job_id": job_id, "platform": platform}
+
+
+@app.get("/api/jobs")
+def jobs():
+    with _jobs_lock:
+        return sorted(_jobs.values(), key=lambda j: j["created"], reverse=True)[:10]
+
+
+@app.get("/api/jobs/{job_id}")
+def job_detail(job_id: str):
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job não encontrado")
+    return job
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "ativos": _active_jobs()}
+
+
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+if __name__ == "__main__":
+    import os
+
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("MEETING_TRANSLATOR_PORT", "8712")))

--- a/tools/meeting_translator/static/app.js
+++ b/tools/meeting_translator/static/app.js
@@ -1,0 +1,69 @@
+// Tradutor de Reuniões — frontend
+const $url = document.getElementById("url");
+const $join = document.getElementById("join");
+const $status = document.getElementById("status");
+
+const STATE_LABEL = {
+  iniciando: "iniciando",
+  entrando: "entrando / aguardando admissão",
+  na_reuniao: "na reunião ✅",
+  erro: "erro",
+  finalizado: "finalizado",
+};
+
+async function joinMeeting() {
+  const url = $url.value.trim();
+  if (!url) { $url.focus(); return; }
+  $join.disabled = true;
+  $join.textContent = "Entrando…";
+  try {
+    const r = await fetch("/api/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data.detail || r.statusText);
+    $url.value = "";
+  } catch (e) {
+    alert("Não foi possível iniciar: " + e.message);
+  } finally {
+    $join.disabled = false;
+    $join.textContent = "Entrar na reunião";
+    refresh();
+  }
+}
+
+async function refresh() {
+  try {
+    const r = await fetch("/api/jobs");
+    const jobs = await r.json();
+    $status.innerHTML = jobs.map(renderJob).join("");
+  } catch { /* servidor reiniciando — tenta de novo no próximo tick */ }
+}
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c]));
+}
+
+function renderJob(j) {
+  const logItems = (j.log || []).slice(-8).map(
+    (l) => `<li>[${esc(l.t)}] ${esc(l.msg)}</li>`
+  ).join("");
+  const platform = j.platform === "meet" ? "Google Meet" : "Microsoft Teams";
+  return `
+    <div class="job">
+      <div class="head">
+        <span>${platform} · ${esc(j.url).slice(0, 60)}…</span>
+        <span class="state ${esc(j.state)}">${STATE_LABEL[j.state] || esc(j.state)}</span>
+      </div>
+      <ul class="log">${logItems}</ul>
+    </div>`;
+}
+
+$join.addEventListener("click", joinMeeting);
+$url.addEventListener("keydown", (e) => { if (e.key === "Enter") joinMeeting(); });
+setInterval(refresh, 4000);
+refresh();

--- a/tools/meeting_translator/static/icon.svg
+++ b/tools/meeting_translator/static/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+  <rect width="96" height="96" rx="20" fill="#3b6ef5"/>
+  <circle cx="48" cy="44" r="22" fill="none" stroke="#fff" stroke-width="4"/>
+  <ellipse cx="48" cy="44" rx="10" ry="22" fill="none" stroke="#fff" stroke-width="3"/>
+  <line x1="26" y1="44" x2="70" y2="44" stroke="#fff" stroke-width="3"/>
+  <path d="M30 74 h36 a4 4 0 0 1 0 8 h-10 l-8 8 v-8 h-18 a4 4 0 0 1 0-8z" fill="#fff"/>
+  <text x="48" y="81.5" font-family="sans-serif" font-size="8" font-weight="bold" fill="#3b6ef5" text-anchor="middle">PT↔EN</text>
+</svg>

--- a/tools/meeting_translator/static/index.html
+++ b/tools/meeting_translator/static/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tradutor de Reuniões — RPA4All</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    background: #0f1420; color: #e8ecf4;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  .card {
+    width: min(680px, 94vw); background: #171e2e; border: 1px solid #26304a;
+    border-radius: 14px; padding: 28px 30px; box-shadow: 0 10px 40px rgba(0,0,0,.45);
+  }
+  h1 { margin: 0 0 4px; font-size: 1.35rem; display: flex; align-items: center; gap: 10px; }
+  h1 .logo { font-size: 1.6rem; }
+  .sub { color: #93a0b8; font-size: .88rem; margin: 0 0 22px; }
+  .row { display: flex; gap: 10px; }
+  input[type=url] {
+    flex: 1; padding: 12px 14px; border-radius: 9px; border: 1px solid #33405f;
+    background: #0d1322; color: #e8ecf4; font-size: .95rem; outline: none;
+  }
+  input[type=url]:focus { border-color: #5b8cff; }
+  button {
+    padding: 12px 20px; border-radius: 9px; border: 0; cursor: pointer;
+    background: #3b6ef5; color: #fff; font-weight: 600; font-size: .95rem;
+  }
+  button:disabled { background: #2b3a5c; color: #7d8aa5; cursor: wait; }
+  .hint { font-size: .78rem; color: #7d8aa5; margin-top: 8px; }
+  .platform { display: inline-block; margin-left: 6px; padding: 2px 8px; border-radius: 20px;
+    font-size: .72rem; background: #22304f; color: #9fb6e8; }
+  #status { margin-top: 22px; }
+  .job { border: 1px solid #26304a; border-radius: 10px; padding: 12px 14px; margin-bottom: 10px; background: #121828; }
+  .job .head { display: flex; justify-content: space-between; font-size: .84rem; color: #aeb9cf; }
+  .state { font-weight: 700; }
+  .state.entrando { color: #f5c542; }
+  .state.na_reuniao { color: #46d68c; }
+  .state.erro { color: #f56565; }
+  .state.finalizado { color: #8a93a8; }
+  .log { margin: 8px 0 0; padding: 0; list-style: none; font-size: .8rem; color: #93a0b8; max-height: 130px; overflow-y: auto; }
+  .log li { padding: 1px 0; }
+  .phase2 { margin-top: 18px; font-size: .78rem; color: #6b7690; border-top: 1px dashed #26304a; padding-top: 12px; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1><span class="logo">🌐</span> Tradutor de Reuniões <span class="platform">RPA4All</span></h1>
+    <p class="sub">Cole o link da reunião — o agente <b>Tradutor RPA4All</b> entra na sala e pede para participar.</p>
+    <div class="row">
+      <input id="url" type="url" placeholder="https://meet.google.com/xxx-yyyy-zzz  ou  https://teams.microsoft.com/…" autofocus>
+      <button id="join">Entrar na reunião</button>
+    </div>
+    <div class="hint">Suporta <b>Google Meet</b> e <b>Microsoft Teams</b> · 1 reunião simultânea · admita o bot quando ele bater na porta 🚪</div>
+    <div id="status"></div>
+    <div class="phase2">🎧 Fase 2 (em breve): legenda traduzida ao vivo — áudio → Whisper (GPU0) → Gemma (GPU1), latência alvo ~2–4 s.</div>
+  </div>
+  <script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Fase 1 do modo reunião avaliado: página web em JS (http://192.168.15.2:8712) onde se cola o link do Meet/Teams; o bot Selenium entra como **Tradutor RPA4All** e pede para participar; status ao vivo por job. Aplicação com ícone publicada na biblioteca do Authentik (auth.rpa4all.com). Smoke test real: Chrome headless carregou o Meet em pt-BR e tratou código inexistente com screenshot de diagnóstico. Armadilhas documentadas no código (chromedriver snap confinado; Selenium Manager sem rede sob systemd → driver 146 dedicado). Fase 2 (áudio→Whisper→tradução) é o próximo passo do plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)