### PR TITLE
fix(tunnel): encerra restart-loop do guardian que causava 1033 no Grafana

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,18 +1,18 @@
 {
-  "generated_at": "2026-07-17T01:20:27.409352+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/ba6e0dc2-8033-402c-aa0b-e458fb4b91b1/scratchpad/tuya-selfheal",
+  "generated_at": "2026-07-17T10:58:22.115228+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/ba6e0dc2-8033-402c-aa0b-e458fb4b91b1/scratchpad/cf-guardian",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 172,
+    "repo_services": 174,
     "trading_instances": 12,
-    "critical_services": 66,
+    "critical_services": 68,
     "domains": {
       "identity": 4,
       "monitoring": 14,
-      "network": 16,
+      "network": 18,
       "operations": 95,
       "storage": 32,
       "trading": 11
@@ -354,6 +354,22 @@
       "domain": "network",
       "kind": "systemd",
       "source": "tools/tunnels/cloudflared-named@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared-tunnel-guardian.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/cloudflared-tunnel-guardian.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared-tunnel-guardian.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/cloudflared-tunnel-guardian.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1951,6 +1967,20 @@
         "name": "cloudflared-named@.service",
         "domain": "network",
         "source": "tools/tunnels/cloudflared-named@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "cloudflared-tunnel-guardian.service",
+        "domain": "network",
+        "source": "systemd/cloudflared-tunnel-guardian.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "cloudflared-tunnel-guardian.timer",
+        "domain": "network",
+        "source": "systemd/cloudflared-tunnel-guardian.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-17T01:20:27.409352+00:00`
+- Generated at: `2026-07-17T10:58:22.115228+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `172`
-- Critical services flagged for MVP: `66`
+- Repo services discovered: `174`
+- Critical services flagged for MVP: `68`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,7 +12,7 @@
 
 - `identity`: 4
 - `monitoring`: 14
-- `network`: 16
+- `network`: 18
 - `operations`: 95
 - `storage`: 32
 - `trading`: 11
@@ -58,6 +58,8 @@
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
 - `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
+- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
+- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
 - `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
 - `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
 - `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
@@ -76,8 +78,6 @@
 - `disk-clean.timer` (storage, systemd) from `systemd/disk-clean.timer`
 - `disk-spindown.service` (storage, systemd) from `tools/homelab/disk-spindown.service`
 - `homelab-disk-backup.service` (storage, systemd) from `tools/backup/homelab-disk-backup.service`
-- `homelab-tape-log-drain-nextcloud.service` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.service`
-- `homelab-tape-log-drain-nextcloud.timer` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.timer`
 
 ## Serviços anotados manualmente
 

--- a/deploy/vpn/cloudflared-tunnel-guardian.sh
+++ b/deploy/vpn/cloudflared-tunnel-guardian.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# End-to-end guardian: WAN routes + cloudflared tunnel + Grafana origin.
+# Conservative restarts — evita loop que causa 1033/502.
+set -euo pipefail
+
+GRAFANA_URL="${GRAFANA_URL:-http://127.0.0.1:3002}"
+GRAFANA_CONTAINER="${GRAFANA_CONTAINER:-grafana}"
+CF_READY_URL="${CF_READY_URL:-http://127.0.0.1:20241/ready}"
+CF_SERVICE="${CF_SERVICE:-cloudflared-rpa4all.service}"
+ROUTES_SCRIPT="${ROUTES_SCRIPT:-/usr/local/sbin/cloudflared-vpn-routes.sh}"
+STATE_DIR="${STATE_DIR:-/var/lib/cloudflared-tunnel-guardian}"
+LOG_TAG="cloudflared-tunnel-guardian"
+
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-5}"
+MAX_CF_RESTARTS_HOUR="${MAX_CF_RESTARTS_HOUR:-2}"
+MAX_GRAFANA_RESTARTS_HOUR="${MAX_GRAFANA_RESTARTS_HOUR:-3}"
+RESTART_COOLDOWN_SECS="${RESTART_COOLDOWN_SECS:-600}"
+STARTUP_GRACE_SECS="${STARTUP_GRACE_SECS:-45}"
+
+mkdir -p "$STATE_DIR"
+
+log() { logger -t "$LOG_TAG" "$*"; }
+
+read_counter() {
+  local f="$1"
+  cat "$f" 2>/dev/null || echo 0
+}
+
+write_counter() {
+  echo "$2" > "$1"
+}
+
+rate_ok() {
+  local counter_file="$1" ts_file="$2" max_hour="$3"
+  local now count last_ts
+
+  now=$(date +%s)
+  count=$(read_counter "$counter_file")
+  last_ts=$(read_counter "$ts_file")
+
+  if (( now - last_ts > 3600 )); then
+    count=0
+  fi
+  (( count < max_hour ))
+}
+
+recent_restart() {
+  local ts_file="$STATE_DIR/cf_restart_ts"
+  local now last_ts
+
+  now=$(date +%s)
+  last_ts=$(read_counter "$ts_file")
+  (( now - last_ts < RESTART_COOLDOWN_SECS ))
+}
+
+cloudflared_in_startup() {
+  local started_at now started_epoch
+
+  started_at=$(systemctl show "$CF_SERVICE" -p ActiveEnterTimestamp --value 2>/dev/null || true)
+  [[ -n "$started_at" && "$started_at" != "n/a" ]] || return 1
+  started_epoch=$(date -d "$started_at" +%s 2>/dev/null || echo 0)
+  (( $(date +%s) - started_epoch < STARTUP_GRACE_SECS ))
+}
+
+bump_restart() {
+  local counter_file="$1" ts_file="$2"
+  local now count last_ts
+
+  now=$(date +%s)
+  count=$(read_counter "$counter_file")
+  last_ts=$(read_counter "$ts_file")
+  if (( now - last_ts > 3600 )); then
+    count=0
+  fi
+  count=$((count + 1))
+  write_counter "$counter_file" "$count"
+  write_counter "$ts_file" "$now"
+  write_counter "$STATE_DIR/cf_consecutive_failures" 0
+}
+
+probe_routes() {
+  [[ -x "$ROUTES_SCRIPT" ]] || return 1
+  "$ROUTES_SCRIPT"
+}
+
+probe_cloudflared() {
+  local resp
+  resp=$(curl -sf --max-time 5 "$CF_READY_URL" 2>/dev/null) || return 1
+  echo "$resp" | grep -qE '"readyConnections":([1-9]|[1-9][0-9]+)'
+}
+
+probe_grafana() {
+  local resp
+  resp=$(curl -sf --max-time 5 "${GRAFANA_URL}/api/health" 2>/dev/null) || return 1
+  echo "$resp" | grep -qE '"database"\s*:\s*"ok"'
+}
+
+restart_cloudflared() {
+  if recent_restart; then
+    log "SKIP restart: cooldown ${RESTART_COOLDOWN_SECS}s ativo"
+    return 1
+  fi
+  if ! rate_ok "$STATE_DIR/cf_restarts" "$STATE_DIR/cf_restart_ts" "$MAX_CF_RESTARTS_HOUR"; then
+    log "RATE LIMIT: cloudflared restart bloqueado (${MAX_CF_RESTARTS_HOUR}/h)"
+    return 1
+  fi
+  log "reiniciando ${CF_SERVICE} (rotas antes do restart)"
+  probe_routes || true
+  systemctl restart "$CF_SERVICE"
+  bump_restart "$STATE_DIR/cf_restarts" "$STATE_DIR/cf_restart_ts"
+  sleep "$STARTUP_GRACE_SECS"
+  probe_cloudflared
+}
+
+restart_grafana() {
+  if ! rate_ok "$STATE_DIR/grafana_restarts" "$STATE_DIR/grafana_restart_ts" "$MAX_GRAFANA_RESTARTS_HOUR"; then
+    log "RATE LIMIT: grafana restart bloqueado"
+    return 1
+  fi
+  log "reiniciando container ${GRAFANA_CONTAINER}"
+  docker restart "$GRAFANA_CONTAINER" >/dev/null
+  bump_restart "$STATE_DIR/grafana_restarts" "$STATE_DIR/grafana_restart_ts"
+  sleep 10
+  probe_grafana
+}
+
+cf_fail=$(read_counter "$STATE_DIR/cf_consecutive_failures")
+gf_fail=$(read_counter "$STATE_DIR/grafana_consecutive_failures")
+
+# 1) Always re-apply routes first (cheap, idempotent)
+if ! probe_routes; then
+  log "ERRO: falha ao aplicar rotas WAN do cloudflared"
+  cf_fail=$((cf_fail + 1))
+fi
+
+# 2) Cloudflared health — never restart during startup grace
+if cloudflared_in_startup; then
+  log "cloudflared em startup grace (${STARTUP_GRACE_SECS}s) — skip probe/restart"
+elif probe_cloudflared; then
+  cf_fail=0
+else
+  cf_fail=$((cf_fail + 1))
+  log "cloudflared unhealthy (falhas consecutivas=${cf_fail}/${FAIL_THRESHOLD})"
+  if (( cf_fail >= FAIL_THRESHOLD )); then
+    restart_cloudflared && cf_fail=0 || true
+  fi
+fi
+write_counter "$STATE_DIR/cf_consecutive_failures" "$cf_fail"
+
+# 3) Grafana origin health
+if probe_grafana; then
+  gf_fail=0
+else
+  gf_fail=$((gf_fail + 1))
+  log "grafana unhealthy (falhas consecutivas=${gf_fail})"
+  if (( gf_fail >= 3 )); then
+    restart_grafana && gf_fail=0 || true
+  fi
+fi
+write_counter "$STATE_DIR/grafana_consecutive_failures" "$gf_fail"
+
+# 4) Prometheus textfile metrics
+PROM_DIR="${TEXTFILE_DIR:-/var/lib/prometheus/node-exporter}"
+if [[ -d "$PROM_DIR" ]]; then
+  {
+    echo "# HELP cloudflared_tunnel_guardian_up 1 se rotas+tunnel+grafana OK"
+    echo "# TYPE cloudflared_tunnel_guardian_up gauge"
+    if (( cf_fail == 0 && gf_fail == 0 )); then echo "cloudflared_tunnel_guardian_up 1"; else echo "cloudflared_tunnel_guardian_up 0"; fi
+    echo "# HELP cloudflared_tunnel_guardian_cf_failures Consecutive cloudflared probe failures"
+    echo "# TYPE cloudflared_tunnel_guardian_cf_failures gauge"
+    echo "cloudflared_tunnel_guardian_cf_failures ${cf_fail}"
+    echo "# HELP cloudflared_tunnel_guardian_grafana_failures Consecutive grafana probe failures"
+    echo "# TYPE cloudflared_tunnel_guardian_grafana_failures gauge"
+    echo "cloudflared_tunnel_guardian_grafana_failures ${gf_fail}"
+  } > "${PROM_DIR}/cloudflared_tunnel_guardian.prom.$$"
+  mv "${PROM_DIR}/cloudflared_tunnel_guardian.prom.$$" "${PROM_DIR}/cloudflared_tunnel_guardian.prom"
+fi
+
+if (( cf_fail > 0 || gf_fail > 0 )); then
+  exit 1
+fi
+
+log "OK: rotas WAN + cloudflared + grafana"

--- a/grafana/exporters/tunnel_healthcheck_config.json
+++ b/grafana/exporters/tunnel_healthcheck_config.json
@@ -54,7 +54,7 @@
       "tunnel_type": "docker",
       "systemd_unit": "pihole.service",
       "docker_container": "pihole",
-      "health_url": "http://127.0.0.1:8053/admin/",
+      "health_url": "http://127.0.0.1:8089/admin/",
       "health_port": 53,
       "enabled": true
     }

--- a/systemd/cloudflared-rpa4all.service.d/50-fast-stop.conf
+++ b/systemd/cloudflared-rpa4all.service.d/50-fast-stop.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStopSec=20

--- a/systemd/cloudflared-tunnel-guardian.service
+++ b/systemd/cloudflared-tunnel-guardian.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cloudflare Tunnel + Grafana guardian (routes, tunnel, origin)
+After=network-online.target docker.service cloudflared-rpa4all.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/cloudflared-tunnel-guardian.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cf-tunnel-guardian
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/cloudflared-tunnel-guardian.timer
+++ b/systemd/cloudflared-tunnel-guardian.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Cloudflare tunnel guardian every 60s
+
+[Timer]
+OnBootSec=120s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Sintoma
grafana.rpa4all.com retornando Cloudflare **1033** intermitente na manhã de 2026-07-17.

## Causa raiz
1. Carrier flaps de ~3s no eth-wan (r8152) derrubavam as 4 conexões do tunnel; o cloudflared reconecta sozinho em ~6s.
2. O **guardian** via `/ready` sem conexões por 3 ciclos (3 min) e reiniciava o serviço — e o stop travava 90s até SIGKILL (grace-period 1m) → um blip virava minutos de 1033. Foram **163 starts em 12h** (cooldown de 180s permitia ~20/h apesar do limite nominal de 4/h).
3. Bônus: o healthcheck exporter reiniciava o **pihole 3x/h há dias** (7.9k checks falhos) porque checava a porta 8053 — a UI do pihole-FTL em host network é **8089**.

## Fix (já aplicado em produção ~07:55, aqui versionado)
- Guardian: `FAIL_THRESHOLD` 3→5, `MAX_CF_RESTARTS_HOUR` 4→2, `RESTART_COOLDOWN_SECS` 180→600.
- Drop-in `TimeoutStopSec=20` no cloudflared-rpa4all (stop rápido em restart legítimo).
- `tunnel_healthcheck_config.json`: pihole health_url 8053→8089 (pihole UP no healer desde o fix).
- Versiona o script/units do guardian que só existiam em `/usr/local` (fora do git).

Pendência física separada: os carrier flaps do eth-wan (8/24h) persistem — EEE já está off; provável cabo/porta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)