### PR TITLE
fix(selfheal): remove referência órfã st_script

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-17T01:03:12.975165+00:00",
+  "generated_at": "2026-07-17T01:11:15.562281+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/ba6e0dc2-8033-402c-aa0b-e458fb4b91b1/scratchpad/tuya-selfheal",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-17T01:03:12.975165+00:00`
+- Generated at: `2026-07-17T01:11:15.562281+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `172`

--- a/tools/homelab/tuya_token_selfheal.py
+++ b/tools/homelab/tuya_token_selfheal.py
@@ -194,7 +194,6 @@ def ha_tuya_status() -> dict:
             for eid in entity_ids
             if states.get(eid) not in (None, "unavailable", "unknown")
         )
-        _ = st_script  # mantido só para documentar a origem da técnica
     else:
         status["entities_total"] = 0
         status["entities_active"] = 0


### PR DESCRIPTION
Smoke test do deploy-tuya-token-selfheal pegou um NameError: linha morta `_ = st_script` sobrou de uma limpeza no PR #219. Uma linha removida; `py_compile` + 13 testes OK. Após merge, o workflow de deploy re-executa e o smoke test valida no homelab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)