### PR TITLE
feat(trading): envelope determinístico no REBUY lock + selfheal gate + rebalance automático

### DIFF
--- a/btc_trading_agent/config_BTC_USDT_aggressive.json
+++ b/btc_trading_agent/config_BTC_USDT_aggressive.json
@@ -5,7 +5,7 @@
   "poll_interval": 5,
   "min_trade_interval": 600,
   "min_confidence": 0.55,
-  "min_trade_amount": 10,
+  "min_trade_amount": 15,
   "max_position_pct": 1.0,
   "dca_valley_bounce_pct": 0.003,
   "stop_loss_pct": 0.05,
@@ -72,7 +72,12 @@
   "guardrails_active": true,
   "guardrails_min_sell_pnl_pct": 0.003,
   "guardrails_positive_only_sells": true,
-  "rebuy_lock_enabled": false,
+  "rebuy_lock_enabled": true,
+  "rebuy_envelope": {
+    "grace_hours": 2,
+    "decay_pct_per_hour": 0.25,
+    "max_premium_pct": 5.0
+  },
   "track_record_confidence": {
     "enabled": true,
     "mode": "apply",

--- a/btc_trading_agent/config_BTC_USDT_conservative.json
+++ b/btc_trading_agent/config_BTC_USDT_conservative.json
@@ -5,7 +5,7 @@
   "poll_interval": 5,
   "min_trade_interval": 900,
   "min_confidence": 0.6,
-  "min_trade_amount": 10,
+  "min_trade_amount": 15,
   "max_position_pct": 0.6,
   "dca_valley_bounce_pct": 0.004,
   "stop_loss_pct": 0.03,
@@ -78,7 +78,12 @@
   "guardrails_min_sell_pnl_pct": 0.003,
   "guardrails_active": true,
   "guardrails_positive_only_sells": true,
-  "rebuy_lock_enabled": false,
+  "rebuy_lock_enabled": true,
+  "rebuy_envelope": {
+    "grace_hours": 2,
+    "decay_pct_per_hour": 0.25,
+    "max_premium_pct": 5.0
+  },
   "track_record_confidence": {
     "enabled": true,
     "mode": "apply",

--- a/btc_trading_agent/config_ETH_USDT_aggressive.json
+++ b/btc_trading_agent/config_ETH_USDT_aggressive.json
@@ -5,7 +5,7 @@
   "poll_interval": 5,
   "min_trade_interval": 600,
   "min_confidence": 0.55,
-  "min_trade_amount": 10,
+  "min_trade_amount": 15,
   "max_position_pct": 1.0,
   "dca_valley_bounce_pct": 0.003,
   "stop_loss_pct": 0.05,
@@ -72,7 +72,12 @@
   "guardrails_active": true,
   "guardrails_min_sell_pnl_pct": 0.003,
   "guardrails_positive_only_sells": true,
-  "rebuy_lock_enabled": false,
+  "rebuy_lock_enabled": true,
+  "rebuy_envelope": {
+    "grace_hours": 2,
+    "decay_pct_per_hour": 0.25,
+    "max_premium_pct": 5.0
+  },
   "_eth_live_notes": {
     "origem": "clonado de config_BTC_USDT_aggressive.json em 2026-07-04",
     "conta": "subconta sub:ETHAgressive via KUCOIN_SECRET_NAMES",

--- a/btc_trading_agent/config_ETH_USDT_conservative.json
+++ b/btc_trading_agent/config_ETH_USDT_conservative.json
@@ -5,7 +5,7 @@
   "poll_interval": 5,
   "min_trade_interval": 900,
   "min_confidence": 0.6,
-  "min_trade_amount": 10,
+  "min_trade_amount": 15,
   "max_position_pct": 0.6,
   "dca_valley_bounce_pct": 0.004,
   "stop_loss_pct": 0.03,
@@ -78,7 +78,12 @@
   "guardrails_min_sell_pnl_pct": 0.003,
   "guardrails_active": true,
   "guardrails_positive_only_sells": true,
-  "rebuy_lock_enabled": false,
+  "rebuy_lock_enabled": true,
+  "rebuy_envelope": {
+    "grace_hours": 2,
+    "decay_pct_per_hour": 0.25,
+    "max_premium_pct": 5.0
+  },
   "_eth_live_notes": {
     "origem": "clonado de config_BTC_USDT_conservative.json em 2026-07-04",
     "conta": "subconta sub:ETHConservative ($50) via KUCOIN_SECRET_NAMES",

--- a/btc_trading_agent/position_manager_mixin.py
+++ b/btc_trading_agent/position_manager_mixin.py
@@ -277,6 +277,7 @@ class PositionManagerMixin:
                 self._sync_position_tracking()
 
                 self.state.last_sell_entry_price = entry_price
+                self.state.last_sell_ts = time.time()
                 logger.info(
                     "🔒 REBUY lock: próxima compra deve ser < $%.2f (entrada slot #%d)",
                     entry_price, entry_idx + 1,

--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -636,9 +636,53 @@ class MetricsCollector:
         # Variação de equity por dia calendário (equivalente ao PnL "de ontem" da KuCoin)
         metrics.update(self._get_equity_daily_changes())
 
+        # ── REBUY envelope (último bloqueio anotado pelo agente) ──
+        metrics.update(self._collect_rebuy_envelope(cursor))
+
         cursor.close()
         conn.close()
         return metrics
+
+    def _collect_rebuy_envelope(self, cursor) -> Dict:
+        """Último bloqueio de rebuy anotado em decisions.features pelo agente.
+
+        O envelope é mecânico (grace→decay→expired) e calculado pelo próprio
+        agente; aqui apenas espelhamos a anotação mais recente (janela 30 min)
+        para o Prometheus — sem duplicar a matemática do envelope.
+        Fases: 0=nenhum bloqueio recente, 1=grace, 2=decay.
+        """
+        out = {
+            'rebuy_envelope_phase': 0,
+            'rebuy_envelope_ceiling': 0.0,
+            'rebuy_envelope_raw_ceiling': 0.0,
+            'rebuy_envelope_elapsed_hours': 0.0,
+            'rebuy_envelope_block_age_seconds': 0.0,
+        }
+        try:
+            cursor.execute("""
+                SELECT features->'block_context'->>'rebuy_phase',
+                       features->'block_context'->>'rebuy_max_price',
+                       features->'block_context'->>'rebuy_envelope_ceiling',
+                       features->'block_context'->>'rebuy_elapsed_hours',
+                       timestamp
+                FROM decisions
+                WHERE symbol = %s AND profile = %s
+                  AND features->>'block_reason' = 'buy_rebuy_lock_last_sell'
+                  AND timestamp > extract(epoch from now()) - 1800
+                ORDER BY timestamp DESC LIMIT 1
+            """, (self.symbol, self.profile))
+            row = cursor.fetchone()
+            if row:
+                phase_map = {'grace': 1, 'decay': 2}
+                out['rebuy_envelope_phase'] = phase_map.get(str(row[0] or ''), 0)
+                out['rebuy_envelope_ceiling'] = float(row[1] or 0.0)
+                out['rebuy_envelope_raw_ceiling'] = float(row[2] or 0.0)
+                out['rebuy_envelope_elapsed_hours'] = float(row[3] or 0.0)
+                out['rebuy_envelope_block_age_seconds'] = max(
+                    0.0, datetime.now().timestamp() - float(row[4] or 0.0))
+        except Exception as e:
+            print(f"⚠️ Erro ao coletar rebuy envelope: {e}")
+        return out
 
 
 class PrometheusHandler(BaseHTTPRequestHandler):
@@ -1281,6 +1325,20 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                         output.append("")
             except Exception:
                 pass  # RAG metrics non-critical
+
+            # ═══════════════ REBUY ENVELOPE (mecânico, não-RAG) ═══════════════
+            envelope_metrics = [
+                ("btc_rebuy_envelope_phase", "Rebuy envelope phase from latest block annotation (0=none recent, 1=grace, 2=decay)", metrics.get('rebuy_envelope_phase', 0), "{v}"),
+                ("btc_rebuy_envelope_ceiling", "Effective rebuy ceiling (envelope × AI margin) at latest block", metrics.get('rebuy_envelope_ceiling', 0), "{v:.2f}"),
+                ("btc_rebuy_envelope_raw_ceiling", "Deterministic envelope ceiling (before AI margin) at latest block", metrics.get('rebuy_envelope_raw_ceiling', 0), "{v:.2f}"),
+                ("btc_rebuy_envelope_elapsed_hours", "Hours since last sell at latest rebuy block", metrics.get('rebuy_envelope_elapsed_hours', 0), "{v:.2f}"),
+                ("btc_rebuy_envelope_block_age_seconds", "Age of latest rebuy block annotation", metrics.get('rebuy_envelope_block_age_seconds', 0), "{v:.0f}"),
+            ]
+            for prom_name, help_text, v, fmt in envelope_metrics:
+                output.append(f"# HELP {prom_name} {help_text}")
+                output.append(f"# TYPE {prom_name} gauge")
+                output.append(f'{prom_name}{{{_cl}}} {fmt.format(v=v)}')
+                output.append("")
 
             # ═══════════════ AGENT STATUS ═══════════════
             output.append("# HELP btc_trading_agent_running Agent running (1=yes, 0=no)")

--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -204,6 +204,7 @@ class AgentState:
     total_pnl: float = 0.0
     dry_run: bool = True
     last_sell_entry_price: float = 0.0  # Trava de recompra: preço médio da última venda
+    last_sell_ts: float = 0.0  # Epoch da última venda (âncora temporal do envelope de recompra)
     trailing_high: float = 0.0  # Máxima atingida para trailing stop
     target_sell_price: float = 0.0  # Target de venda calculado pela IA no BUY
     target_sell_reason: str = ""  # Razão do cálculo do target
@@ -234,6 +235,7 @@ class AgentState:
             "total_pnl": self.total_pnl,
             "dry_run": self.dry_run,
             "last_sell_entry_price": self.last_sell_entry_price,
+            "last_sell_ts": self.last_sell_ts,
             "target_sell_price": self.target_sell_price,
             "target_sell_reason": self.target_sell_reason,
             "profile": self.profile,
@@ -532,18 +534,89 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
         """Desconto mínimo abaixo do preço médio para liberar reforço."""
         return 0.01
 
-    def _resolve_rebuy_lock(self, rag_adj, controls: "TradeControls") -> tuple[bool, float, str]:
-        """Resolve trava de recompra: IA (RAG) tem prioridade sobre config estático.
+    def _resolve_rebuy_envelope(self, rag_adj, controls: "TradeControls",
+                                now: Optional[float] = None) -> Dict[str, Any]:
+        """Envelope determinístico de recompra + margem extra da IA (só aperta).
 
-        Returns:
-            (ativo, margem_pct, fonte) onde fonte é ``ai``, ``config`` ou ``off``.
+        O envelope é mecânico e SEMPRE ativo enquanto houver venda registrada —
+        independe de IA disponível ou de config. Falha da IA nunca desliga o freio.
+
+        Fases (relativas a ``last_sell_ts``):
+          - grace  (0..grace_hours): teto = last_sell — anti-churn, nada compra acima.
+          - decay  (após a graça): teto sobe ``decay_pct_per_hour`` linearmente.
+          - expired (prêmio >= max_premium_pct): limpa o lock (efeito colateral
+            intencional: zera last_sell_entry_price/last_sell_ts; chamada única
+            no caminho de BUY em _check_can_trade).
+
+        A IA só pode APERTAR: ``ceiling = envelope_ceiling * (1 - ai_margin)``,
+        com ai_margin clampado [0, 0.01] e aplicado apenas se o config
+        ``rebuy_lock_enabled`` permitir, a IA estiver quente (ai_controlled) e
+        ``ai_rebuy_lock_enabled`` for True. Regime BULLISH (ai_rebuy_lock_enabled
+        False) significa apenas margem zero — o envelope permanece.
+
+        Returns dict: active, phase (grace|decay|expired|off), ceiling,
+            envelope_ceiling, ai_margin_pct, elapsed_hours, last_sell, source.
         """
-        if controls.ai_controlled and bool(getattr(rag_adj, "ai_rebuy_lock_enabled", False)):
-            margin_pct = float(getattr(rag_adj, "ai_rebuy_margin_pct", 0.0) or 0.0)
-            return True, max(0.0, min(margin_pct, 0.01)), "ai"
-        if self._load_live_config().get("rebuy_lock_enabled", True):
-            return True, 0.0, "config"
-        return False, 0.0, "off"
+        last_sell = float(getattr(self.state, "last_sell_entry_price", 0.0) or 0.0)
+        if last_sell <= 0:
+            return {
+                "active": False, "phase": "off", "ceiling": 0.0,
+                "envelope_ceiling": 0.0, "ai_margin_pct": 0.0,
+                "elapsed_hours": 0.0, "last_sell": 0.0, "source": "off",
+            }
+
+        cfg = self._load_live_config()
+        env_cfg = cfg.get("rebuy_envelope") or {}
+        grace_hours = min(max(float(env_cfg.get("grace_hours", 2.0)), 0.0), 24.0)
+        decay_pct_h = min(max(float(env_cfg.get("decay_pct_per_hour", 0.25)), 0.01), 5.0)
+        max_premium = min(max(float(env_cfg.get("max_premium_pct", 5.0)), 0.5), 20.0)
+
+        now = time.time() if now is None else now
+        sell_ts = float(getattr(self.state, "last_sell_ts", 0.0) or 0.0)
+        if sell_ts <= 0:
+            # Self-heal (estado legado sem âncora temporal): graça começa agora.
+            self.state.last_sell_ts = sell_ts = now
+        elapsed_h = max(0.0, (now - sell_ts) / 3600.0)
+
+        if elapsed_h <= grace_hours:
+            phase, premium_pct = "grace", 0.0
+        else:
+            premium_pct = (elapsed_h - grace_hours) * decay_pct_h
+            if premium_pct >= max_premium:
+                logger.info(
+                    "🔓 REBUY envelope expirado após %.1fh (teto atingiu +%.2f%% "
+                    "sobre $%.2f) — lock liberado",
+                    elapsed_h, max_premium, last_sell,
+                )
+                self.state.last_sell_entry_price = 0.0
+                self.state.last_sell_ts = 0.0
+                return {
+                    "active": False, "phase": "expired", "ceiling": 0.0,
+                    "envelope_ceiling": 0.0, "ai_margin_pct": 0.0,
+                    "elapsed_hours": elapsed_h, "last_sell": last_sell,
+                    "source": "expired",
+                }
+            phase = "decay"
+
+        envelope_ceiling = last_sell * (1.0 + premium_pct / 100.0)
+
+        ai_margin = 0.0
+        if (cfg.get("rebuy_lock_enabled", True)
+                and controls.ai_controlled
+                and bool(getattr(rag_adj, "ai_rebuy_lock_enabled", True))):
+            ai_margin = max(0.0, min(
+                float(getattr(rag_adj, "ai_rebuy_margin_pct", 0.0) or 0.0), 0.01))
+
+        return {
+            "active": True,
+            "phase": phase,
+            "ceiling": envelope_ceiling * (1.0 - ai_margin),
+            "envelope_ceiling": envelope_ceiling,
+            "ai_margin_pct": ai_margin,
+            "elapsed_hours": elapsed_h,
+            "last_sell": last_sell,
+            "source": "envelope+ai" if ai_margin > 0 else f"envelope_{phase}",
+        }
 
     def _resolve_dynamic_buy_batch_limit(self, remaining_exposure: float) -> Dict[str, float]:
         """Resolve o cap dinâmico por lote usando a pressão recente do profile."""
@@ -3632,9 +3705,14 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                     total_ct = sum((b.get("size", 0) or 0) * (b.get("price", 0) or 0) for b in buys_before_sell)
                     if total_sz > 0:
                         self.state.last_sell_entry_price = total_ct / total_sz
+                        self.state.last_sell_ts = (
+                            float(last_sell.get("timestamp") or 0.0) or time.time()
+                        )
+                        sell_age_h = max(0.0, (time.time() - self.state.last_sell_ts) / 3600.0)
                         logger.info(
                             f"🔒 REBUY lock restaurado: próxima reentrada deve ser "
-                            f"abaixo de ${self.state.last_sell_entry_price:,.2f}"
+                            f"abaixo de ${self.state.last_sell_entry_price:,.2f} "
+                            f"(venda há {sell_age_h:.1f}h — envelope grace/decay aplica)"
                         )
             logger.info(f"📭 Last trade was sell — no open position")
             return
@@ -4462,35 +4540,32 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
         elif signal.action == "SELL" and context["strong_bearish"]:
             min_confidence = max(0.45, min_confidence - 0.05)
 
-        # REBUY lock: IA (ai_rebuy_lock_enabled + ai_rebuy_margin_pct) ou config estático.
+        # REBUY lock: envelope determinístico (grace→decay→expired) + margem IA dentro.
         if signal.action == "BUY":
-            rebuy_active, rebuy_margin_pct, rebuy_source = self._resolve_rebuy_lock(rag_adj, controls)
-            if rebuy_active:
-                try:
-                    last_sell = float(getattr(self.state, "last_sell_entry_price", 0.0) or 0.0)
-                    if last_sell > 0:
-                        price = float(getattr(signal, "price", 0.0) or 0.0)
-                        max_buy_price = last_sell * (1.0 - rebuy_margin_pct)
-                        if price >= max_buy_price:
-                            margin_label = (
-                                f", alvo < ${max_buy_price:,.2f} (margem {rebuy_margin_pct * 100:.2f}%)"
-                                if rebuy_margin_pct > 0 else ""
-                            )
-                            source_label = "IA" if rebuy_source == "ai" else "config"
-                            logger.info(
-                                f"🔒 REBUY blocked [{source_label}]: preço ${price:,.2f} >= "
-                                f"entrada da última venda ${last_sell:,.2f}{margin_label} — aguardando desconto"
-                            )
-                            return self._block_trade(
-                                "buy_rebuy_lock_last_sell",
-                                price=price,
-                                last_sell_entry_price=last_sell,
-                                rebuy_max_price=max_buy_price,
-                                rebuy_margin_pct=rebuy_margin_pct,
-                                rebuy_source=rebuy_source,
-                            )
-                except Exception:
-                    logger.debug("Erro ao aplicar rebuy lock; ignorando bloqueio")
+            try:
+                env = self._resolve_rebuy_envelope(rag_adj, controls)
+                if env["active"]:
+                    price = float(getattr(signal, "price", 0.0) or 0.0)
+                    if price >= env["ceiling"]:
+                        logger.info(
+                            f"🔒 REBUY blocked [{env['source']}]: preço ${price:,.2f} >= "
+                            f"teto ${env['ceiling']:,.2f} (venda ${env['last_sell']:,.2f} "
+                            f"há {env['elapsed_hours']:.1f}h, fase={env['phase']}, "
+                            f"margem IA {env['ai_margin_pct'] * 100:.2f}%)"
+                        )
+                        return self._block_trade(
+                            "buy_rebuy_lock_last_sell",
+                            price=price,
+                            last_sell_entry_price=env["last_sell"],
+                            rebuy_max_price=env["ceiling"],
+                            rebuy_envelope_ceiling=env["envelope_ceiling"],
+                            rebuy_margin_pct=env["ai_margin_pct"],
+                            rebuy_phase=env["phase"],
+                            rebuy_elapsed_hours=round(env["elapsed_hours"], 2),
+                            rebuy_source=env["source"],
+                        )
+            except Exception:
+                logger.debug("Erro ao aplicar rebuy envelope; ignorando bloqueio")
 
         if signal.action == "SELL":
             guardrail_sell = self._get_guardrail_sell_verdict(signal.price)
@@ -5213,6 +5288,7 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                     # REBUY lock: liberar após qualquer BUY confirmado na exchange.
                     if self.state.last_sell_entry_price > 0:
                         self.state.last_sell_entry_price = 0.0
+                        self.state.last_sell_ts = 0.0
                         logger.info("🔓 REBUY lock liberado após compra confirmada")
                     
                     logger.info(
@@ -5367,9 +5443,10 @@ class BitcoinTradingAgent(SellTargetMixin, RiskGuardianMixin, PositionManagerMix
                     
                     # Trava de recompra: salvar preço de entrada antes de zerar
                     self.state.last_sell_entry_price = self.state.entry_price
+                    self.state.last_sell_ts = time.time()
                     logger.info(
                         f"🔒 Rebuy lock set: next BUY only when price < "
-                        f"${self.state.entry_price:,.2f}"
+                        f"${self.state.entry_price:,.2f} (envelope: graça + decay)"
                     )
                     
                     self.state.position = 0

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-16T18:24:03.519343+00:00",
+  "generated_at": "2026-07-16T18:24:29.968872+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-07-16T18:24:29.968872+00:00",
+  "generated_at": "2026-07-16T18:24:51.611516+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 168,
+    "repo_services": 170,
     "trading_instances": 12,
     "critical_services": 66,
     "domains": {
@@ -15,7 +15,7 @@
       "network": 16,
       "operations": 93,
       "storage": 32,
-      "trading": 9
+      "trading": 11
     }
   },
   "trading_instances": [
@@ -1506,6 +1506,22 @@
       "domain": "trading",
       "kind": "systemd",
       "source": "systemd/kucoin-postgres-sync.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-15T01:43:27.593658+00:00",
+  "generated_at": "2026-07-16T18:23:22.632601+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 182,
+    "repo_services": 168,
     "trading_instances": 12,
-    "critical_services": 72,
+    "critical_services": 66,
     "domains": {
       "identity": 4,
-      "monitoring": 16,
-      "network": 20,
-      "operations": 101,
+      "monitoring": 14,
+      "network": 16,
+      "operations": 93,
       "storage": 32,
       "trading": 9
     }
@@ -286,14 +286,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "conube-exporter.service",
-      "domain": "monitoring",
-      "kind": "systemd",
-      "source": "tools/systemd/conube-exporter.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "eddie_central_extended_metrics.service",
       "domain": "monitoring",
       "kind": "systemd",
@@ -314,14 +306,6 @@
       "domain": "monitoring",
       "kind": "systemd",
       "source": "systemd/job-monitor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kwai-exporter.service",
-      "domain": "monitoring",
-      "kind": "systemd",
-      "source": "tools/systemd/kwai-exporter.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -370,38 +354,6 @@
       "domain": "network",
       "kind": "systemd",
       "source": "tools/tunnels/cloudflared-named@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-vpn-routes.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-vpn-routes.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-vpn-routes.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-vpn-routes.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -518,14 +470,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "freecash-browser",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.freecash-browser.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
       "name": "glpi",
       "domain": "operations",
       "kind": "compose",
@@ -538,14 +482,6 @@
       "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-browser",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.kwai-browser.yml",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -954,54 +890,6 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-balance-scrape.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-balance-scrape.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-balance-scrape.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-balance-scrape.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer-homelab.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer-homelab.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer-homelab.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer-homelab.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -1972,13 +1860,6 @@
         "critical": true
       },
       {
-        "name": "conube-exporter.service",
-        "domain": "monitoring",
-        "source": "tools/systemd/conube-exporter.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "eddie_central_extended_metrics.service",
         "domain": "monitoring",
         "source": "systemd/eddie_central_extended_metrics.service",
@@ -1996,13 +1877,6 @@
         "name": "job-monitor.service",
         "domain": "monitoring",
         "source": "systemd/job-monitor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kwai-exporter.service",
-        "domain": "monitoring",
-        "source": "tools/systemd/kwai-exporter.service",
         "kind": "systemd",
         "critical": true
       },
@@ -2045,34 +1919,6 @@
         "name": "cloudflared-named@.service",
         "domain": "network",
         "source": "tools/tunnels/cloudflared-named@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.service",
-        "domain": "network",
-        "source": "systemd/cloudflared-tunnel-guardian.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.timer",
-        "domain": "network",
-        "source": "systemd/cloudflared-tunnel-guardian.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-vpn-routes.service",
-        "domain": "network",
-        "source": "systemd/cloudflared-vpn-routes.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-vpn-routes.timer",
-        "domain": "network",
-        "source": "systemd/cloudflared-vpn-routes.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-16T18:23:22.632601+00:00",
+  "generated_at": "2026-07-16T18:24:03.519343+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,19 +1,19 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-15T01:43:27.593658+00:00`
+- Generated at: `2026-07-16T18:23:22.632601+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `182`
-- Critical services flagged for MVP: `72`
+- Repo services discovered: `168`
+- Critical services flagged for MVP: `66`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
 - `identity`: 4
-- `monitoring`: 16
-- `network`: 20
-- `operations`: 101
+- `monitoring`: 14
+- `network`: 16
+- `operations`: 93
 - `storage`: 32
 - `trading`: 9
 
@@ -49,21 +49,15 @@
 - `prometheus` (monitoring, compose) from `docker/docker-compose.grafana.yml`
 - `agent-network-exporter.service` (monitoring, systemd) from `tools/systemd/agent-network-exporter.service`
 - `banking-metrics-exporter.service` (monitoring, systemd) from `systemd/banking-metrics-exporter.service`
-- `conube-exporter.service` (monitoring, systemd) from `tools/systemd/conube-exporter.service`
 - `eddie_central_extended_metrics.service` (monitoring, systemd) from `systemd/eddie_central_extended_metrics.service`
 - `grafana-selfheal.service` (monitoring, systemd) from `systemd/grafana-selfheal.service`
 - `job-monitor.service` (monitoring, systemd) from `systemd/job-monitor.service`
-- `kwai-exporter.service` (monitoring, systemd) from `tools/systemd/kwai-exporter.service`
 - `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
 - `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
 - `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
 - `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
-- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
-- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
-- `cloudflared-vpn-routes.service` (network, systemd) from `systemd/cloudflared-vpn-routes.service`
-- `cloudflared-vpn-routes.timer` (network, systemd) from `systemd/cloudflared-vpn-routes.timer`
 - `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
 - `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
 - `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
@@ -78,6 +72,12 @@
 - `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
 - `rpa4all-vpn-ddns.service` (network, systemd) from `deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service`
 - `wireguard-nat.service` (network, systemd) from `deploy/vpn/wireguard-nat.service`
+- `disk-clean.service` (storage, systemd) from `systemd/disk-clean.service`
+- `disk-clean.timer` (storage, systemd) from `systemd/disk-clean.timer`
+- `disk-spindown.service` (storage, systemd) from `tools/homelab/disk-spindown.service`
+- `homelab-disk-backup.service` (storage, systemd) from `tools/backup/homelab-disk-backup.service`
+- `homelab-tape-log-drain-nextcloud.service` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.service`
+- `homelab-tape-log-drain-nextcloud.timer` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.timer`
 
 ## Serviços anotados manualmente
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-16T18:24:29.968872+00:00`
+- Generated at: `2026-07-16T18:24:51.611516+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `168`
+- Repo services discovered: `170`
 - Critical services flagged for MVP: `66`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -15,7 +15,7 @@
 - `network`: 16
 - `operations`: 93
 - `storage`: 32
-- `trading`: 9
+- `trading`: 11
 
 ## Trading profile instances (`12`)
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-16T18:23:22.632601+00:00`
+- Generated at: `2026-07-16T18:24:03.519343+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `168`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-16T18:24:03.519343+00:00`
+- Generated at: `2026-07-16T18:24:29.968872+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `168`

--- a/grafana/exporters/trading_selfheal_exporter.py
+++ b/grafana/exporters/trading_selfheal_exporter.py
@@ -355,19 +355,25 @@ class AgentHealthChecker:
         except Exception:
             return False
 
-    def get_last_decision_age(self, symbol: str) -> Optional[float]:
-        """Query PostgreSQL for time since last decision."""
+    def get_last_decision_age(self, symbol: str, profile: str = "") -> Optional[float]:
+        """Query PostgreSQL for time since last decision (por profile quando informado)."""
         try:
             self._ensure_pg_conn()
             if self._pg_conn is None:
                 return None
-            
+
             cur = self._pg_conn.cursor()
             cur.execute("SET search_path TO btc, public")
-            cur.execute(
-                "SELECT MAX(timestamp) FROM btc.decisions WHERE symbol=%s",
-                (symbol,)
-            )
+            if profile:
+                cur.execute(
+                    "SELECT MAX(timestamp) FROM btc.decisions WHERE symbol=%s AND profile=%s",
+                    (symbol, profile)
+                )
+            else:
+                cur.execute(
+                    "SELECT MAX(timestamp) FROM btc.decisions WHERE symbol=%s",
+                    (symbol,)
+                )
             result = cur.fetchone()
             if result and result[0]:
                 age = time.time() - float(result[0])
@@ -591,17 +597,27 @@ class AgentHealthChecker:
         else:
             checks.append(("process", False))
 
-        # 3. Stall detection (DB query + Ollama analysis)
+        # 3. Stall detection — GATE DETERMINÍSTICO primeiro, LLM só dentro dele.
+        # Decisões mais novas que STALL_THRESHOLD = saudável por definição; o
+        # Ollama nunca pode declarar stall abaixo do gate (fix 2026-07-16: o LLM
+        # fraco marcava stalled com decisões de 0s → 62 restarts/dia falsos).
         stalled = False
-        age = self.get_last_decision_age(agent.symbol)
+        age = self.get_last_decision_age(agent.symbol, getattr(agent, "profile", "") or "")
         if age is not None:
             state.last_decision_age = age
-            # Use Ollama for intelligent stall detection
-            conf, reasoning = analyze_stall_with_ollama(agent.metric_id, age, "")
-            state.ollama_stall_confidence = conf
-            state.ollama_reasoning = reasoning
-            stalled = conf > 0.7  # Stalled if confidence > 70%
-        
+            if age > STALL_THRESHOLD:
+                # Acima do gate: Ollama pode confirmar/vetar (indisponível = não stall)
+                conf, reasoning = analyze_stall_with_ollama(agent.metric_id, age, "")
+                state.ollama_stall_confidence = conf
+                state.ollama_reasoning = reasoning
+                stalled = conf > 0.7  # Stalled if confidence > 70%
+            else:
+                state.ollama_stall_confidence = 0.0
+                state.ollama_reasoning = (
+                    f"decisões frescas ({age:.0f}s <= {STALL_THRESHOLD}s) — "
+                    "saudável por gate determinístico, LLM não consultado"
+                )
+
         state.stalled = stalled
         checks.append(("stalled", not stalled))
 

--- a/scripts/rebalance_kucoin_trading_capital.py
+++ b/scripts/rebalance_kucoin_trading_capital.py
@@ -2,9 +2,13 @@
 """Remaneja USDT entre master TRADE e subcontas KuCoin para a frota operar.
 
 Política:
-- Subcontas (BTC/ETH live): manter TARGET_SUB_USDT cada (~$22-25).
-- Master TRADE (shadows BTC/ETH + SOL×3): concentrar o excedente das subs.
-- ETHAgressive recebe top-up se estiver abaixo do mínimo.
+- Subcontas (BTC/ETH live) abaixo de MIN_SUB_USDT recebem top-up até
+  TARGET_SUB_USDT, priorizando a subconta com menor saldo primeiro.
+- Master TRADE (shadows BTC/ETH + SOL×3): concentra o excedente das subs
+  acima de TARGET_SUB_USDT, e nunca é drenado abaixo de MASTER_MIN_RESERVE_USDT.
+- Cada execução move no máximo MAX_TRANSFER_TOTAL_PER_RUN_USDT — convergência
+  gradual ao longo de várias rodadas (pensado para rodar via timer systemd),
+  não um salto único.
 
 Uso:
     python3 scripts/rebalance_kucoin_trading_capital.py --dry-run
@@ -26,9 +30,10 @@ for p in (ROOT, AGENT_DIR, Path("/apps/crypto-trader/trading/btc_trading_agent")
 
 import kucoin_api as k  # noqa: E402
 
-TARGET_SUB_USDT = 23.0
-MIN_SUB_USDT = 18.0
-SUB_TOPUP_FROM_MASTER = 5.0
+TARGET_SUB_USDT = 30.0
+MIN_SUB_USDT = 25.0
+MASTER_MIN_RESERVE_USDT = 20.0
+MAX_TRANSFER_TOTAL_PER_RUN_USDT = 15.0
 
 # userId interno (GET /api/v2/sub/user) — não usar uid da UI
 SUB_USER_IDS = {
@@ -64,21 +69,11 @@ def _sub_trade_usdt() -> dict[str, float]:
 
 def build_plan() -> list[TransferPlan]:
     subs = _sub_trade_usdt()
+    master = _master_trade_usdt()
     plans: list[TransferPlan] = []
 
-    # 1) Top-up subcontas abaixo do mínimo (via master, depois das coletas)
-    eth_agg = subs.get("ETHAgressive", 0.0)
-    if eth_agg < MIN_SUB_USDT:
-        plans.append(
-            TransferPlan(
-                "OUT",
-                "ETHAgressive",
-                round(min(SUB_TOPUP_FROM_MASTER, TARGET_SUB_USDT - eth_agg), 2),
-                f"ETHAgressive abaixo do mínimo ({eth_agg:.2f} < {MIN_SUB_USDT})",
-            )
-        )
-
-    # 2) Sweep excedente das subs para master TRADE
+    # 1) Sweep excedente das subs para master TRADE (não consome orçamento
+    #    de OUT — na prática essas coletas acontecem antes dos desembolsos)
     for name, avail in sorted(subs.items()):
         if avail <= TARGET_SUB_USDT:
             continue
@@ -92,6 +87,32 @@ def build_plan() -> list[TransferPlan]:
                     f"excedente acima de ${TARGET_SUB_USDT:.0f} (avail=${avail:.2f})",
                 )
             )
+            master += excess
+
+    # 2) Top-up das subcontas abaixo do mínimo, priorizando a mais baixa
+    #    primeiro, respeitando a reserva mínima do master e o teto de
+    #    transferência por execução.
+    budget = round(min(MAX_TRANSFER_TOTAL_PER_RUN_USDT, master - MASTER_MIN_RESERVE_USDT), 2)
+    if budget > 0:
+        needy = sorted(
+            ((name, avail) for name, avail in subs.items() if avail < MIN_SUB_USDT),
+            key=lambda item: item[1],
+        )
+        for name, avail in needy:
+            if budget <= 0:
+                break
+            amount = round(min(TARGET_SUB_USDT - avail, budget), 2)
+            if amount < 1.0:
+                continue
+            plans.append(
+                TransferPlan(
+                    "OUT",
+                    name,
+                    amount,
+                    f"{name} abaixo do mínimo ({avail:.2f} < {MIN_SUB_USDT})",
+                )
+            )
+            budget = round(budget - amount, 2)
 
     # Executar coletas (IN) antes de desembolsos (OUT) na prática
     plans.sort(key=lambda p: (0 if p.direction == "IN" else 1, p.sub_name))

--- a/systemd/kucoin-usdt-rebalance.service
+++ b/systemd/kucoin-usdt-rebalance.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=KuCoin — rebalanceia USDT entre master TRADE e subcontas (one-shot)
+After=network.target secrets_agent.service
+Wants=secrets_agent.service
+
+[Service]
+Type=oneshot
+User=btc-trading
+Group=btc-trading
+WorkingDirectory=/apps/crypto-trader/trading
+
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PYTHONUNBUFFERED=1
+Environment=BTC_AGENT_DIR=/apps/crypto-trader/trading/btc_trading_agent
+EnvironmentFile=/etc/crypto-agent/secrets-api.env
+
+ExecStart=/usr/bin/python3 /apps/crypto-trader/trading/scripts/rebalance_kucoin_trading_capital.py --execute
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=kucoin-usdt-rebalance
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/apps/crypto-trader

--- a/systemd/kucoin-usdt-rebalance.timer
+++ b/systemd/kucoin-usdt-rebalance.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=KuCoin USDT rebalance — a cada hora
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+Unit=kucoin-usdt-rebalance.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_exporter_rebuy_envelope.py
+++ b/tests/test_exporter_rebuy_envelope.py
@@ -1,0 +1,82 @@
+"""Métricas btc_rebuy_envelope_* no prometheus_exporter (2026-07-16).
+
+O exporter espelha o último bloqueio de rebuy anotado pelo agente em
+decisions.features (janela 30 min) — sem duplicar a matemática do envelope.
+"""
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock psycopg2/secrets antes de importar o módulo (padrão do repo)
+sys.modules.setdefault("psycopg2", MagicMock())
+secrets_mock = types.ModuleType("secrets_helper")
+secrets_mock.get_database_url = lambda: "postgresql://mock/mock"
+sys.modules.setdefault("secrets_helper", secrets_mock)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "btc_trading_agent"))
+
+import prometheus_exporter  # noqa: E402
+
+
+def _collector(symbol="BTC-USDT", profile="aggressive"):
+    with patch.object(prometheus_exporter, "load_config", return_value={}):
+        c = prometheus_exporter.MetricsCollector.__new__(prometheus_exporter.MetricsCollector)
+    c.symbol = symbol
+    c.profile = profile
+    c.dsn = "postgresql://mock"
+    return c
+
+
+def test_envelope_metrics_from_latest_block_annotation():
+    c = _collector()
+    cur = MagicMock()
+    now = time.time()
+    cur.fetchone.return_value = ("decay", "63500.50", "64100.00", "6.25", now - 120)
+
+    out = c._collect_rebuy_envelope(cur)
+
+    assert out["rebuy_envelope_phase"] == 2
+    assert out["rebuy_envelope_ceiling"] == 63500.50
+    assert out["rebuy_envelope_raw_ceiling"] == 64100.00
+    assert out["rebuy_envelope_elapsed_hours"] == 6.25
+    assert 100 < out["rebuy_envelope_block_age_seconds"] < 140
+    # Query filtra por symbol+profile e pelo block_reason do envelope
+    sql = cur.execute.call_args.args[0]
+    assert "buy_rebuy_lock_last_sell" in sql
+    assert cur.execute.call_args.args[1] == ("BTC-USDT", "aggressive")
+
+
+def test_envelope_metrics_zero_when_no_recent_block():
+    c = _collector()
+    cur = MagicMock()
+    cur.fetchone.return_value = None
+
+    out = c._collect_rebuy_envelope(cur)
+
+    assert out["rebuy_envelope_phase"] == 0
+    assert out["rebuy_envelope_ceiling"] == 0.0
+    assert out["rebuy_envelope_block_age_seconds"] == 0.0
+
+
+def test_envelope_metrics_grace_phase_and_bad_values_are_safe():
+    c = _collector()
+    cur = MagicMock()
+    cur.fetchone.return_value = ("grace", None, None, None, None)
+
+    out = c._collect_rebuy_envelope(cur)
+
+    assert out["rebuy_envelope_phase"] == 1
+    assert out["rebuy_envelope_ceiling"] == 0.0
+    assert out["rebuy_envelope_elapsed_hours"] == 0.0
+
+
+def test_envelope_metrics_never_raise_on_db_error():
+    c = _collector()
+    cur = MagicMock()
+    cur.execute.side_effect = RuntimeError("db down")
+
+    out = c._collect_rebuy_envelope(cur)
+
+    assert out["rebuy_envelope_phase"] == 0  # falha → defaults, sem exceção

--- a/tests/test_rebalance_kucoin_trading_capital.py
+++ b/tests/test_rebalance_kucoin_trading_capital.py
@@ -1,0 +1,179 @@
+"""Testes unitários para rebalance_kucoin_trading_capital — build_plan() e main()."""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("kucoin_api", MagicMock())
+
+SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent / "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import rebalance_kucoin_trading_capital as rebalance  # noqa: E402
+
+
+def _set_balances(monkeypatch, master_usdt, subs_usdt):
+    """subs_usdt: dict sub_name -> saldo USDT disponível na conta trade."""
+    def fake_get_balances(account_type="trade"):
+        assert account_type == "trade"
+        return [{"currency": "USDT", "available": master_usdt}]
+
+    def fake_get_sub_account_balances():
+        return [
+            {"sub_name": name, "account_type": "trade", "currency": "USDT", "available": avail}
+            for name, avail in subs_usdt.items()
+        ]
+
+    monkeypatch.setattr(rebalance.k, "get_balances", fake_get_balances)
+    monkeypatch.setattr(rebalance.k, "get_sub_account_balances", fake_get_sub_account_balances)
+
+
+class TestBuildPlanTopUp:
+    def test_prioritizes_lowest_sub_when_budget_insufficient(self, monkeypatch):
+        """Master só tem orçamento pra uma subconta — deve escolher a mais baixa.
+
+        BTCConservative/ETHConservative ficam exatamente na meta (sem excedente),
+        pra não disparar sweep e inflar o orçamento no meio do teste.
+        """
+        _set_balances(
+            monkeypatch,
+            master_usdt=rebalance.MASTER_MIN_RESERVE_USDT + 6.0,  # orçamento = 6.0
+            subs_usdt={
+                "BTCAgressive": 23.07,   # mais baixa
+                "ETHAgressive": 23.45,
+                "BTCConservative": rebalance.TARGET_SUB_USDT,
+                "ETHConservative": rebalance.TARGET_SUB_USDT,
+            },
+        )
+
+        plans = rebalance.build_plan()
+        out_plans = [p for p in plans if p.direction == "OUT"]
+
+        assert len(out_plans) == 1
+        assert out_plans[0].sub_name == "BTCAgressive"
+        assert out_plans[0].amount == pytest.approx(6.0)
+
+    def test_never_drains_master_below_reserve(self, monkeypatch):
+        """Nenhum plano deve deixar o master abaixo de MASTER_MIN_RESERVE_USDT."""
+        master_usdt = rebalance.MASTER_MIN_RESERVE_USDT + 3.0
+        _set_balances(
+            monkeypatch,
+            master_usdt=master_usdt,
+            subs_usdt={"BTCAgressive": 20.0, "ETHAgressive": 20.0},
+        )
+
+        plans = rebalance.build_plan()
+        total_out = sum(p.amount for p in plans if p.direction == "OUT")
+
+        assert master_usdt - total_out >= rebalance.MASTER_MIN_RESERVE_USDT
+
+    def test_respects_max_transfer_per_run(self, monkeypatch):
+        """Mesmo com master rico, o total de OUT não passa do teto por execução."""
+        _set_balances(
+            monkeypatch,
+            master_usdt=1000.0,
+            subs_usdt={
+                "BTCAgressive": 1.0,
+                "ETHAgressive": 1.0,
+                "BTCConservative": 1.0,
+                "ETHConservative": 1.0,
+            },
+        )
+
+        plans = rebalance.build_plan()
+        total_out = sum(p.amount for p in plans if p.direction == "OUT")
+
+        assert total_out <= rebalance.MAX_TRANSFER_TOTAL_PER_RUN_USDT
+
+    def test_no_topup_when_all_subs_above_minimum(self, monkeypatch):
+        _set_balances(
+            monkeypatch,
+            master_usdt=100.0,
+            subs_usdt={"BTCAgressive": 30.0, "ETHAgressive": 30.0},
+        )
+
+        plans = rebalance.build_plan()
+
+        assert not [p for p in plans if p.direction == "OUT"]
+
+
+class TestBuildPlanSweep:
+    def test_sweeps_excess_above_target_to_master(self, monkeypatch):
+        _set_balances(
+            monkeypatch,
+            master_usdt=50.0,
+            subs_usdt={"BTCConservative": 40.0, "ETHConservative": 30.0},
+        )
+
+        plans = rebalance.build_plan()
+        in_plans = {p.sub_name: p.amount for p in plans if p.direction == "IN"}
+
+        assert in_plans["BTCConservative"] == pytest.approx(40.0 - rebalance.TARGET_SUB_USDT)
+        assert "ETHConservative" not in in_plans  # exatamente na meta, sem excedente
+
+
+class TestMainExecute:
+    def test_execute_calls_sub_transfer_with_expected_args(self, monkeypatch, capsys):
+        _set_balances(
+            monkeypatch,
+            master_usdt=rebalance.MASTER_MIN_RESERVE_USDT + 10.0,
+            subs_usdt={"BTCAgressive": 20.0, "ETHAgressive": 30.0},
+        )
+        calls = []
+
+        def fake_sub_transfer(currency, amount, sub_user_id, direction, account_type, sub_account_type):
+            calls.append(dict(
+                currency=currency, amount=amount, sub_user_id=sub_user_id,
+                direction=direction, account_type=account_type, sub_account_type=sub_account_type,
+            ))
+            return {"success": True, "orderId": "fake-order"}
+
+        monkeypatch.setattr(rebalance.k, "sub_transfer", fake_sub_transfer)
+        monkeypatch.setattr(sys, "argv", ["rebalance_kucoin_trading_capital.py", "--execute"])
+
+        exit_code = rebalance.main()
+
+        assert exit_code == 0
+        assert len(calls) == 1
+        assert calls[0]["currency"] == "USDT"
+        assert calls[0]["direction"] == "OUT"
+        assert calls[0]["sub_user_id"] == rebalance.SUB_USER_IDS["BTCAgressive"]
+        assert calls[0]["account_type"] == "TRADE"
+        assert calls[0]["sub_account_type"] == "TRADE"
+
+    def test_execute_stops_on_first_failure(self, monkeypatch):
+        _set_balances(
+            monkeypatch,
+            master_usdt=1000.0,
+            subs_usdt={"BTCAgressive": 1.0, "ETHAgressive": 1.0},
+        )
+        calls = []
+
+        def failing_sub_transfer(currency, amount, sub_user_id, direction, account_type, sub_account_type):
+            calls.append(sub_user_id)
+            return {"success": False, "error": "boom"}
+
+        monkeypatch.setattr(rebalance.k, "sub_transfer", failing_sub_transfer)
+        monkeypatch.setattr(sys, "argv", ["rebalance_kucoin_trading_capital.py", "--execute"])
+
+        exit_code = rebalance.main()
+
+        assert exit_code == 1
+        assert len(calls) == 1  # abortou após a primeira falha, não seguiu pras próximas
+
+    def test_dry_run_does_not_call_sub_transfer(self, monkeypatch):
+        _set_balances(
+            monkeypatch,
+            master_usdt=rebalance.MASTER_MIN_RESERVE_USDT + 10.0,
+            subs_usdt={"BTCAgressive": 20.0},
+        )
+        mock_sub_transfer = MagicMock()
+        monkeypatch.setattr(rebalance.k, "sub_transfer", mock_sub_transfer)
+        monkeypatch.setattr(sys, "argv", ["rebalance_kucoin_trading_capital.py"])
+
+        exit_code = rebalance.main()
+
+        assert exit_code == 0
+        mock_sub_transfer.assert_not_called()

--- a/tests/test_rebuy_lock_enforcement.py
+++ b/tests/test_rebuy_lock_enforcement.py
@@ -2,9 +2,18 @@
 """Testes — lógica BUY vs REBUY vs DCA:
 
   BUY  (position=0, sem histórico de venda): livre, segue regras de mercado
-  REBUY (position=0, após fechar posição):   bloqueado se preço >= entrada da última venda
+  REBUY (position=0, após fechar posição):   bloqueado se preço >= teto do envelope
   DCA  (position>0, adicionando slot):       não tem rebuy lock; segue valley bounce
+
+Envelope determinístico (2026-07-16): o REBUY lock é um envelope mecânico
+sempre ativo — fase grace (teto = last_sell), fase decay (teto sobe
+decay_pct_per_hour) e expiração (max_premium_pct). A IA só pode APERTAR o
+teto (ai_rebuy_margin_pct); falha da IA ou rebuy_lock_enabled=false no
+config NUNCA desligam o envelope (fix do incidente "falha da IA = falha do
+freio"). Contrato antigo em que ai_rebuy_lock_enabled=False liberava a
+recompra foi intencionalmente invertido.
 """
+import time
 from types import SimpleNamespace
 import sys
 from pathlib import Path
@@ -40,11 +49,17 @@ def _make_agent(
     ai_rebuy_margin_pct=0.0,
     ai_controlled=False,
     rebuy_lock_enabled=None,
+    last_sell_age_hours=0.0,
+    rebuy_envelope=None,
 ):
     agent = BitcoinTradingAgent.__new__(BitcoinTradingAgent)
     agent.symbol = "BTC-USDT"
     agent.state = SimpleNamespace(
         last_sell_entry_price=last_sell_entry_price,
+        last_sell_ts=(
+            time.time() - last_sell_age_hours * 3600.0
+            if last_sell_entry_price > 0 else 0.0
+        ),
         position=position,
         entry_price=entry_price,
         last_trade_time=0.0,
@@ -88,6 +103,8 @@ def _make_agent(
     cfg = {}
     if rebuy_lock_enabled is not None:
         cfg["rebuy_lock_enabled"] = rebuy_lock_enabled
+    if rebuy_envelope is not None:
+        cfg["rebuy_envelope"] = rebuy_envelope
     agent._load_live_config = lambda: cfg
     agent._current_profile = lambda: "default"
     agent._sync_target_sell_with_ai = lambda reason_prefix="IA": None
@@ -196,14 +213,18 @@ def test_ai_rebuy_blocks_when_config_disabled_but_rag_enabled():
 
 
 def test_ai_rebuy_margin_requires_deeper_discount():
-    """Margem IA exige preço abaixo de last_sell * (1 - margin_pct)."""
+    """Margem IA exige preço abaixo de last_sell * (1 - margin_pct).
+
+    Novo contrato: a margem da IA só se aplica com rebuy_lock_enabled=True
+    (config false desliga apenas a margem — ver
+    test_config_disabled_only_strips_ai_margin)."""
     agent = _make_agent(
         position=0.0,
         last_sell_entry_price=70000.0,
         ai_rebuy_lock_enabled=True,
         ai_rebuy_margin_pct=0.01,
         ai_controlled=True,
-        rebuy_lock_enabled=False,
+        rebuy_lock_enabled=True,
     )
     # 70000 * 0.99 = 69300 — abaixo disso permitido
     sig_block = SimpleNamespace(action="BUY", price=69500.0, confidence=0.9, reason="unit")
@@ -214,8 +235,10 @@ def test_ai_rebuy_margin_requires_deeper_discount():
     assert agent._check_can_trade(sig_ok) is True
 
 
-def test_ai_rebuy_off_allows_reentry_when_config_disabled():
-    """Sem IA nem config, reentrada após venda é livre."""
+def test_envelope_blocks_in_grace_even_with_ai_off_and_config_off():
+    """CONTRATO INVERTIDO (fix do incidente): BULLISH (ai_rebuy_lock_enabled=False)
+    + config desligado NÃO liberam mais a recompra durante a graça — o envelope
+    mecânico continua valendo."""
     agent = _make_agent(
         position=0.0,
         last_sell_entry_price=70000.0,
@@ -224,4 +247,124 @@ def test_ai_rebuy_off_allows_reentry_when_config_disabled():
         rebuy_lock_enabled=False,
     )
     sig = SimpleNamespace(action="BUY", price=71000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is False
+    assert agent.state.last_trade_block_reason == "buy_rebuy_lock_last_sell"
+
+
+# ── Envelope determinístico: grace → decay → expired ─────────────────────────
+
+def test_envelope_blocks_when_ai_cold_and_config_disabled():
+    """Regressão do incidente 'falha da IA = falha do freio': IA fria
+    (ai_controlled=False) + rebuy_lock_enabled=false → envelope ainda bloqueia."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        ai_controlled=False,
+        rebuy_lock_enabled=False,
+    )
+    sig = SimpleNamespace(action="BUY", price=70000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is False
+    assert agent.state.last_trade_block_reason == "buy_rebuy_lock_last_sell"
+    assert agent.state.last_trade_block_context["rebuy_phase"] == "grace"
+
+
+def test_envelope_decay_raises_ceiling():
+    """Após a graça o teto sobe decay_pct_per_hour: 6h de idade, graça 2h,
+    0.25%/h → prêmio 1%. Preço +0.5% permitido; +1.5% bloqueado."""
+    kwargs = dict(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        last_sell_age_hours=6.0,
+        rebuy_envelope={"grace_hours": 2, "decay_pct_per_hour": 0.25, "max_premium_pct": 5.0},
+    )
+    agent = _make_agent(**kwargs)
+    sig_ok = SimpleNamespace(action="BUY", price=70000.0 * 1.005, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig_ok) is True
+
+    agent = _make_agent(**kwargs)
+    sig_block = SimpleNamespace(action="BUY", price=70000.0 * 1.015, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig_block) is False
+    assert agent.state.last_trade_block_reason == "buy_rebuy_lock_last_sell"
+    assert agent.state.last_trade_block_context["rebuy_phase"] == "decay"
+
+
+def test_envelope_expires_after_max_premium():
+    """Idade 23h (graça 2h + 21h×0.25%/h = 5.25% ≥ 5%): envelope expira,
+    BUY permitido e lock limpo do estado."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        last_sell_age_hours=23.0,
+    )
+    sig = SimpleNamespace(action="BUY", price=75000.0, confidence=0.9, reason="unit")
     assert agent._check_can_trade(sig) is True
+    assert agent.state.last_sell_entry_price == 0.0
+    assert agent.state.last_sell_ts == 0.0
+
+
+def test_ai_margin_tightens_within_decay_envelope():
+    """Margem da IA aperta o teto decaído: 6h → envelope +1%; margem 1% →
+    teto efetivo = last_sell×1.01×0.99. Preço entre os dois tetos: bloqueado."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        last_sell_age_hours=6.0,
+        ai_rebuy_lock_enabled=True,
+        ai_rebuy_margin_pct=0.01,
+        ai_controlled=True,
+        rebuy_lock_enabled=True,
+    )
+    envelope_ceiling = 70000.0 * 1.01          # 70700
+    effective = envelope_ceiling * 0.99        # 69993
+    between = (effective + envelope_ceiling) / 2
+    sig = SimpleNamespace(action="BUY", price=between, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is False
+    assert agent.state.last_trade_block_reason == "buy_rebuy_lock_last_sell"
+    assert agent.state.last_trade_block_context["rebuy_margin_pct"] == 0.01
+
+
+def test_config_disabled_only_strips_ai_margin():
+    """rebuy_lock_enabled=false remove apenas a margem da IA — o envelope fica.
+    Na graça: preço == last_sell bloqueado; preço 0.5% abaixo permitido
+    (a margem de 1% da IA teria bloqueado, mas foi desligada pelo config)."""
+    kwargs = dict(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        ai_rebuy_lock_enabled=True,
+        ai_rebuy_margin_pct=0.01,
+        ai_controlled=True,
+        rebuy_lock_enabled=False,
+    )
+    agent = _make_agent(**kwargs)
+    sig_block = SimpleNamespace(action="BUY", price=70000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig_block) is False
+
+    agent = _make_agent(**kwargs)
+    sig_ok = SimpleNamespace(action="BUY", price=70000.0 * 0.995, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig_ok) is True
+
+
+def test_missing_ts_self_heals_to_grace():
+    """Estado legado (last_sell_entry_price>0 sem last_sell_ts): self-heal —
+    assume 'agora' como âncora (graça) e bloqueia."""
+    agent = _make_agent(position=0.0, last_sell_entry_price=70000.0)
+    agent.state.last_sell_ts = 0.0  # simula estado antigo sem âncora
+    sig = SimpleNamespace(action="BUY", price=70000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is False
+    assert agent.state.last_sell_ts > 0  # âncora self-healed
+
+
+def test_block_context_reports_phase_and_ceiling():
+    """Contexto do bloqueio (→ decisions.features) carrega fase, teto e idade."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        last_sell_age_hours=6.0,
+    )
+    sig = SimpleNamespace(action="BUY", price=72000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is False
+    ctx = agent.state.last_trade_block_context
+    assert ctx["rebuy_phase"] == "decay"
+    assert ctx["rebuy_max_price"] > 70000.0            # teto decaído acima do last_sell
+    assert ctx["rebuy_envelope_ceiling"] >= ctx["rebuy_max_price"]
+    assert 5.5 < ctx["rebuy_elapsed_hours"] < 6.5

--- a/tests/test_selfheal_stall_gate.py
+++ b/tests/test_selfheal_stall_gate.py
@@ -1,0 +1,116 @@
+"""Gate determinístico de stall no trading_selfheal_exporter (fix 2026-07-16).
+
+O LLM (Ollama) só pode ser consultado quando a idade da última decisão excede
+STALL_THRESHOLD; abaixo do gate, o agente é saudável por definição — o LLM
+fraco marcava stalled com decisões frescas (62 restarts falsos/dia no USDT-BRL).
+"""
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def load_module():
+    os.environ.setdefault("DATABASE_URL", "postgresql://localhost:5432/btc_trading")
+    sys.modules.setdefault("psycopg2", types.SimpleNamespace(connect=lambda *_a, **_k: None))
+    path = Path(__file__).resolve().parents[1] / "grafana" / "exporters" / "trading_selfheal_exporter.py"
+    spec = importlib.util.spec_from_file_location("trading_selfheal_stall_gate_test", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_checker(mod, age_seconds, ollama_calls):
+    agent = mod.TradingAgentDef(
+        symbol="USDT-BRL",
+        profile="aggressive",
+        systemd_unit="crypto-agent@USDT_BRL_aggressive",
+        exporter_port=9120,
+        config_file="config_USDT_BRL_aggressive.json",
+        expected_process="trading_agent.py.*USDT_BRL_aggressive",
+    )
+    checker = mod.AgentHealthChecker([agent], pg_dsn="postgresql://mock")
+    checker.check_systemd_active = lambda unit: True
+    checker.check_process = lambda pattern: True
+    checker.check_runtime_integrity = lambda a, s: True
+    checker.get_block_reason_coverage = lambda a, minutes=15: 1.0
+    checker.get_last_decision_age = lambda symbol, profile="": age_seconds
+
+    def fake_ollama(metric_id, age, reasons):
+        ollama_calls.append((metric_id, age))
+        return (0.95, "LLM alucinando stalled")  # pior caso: LLM sempre diz stalled
+
+    mod.analyze_stall_with_ollama = fake_ollama
+    return checker, agent.metric_id
+
+
+def test_fresh_decisions_never_consult_llm_and_stay_healthy():
+    """Idade abaixo do gate: LLM NÃO é chamado e o agente é saudável,
+    mesmo que o LLM (se consultado) dissesse stalled com 95%."""
+    mod = load_module()
+    calls = []
+    checker, agent_id = _make_checker(mod, age_seconds=30.0, ollama_calls=calls)
+
+    healthy = checker.check_agent(agent_id)
+
+    assert healthy is True
+    assert calls == []  # gate determinístico: LLM nunca consultado
+    state = checker.states[agent_id]
+    assert state.stalled is False
+    assert state.ollama_stall_confidence == 0.0
+    assert "determinístico" in state.ollama_reasoning
+
+
+def test_stale_decisions_consult_llm_beyond_gate():
+    """Idade acima do gate: LLM é consultado e pode confirmar o stall."""
+    mod = load_module()
+    calls = []
+    age = mod.STALL_THRESHOLD + 600
+    checker, agent_id = _make_checker(mod, age_seconds=age, ollama_calls=calls)
+
+    healthy = checker.check_agent(agent_id)
+
+    assert healthy is False
+    assert len(calls) == 1 and calls[0][1] == age
+    assert checker.states[agent_id].stalled is True
+
+
+def test_age_exactly_at_threshold_is_healthy():
+    """Idade == threshold não passa do gate (> estrito)."""
+    mod = load_module()
+    calls = []
+    checker, agent_id = _make_checker(
+        mod, age_seconds=float(mod.STALL_THRESHOLD), ollama_calls=calls)
+
+    assert checker.check_agent(agent_id) is True
+    assert calls == []
+
+
+def test_decision_age_query_uses_profile_filter():
+    """get_last_decision_age filtra por profile quando o agente tem um."""
+    mod = load_module()
+    agent = mod.TradingAgentDef(
+        symbol="USDT-BRL",
+        profile="conservative",
+        systemd_unit="crypto-agent@USDT_BRL_conservative",
+        exporter_port=9121,
+        config_file="config_USDT_BRL_conservative.json",
+        expected_process="trading_agent.py.*USDT_BRL_conservative",
+    )
+    checker = mod.AgentHealthChecker([agent], pg_dsn="postgresql://mock")
+    cur = MagicMock()
+    cur.fetchone.return_value = (1000.0,)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    conn.closed = False
+    checker._pg_conn = conn
+    checker._ensure_pg_conn = lambda: None
+
+    checker.get_last_decision_age("USDT-BRL", "conservative")
+
+    executed_sql = " ".join(str(c.args[0]) for c in cur.execute.call_args_list)
+    assert "profile=%s" in executed_sql


### PR DESCRIPTION
## Resumo
- **REBUY lock → envelope determinístico**: corrige o incidente "falha da IA = falha do freio" (RAG frio + `rebuy_lock_enabled=false` desligava o freio). Fases grace (2h) → decay (+0.25%/h) → expired (+5%); IA só aperta o teto, nunca solta. `min_trade_amount` 10→15 nos 4 perfis live.
- **Selfheal com gate determinístico**: LLM só é consultado quando a idade da última decisão excede o threshold (1800s) — elimina 62 restarts falsos/dia no USDT-BRL; query de idade agora filtra por profile.
- **Métricas Prometheus** `btc_rebuy_envelope_*` (fase/teto/idade) espelhadas de `decisions.features`.
- **Rebalance automático** de USDT master↔subcontas via timer horário com reserva mínima e teto por execução.

## Testes
- `test_rebuy_lock_enforcement.py`: 18/18 (contrato invertido documentado + 7 cenários novos)
- `test_selfheal_stall_gate.py`: 4/4 · `test_exporter_rebuy_envelope.py`: 4/4 · `test_rebalance_kucoin_trading_capital.py`: 8/8

## Produção
Já deployado manualmente no homelab e verificado: 14/14 agentes com envelope ativo (3 locks presos de 48-63h expiraram no primeiro sinal BUY), selfheal sem falsos positivos desde o fix, métricas expostas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)