### PR TITLE
fix(secrets-agent): incluir value na resposta de fallback por fields

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-09T02:55:55.676576+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-07-11T18:11:05.793304+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/6e454367-dabd-48bd-88ea-c0c3df4c24cc/scratchpad/hotfix-worktree",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-09T02:55:55.676576+00:00`
+- Generated at: `2026-07-11T18:11:05.793304+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `165`

--- a/tools/secrets_agent/secrets_agent.py
+++ b/tools/secrets_agent/secrets_agent.py
@@ -737,7 +737,14 @@ def get_secret(request: Request, item_id: str, field: str = "password"):
     if fields:
         ACCESS_SUCCESS.inc()
         audit_log(ip, "fetch", item_id, "ok")
-        return {"id": item_id, "fields": fields, "source": "authentik"}
+        response = {"id": item_id, "fields": fields, "source": "authentik"}
+        if field in fields:
+            # Clientes legados leem apenas "value" — sem isso, uma falha
+            # transiente no passo 1 (busca por field exato) faz o passo 2
+            # responder 200 OK com "value" ausente, e o caller silenciosamente
+            # trata como secret vazio em vez de erro.
+            response["value"] = fields[field]
+        return response
 
     # 3. Fallback: LocalVault
     local_val = local_vault.get(item_id, field)


### PR DESCRIPTION
## Summary
- Corrige falso positivo de `entry_not_found` no monitor `tuya-token-renewer.service`.
- Causa raiz: quando a busca por field exato no Authentik falha por erro transiente de rede (`RemoteDisconnected`), o endpoint `/secrets/{item_id}` cai no fallback multi-field, que responde 200 OK sem a chave `"value"`. Clientes que fazem `resp.get("value", "")` (ex.: `tuya_token_renewer.py`) recebem string vazia silenciosa em vez de erro.
- Fix: quando o field pedido está presente no dict `fields`, também popular `"value"` na resposta.

## Test plan
- [x] Revisão manual do diff (mudança aditiva, backward-compatible)
- [ ] Após deploy, confirmar nos logs do secrets_agent que próximas falhas transientes do Authentik não geram mais alerta falso de Tuya

🤖 Generated with [Claude Code](https://claude.com/claude-code)