### PR TITLE
feat(selfheal): suíte de self-heal seguro — eth-wan, ProtonVPN unit, presença IoT

### DIFF
--- a/.github/workflows/deploy-network-selfheal.yml
+++ b/.github/workflows/deploy-network-selfheal.yml
@@ -1,0 +1,76 @@
+name: Deploy Network Selfheal Suite
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ethwan_selfheal'
+      - 'scripts/protonvpn_unit_selfheal'
+      - 'tools/homelab/iot_presence_watchdog.py'
+      - 'systemd/ethwan-selfheal.service'
+      - 'systemd/protonvpn-unit-selfheal.*'
+      - 'systemd/iot-presence-watchdog.*'
+      - 'systemd/tuya-token-selfheal.service'
+      - '.github/workflows/deploy-network-selfheal.yml'
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    # Self-hosted runner no homelab — instala direto com sudo
+    runs-on: [self-hosted, linux, homelab]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validar sintaxe
+        run: |
+          set -euo pipefail
+          bash -n scripts/ethwan_selfheal
+          bash -n scripts/protonvpn_unit_selfheal
+          python3 -m py_compile tools/homelab/iot_presence_watchdog.py
+
+      - name: Instalar scripts e units
+        run: |
+          set -euo pipefail
+          sudo install -D -m 0755 scripts/ethwan_selfheal /usr/local/bin/ethwan_selfheal
+          sudo install -D -m 0755 scripts/protonvpn_unit_selfheal /usr/local/bin/protonvpn_unit_selfheal
+          sudo install -D -m 0755 tools/homelab/iot_presence_watchdog.py /usr/local/bin/iot_presence_watchdog.py
+
+          sudo install -D -m 0644 systemd/ethwan-selfheal.service /etc/systemd/system/ethwan-selfheal.service
+          sudo install -D -m 0644 systemd/protonvpn-unit-selfheal.service /etc/systemd/system/protonvpn-unit-selfheal.service
+          sudo install -D -m 0644 systemd/protonvpn-unit-selfheal.timer /etc/systemd/system/protonvpn-unit-selfheal.timer
+          sudo install -D -m 0644 systemd/iot-presence-watchdog.service /etc/systemd/system/iot-presence-watchdog.service
+          sudo install -D -m 0644 systemd/iot-presence-watchdog.timer /etc/systemd/system/iot-presence-watchdog.timer
+          sudo install -D -m 0644 systemd/tuya-token-selfheal.service /etc/systemd/system/tuya-token-selfheal.service
+
+          sudo systemctl daemon-reload
+          sudo systemctl enable --now ethwan-selfheal.service
+          sudo systemctl enable --now protonvpn-unit-selfheal.timer
+          sudo systemctl enable --now iot-presence-watchdog.timer
+          sudo systemctl restart tuya-token-selfheal.timer
+          echo "✅ Units instaladas e habilitadas"
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          sleep 5
+          systemctl is-active ethwan-selfheal.service
+
+          sudo systemctl start protonvpn-unit-selfheal.service
+          test -f /var/lib/prometheus/node-exporter/protonvpn_unit_selfheal.prom
+          grep -q "protonvpn_tunnel_ok" /var/lib/prometheus/node-exporter/protonvpn_unit_selfheal.prom
+
+          sudo systemctl start iot-presence-watchdog.service
+          test -f /var/lib/prometheus/node-exporter/iot_presence.prom
+          grep -q "iot_devices_present_count" /var/lib/prometheus/node-exporter/iot_presence.prom
+
+          test -f /var/lib/prometheus/node-exporter/ethwan_selfheal.prom
+          grep -q "ethwan_link_up" /var/lib/prometheus/node-exporter/ethwan_selfheal.prom
+
+          echo "✅ Métricas das 3 suítes publicadas:"
+          grep -hE "^(ethwan_link_up|protonvpn_tunnel_ok|iot_devices_present_count)" \
+            /var/lib/prometheus/node-exporter/ethwan_selfheal.prom \
+            /var/lib/prometheus/node-exporter/protonvpn_unit_selfheal.prom \
+            /var/lib/prometheus/node-exporter/iot_presence.prom

--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,6 +1,6 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-16T22:02:16.706426",
+  "generatedAt": "2026-07-17T09:28:59.137891",
   "environment": "production",
   "categories": {
     "services": {
@@ -201,9 +201,9 @@
         "contexts": [
           "mailu-backend",
           "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-dovecot"
+          "mailu-dovecot",
+          "mailu-postfix"
         ]
       },
       "ADMIN_EMAIL": {
@@ -1421,10 +1421,10 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
-          "netbox-postgres",
-          "grafana",
           "glpi",
-          "glpi-db"
+          "glpi-db",
+          "netbox-postgres",
+          "grafana"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -1700,7 +1700,7 @@
         "name": "MAX_HEALS_24H",
         "type": "integer",
         "source": "systemd",
-        "value": "3",
+        "value": "6",
         "contexts": [
           "tuya-token-selfheal"
         ]
@@ -1714,39 +1714,150 @@
           "tuya-token-selfheal"
         ]
       },
+      "BYPASS_CONF": {
+        "name": "BYPASS_CONF",
+        "type": "path",
+        "source": "systemd",
+        "value": "/etc/iot-vpn-bypass.conf",
+        "contexts": [
+          "iot-presence-watchdog"
+        ]
+      },
+      "LEASES_FILE": {
+        "name": "LEASES_FILE",
+        "type": "path",
+        "source": "systemd",
+        "value": "/var/lib/misc/dnsmasq.leases",
+        "contexts": [
+          "iot-presence-watchdog",
+          "dhcp-selfheal"
+        ]
+      },
+      "UNIT": {
+        "name": "UNIT",
+        "type": "string",
+        "source": "systemd",
+        "value": "wg-quick@protonvpn.service",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "WG_IFACE": {
+        "name": "WG_IFACE",
+        "type": "string",
+        "source": "systemd",
+        "value": "protonvpn",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "WAN_IFACE": {
+        "name": "WAN_IFACE",
+        "type": "string",
+        "source": "systemd",
+        "value": "eth-wan",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "HANDSHAKE_MAX_AGE": {
+        "name": "HANDSHAKE_MAX_AGE",
+        "type": "integer",
+        "source": "systemd",
+        "value": "600",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "IFACE": {
+        "name": "IFACE",
+        "type": "string",
+        "source": "systemd",
+        "value": "eth-wan",
+        "contexts": [
+          "ethwan-selfheal"
+        ]
+      },
+      "CHECK_INTERVAL": {
+        "name": "CHECK_INTERVAL",
+        "type": "integer",
+        "source": "systemd",
+        "value": "30",
+        "contexts": [
+          "grafana-selfheal",
+          "ethwan-selfheal",
+          "dhcp-selfheal"
+        ]
+      },
+      "LINK_DOWN_GRACE": {
+        "name": "LINK_DOWN_GRACE",
+        "type": "integer",
+        "source": "systemd",
+        "value": "20",
+        "contexts": [
+          "ethwan-selfheal"
+        ]
+      },
+      "BRINGUP_SCRIPT": {
+        "name": "BRINGUP_SCRIPT",
+        "type": "path",
+        "source": "systemd",
+        "value": "/usr/local/bin/eth-wan-bringup.sh",
+        "contexts": [
+          "ethwan-selfheal"
+        ]
+      },
+      "USB_PORT": {
+        "name": "USB_PORT",
+        "type": "string",
+        "source": "systemd",
+        "value": "2-2",
+        "contexts": [
+          "ethwan-selfheal"
+        ]
+      },
+      "HEAL_COOLDOWN": {
+        "name": "HEAL_COOLDOWN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "120",
+        "contexts": [
+          "ethwan-selfheal"
+        ]
+      },
       "PYTHONUNBUFFERED": {
         "name": "PYTHONUNBUFFERED",
         "type": "boolean",
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "marketing-x-posts",
-          "eddie-expurgo",
           "eddie-calendar",
-          "coordinator",
-          "crypto-agent@",
-          "approval-gateway",
-          "eddie-telegram-bot",
-          "marketing-email-drip",
-          "daily-agenda-panel",
-          "tape-component-quality-exporter",
-          "clear-trading-agent",
           "bn-acervo-agent",
-          "marketing-api",
-          "marketing-daily-report",
-          "ollama-gpu-coordinator",
-          "banking-metrics-exporter",
-          "candle-collector",
-          "diretor",
-          "kucoin-usdt-rebalance",
-          "notebook-power-agent",
-          "trading-analyst-weekly-retrain",
-          "trading-daily-report",
-          "meeting-translator",
+          "crypto-agent@",
+          "kucoin-postgres-sync",
           "daily-agenda-broadcast",
+          "tape-component-quality-exporter",
+          "diretor",
           "rss-sentiment-exporter",
+          "trading-analyst-weekly-retrain",
+          "meeting-translator",
+          "daily-agenda-panel",
+          "ollama-gpu-coordinator",
+          "notebook-power-agent",
+          "eddie-expurgo",
+          "kucoin-usdt-rebalance",
+          "marketing-x-posts",
+          "marketing-email-drip",
           "agent-network-exporter",
-          "kucoin-postgres-sync"
+          "eddie-telegram-bot",
+          "coordinator",
+          "candle-collector",
+          "clear-trading-agent",
+          "banking-metrics-exporter",
+          "marketing-api",
+          "trading-daily-report",
+          "marketing-daily-report",
+          "approval-gateway"
         ]
       },
       "NARRATOR_STATE_FILE": {
@@ -1764,16 +1875,16 @@
         "source": "systemd",
         "value": "/var/db/ltfs-tools/libs",
         "contexts": [
-          "tape-component-quality-exporter",
+          "llm-log-panel",
           "marketing-x-posts",
-          "marketing-daily-report",
-          "ollama-finetune",
-          "clear-trading-agent",
           "rss-sentiment-exporter",
           "marketing-api",
-          "llm-log-panel",
           "marketing-email-drip",
-          "candle-collector"
+          "clear-trading-agent",
+          "candle-collector",
+          "marketing-daily-report",
+          "tape-component-quality-exporter",
+          "ollama-finetune"
         ]
       },
       "PATH": {
@@ -1782,16 +1893,16 @@
         "source": "systemd",
         "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "contexts": [
-          "tape-component-quality-exporter",
-          "kucoin-postgres-sync",
           "kucoin-usdt-rebalance",
           "github-agent",
           "specialized_agents-dashboard",
-          "homelab-dashboard",
-          "crypto-agent@",
           "job-monitor",
           "eddie-whatsapp-bot",
-          "rpa4all-validation"
+          "homelab-dashboard",
+          "rpa4all-validation",
+          "kucoin-postgres-sync",
+          "crypto-agent@",
+          "tape-component-quality-exporter"
         ]
       },
       "OLLAMA_SENTIMENT_MODEL": {
@@ -1848,11 +1959,11 @@
         "source": "systemd",
         "value": "/apps/crypto-trader",
         "contexts": [
-          "crypto-agent@",
-          "rss-sentiment-exporter",
           "llm-log-panel",
-          "ollama-finetune",
-          "candle-collector"
+          "rss-sentiment-exporter",
+          "crypto-agent@",
+          "candle-collector",
+          "ollama-finetune"
         ]
       },
       "WAIT_SECONDS": {
@@ -2209,16 +2320,6 @@
           "homelab-tape-log-drain-sg1"
         ]
       },
-      "CHECK_INTERVAL": {
-        "name": "CHECK_INTERVAL",
-        "type": "integer",
-        "source": "systemd",
-        "value": "30",
-        "contexts": [
-          "dhcp-selfheal",
-          "grafana-selfheal"
-        ]
-      },
       "FAIL_THRESHOLD": {
         "name": "FAIL_THRESHOLD",
         "type": "integer",
@@ -2234,8 +2335,8 @@
         "source": "systemd",
         "value": "3",
         "contexts": [
-          "dhcp-selfheal",
-          "grafana-selfheal"
+          "grafana-selfheal",
+          "dhcp-selfheal"
         ]
       },
       "TEXTFILE_DIR": {
@@ -2280,8 +2381,8 @@
         "source": "systemd",
         "value": "http://localhost:3004",
         "contexts": [
-          "eddie-whatsapp-bot",
-          "eddie-expurgo"
+          "eddie-expurgo",
+          "eddie-whatsapp-bot"
         ]
       },
       "ADMIN_NUMBERS": {
@@ -2308,8 +2409,8 @@
         "source": "systemd",
         "value": "948686300",
         "contexts": [
-          "eddie-expurgo",
-          "eddie-calendar"
+          "eddie-calendar",
+          "eddie-expurgo"
         ]
       },
       "ADMIN_PHONE": {
@@ -2353,15 +2454,6 @@
         "type": "string",
         "source": "systemd",
         "value": "homelab-lan-dhcp.service",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "LEASES_FILE": {
-        "name": "LEASES_FILE",
-        "type": "path",
-        "source": "systemd",
-        "value": "/var/lib/misc/dnsmasq.leases",
         "contexts": [
           "dhcp-selfheal"
         ]
@@ -2563,8 +2655,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "config",
-          "configure_authentik_nextcloud_oidc"
+          "configure_authentik_nextcloud_oidc",
+          "config"
         ]
       },
       "NEXTCLOUD_ADMIN_USER": {
@@ -2627,8 +2719,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "config",
-          "configure_diretor_model"
+          "configure_diretor_model",
+          "config"
         ]
       },
       "HOMELAB_USER": {
@@ -2781,11 +2873,11 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_INTERVAL": {
@@ -2794,11 +2886,11 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_EXPR": {
@@ -2808,9 +2900,9 @@
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -2819,11 +2911,11 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SEVERITY": {
@@ -2832,11 +2924,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_COMPONENT": {
@@ -2854,11 +2946,11 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -2867,11 +2959,11 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -2899,9 +2991,9 @@
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -2910,11 +3002,11 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_SEVERITY": {
@@ -2923,11 +3015,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_COMPONENT": {
@@ -2945,11 +3037,11 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -2958,11 +3050,11 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_ACTION": {
@@ -2990,9 +3082,9 @@
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -3001,11 +3093,11 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_SEVERITY": {
@@ -3014,11 +3106,11 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_COMPONENT": {
@@ -3036,11 +3128,11 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -3049,11 +3141,11 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DASHBOARD": {
@@ -3072,9 +3164,9 @@
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -3083,10 +3175,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "alert_rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -3095,10 +3187,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "alert_rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -3116,10 +3208,10 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "alert_rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -3128,10 +3220,10 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "alert_rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -3150,8 +3242,8 @@
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_FOR": {
@@ -3160,9 +3252,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -3171,9 +3263,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -3191,9 +3283,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -3202,9 +3294,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -3222,8 +3314,8 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_FOR": {
@@ -3232,9 +3324,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -3243,9 +3335,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -3263,9 +3355,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -3274,9 +3366,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -4322,9 +4414,9 @@
         "source": "yaml",
         "value": "trading_agent_alerts",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -4333,9 +4425,9 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -4344,8 +4436,8 @@
         "source": "yaml",
         "value": "trading_agent_up == 0",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_FOR": {
@@ -4354,9 +4446,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -4365,9 +4457,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -4385,9 +4477,9 @@
         "source": "yaml",
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -4396,9 +4488,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -4416,8 +4508,8 @@
         "source": "yaml",
         "value": "trading_agent_stalled == 1",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_FOR": {
@@ -4426,9 +4518,9 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -4437,9 +4529,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -4457,9 +4549,9 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -4468,9 +4560,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -4488,8 +4580,8 @@
         "source": "yaml",
         "value": "trading_agent_last_decision_age_seconds > 900",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_FOR": {
@@ -4498,9 +4590,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -4509,9 +4601,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -4529,9 +4621,9 @@
         "source": "yaml",
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -4540,9 +4632,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -4551,8 +4643,8 @@
         "source": "yaml",
         "value": "trading_agent_consecutive_failures > 6",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_FOR": {
@@ -4561,8 +4653,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_SEVERITY": {
@@ -4571,8 +4663,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_COMPONENT": {
@@ -4590,8 +4682,8 @@
         "source": "yaml",
         "value": "\ud83d\udea8 Trading Agent {{ $labels.symbol }} \u2014 Self-Heal FAILED",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -4600,8 +4692,8 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} failed health checks {{ $value | humanize }} times. Auto-restart n\u00e3o conseguiu recuperar. Interven\u00e7\u00e3o manual necess\u00e1ria.",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -4628,8 +4720,8 @@
         "source": "yaml",
         "value": "up{job=\"crypto-exporters\"} == 0",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_4_FOR": {
@@ -4692,8 +4784,8 @@
         "source": "yaml",
         "value": "increase(trading_selfheal_actions_total{action=\"ollama_error\"}[1h]) > 5",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_5_FOR": {
@@ -4756,8 +4848,8 @@
         "source": "yaml",
         "value": "rate(trading_agent_restart_total[1h]) > 3",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_6_FOR": {
@@ -5108,8 +5200,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -5118,8 +5210,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -5128,8 +5220,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -5138,8 +5230,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -5148,8 +5240,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -5158,8 +5250,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -5177,8 +5269,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -5187,8 +5279,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -5197,8 +5289,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -5207,8 +5299,8 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -5217,8 +5309,8 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "APIVERSION": {
@@ -5227,12 +5319,12 @@
         "source": "yaml",
         "value": "1",
         "contexts": [
-          "contactpoints",
-          "dashboards",
           "datasources",
           "policies",
-          "authentik-http",
-          "rules"
+          "contactpoints",
+          "rules",
+          "dashboards",
+          "authentik-http"
         ]
       },
       "DELETEDATASOURCES_0_NAME": {
@@ -15527,8 +15619,8 @@
         "source": "yaml",
         "value": "Homelab MCP Server",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "VERSION": {
@@ -15537,8 +15629,8 @@
         "source": "yaml",
         "value": "0.0.1",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "SCHEMA": {
@@ -15547,8 +15639,8 @@
         "source": "yaml",
         "value": "v1",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_NAME": {
@@ -15557,8 +15649,8 @@
         "source": "yaml",
         "value": "homelab",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_COMMAND": {
@@ -15567,8 +15659,8 @@
         "source": "yaml",
         "value": "/home/edenilson/shared-auto-dev/.venv/bin/python",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_ENV_HOMELAB_URL": {
@@ -15577,8 +15669,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:8503",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_ENV_API_BASE_URL": {
@@ -15587,8 +15679,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:3000",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "TOPIC": {
@@ -15597,8 +15689,8 @@
         "source": "yaml",
         "value": "viral_trends",
         "contexts": [
-          "curiosidades",
           "viral_trends",
+          "curiosidades",
           "cripto"
         ]
       },
@@ -15608,8 +15700,8 @@
         "source": "yaml",
         "value": "Trend alert: {trend_title}",
         "contexts": [
-          "curiosidades",
           "viral_trends",
+          "curiosidades",
           "cripto"
         ]
       },
@@ -15619,8 +15711,8 @@
         "source": "yaml",
         "value": "Hook: Essa trend est\u00e1 com score {score} agora.\nPasso 1: Use o gancho nos primeiros 2 segundos.\nPasso 2: Entregue valor r\u00e1pido sobre {trend_title}.\nPasso 3: CTA claro no final para aumentar reten\u00e7\u00e3o.\nTags: {tags}.\n",
         "contexts": [
-          "curiosidades",
           "viral_trends",
+          "curiosidades",
           "cripto"
         ]
       },
@@ -15630,8 +15722,8 @@
         "source": "yaml",
         "value": "Marca algu\u00e9m que precisa surfar essa trend hoje!",
         "contexts": [
-          "curiosidades",
           "viral_trends",
+          "curiosidades",
           "cripto"
         ]
       },
@@ -15764,9 +15856,9 @@
         "contexts": [
           "mailu-backend",
           "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-dovecot"
+          "mailu-dovecot",
+          "mailu-postfix"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -16252,10 +16344,10 @@
         "value": "***REDACTED***",
         "contexts": [
           "mailu-db",
-          "wikijs-db",
-          "netbox-postgres",
+          "postgres",
           "mail-db",
-          "postgres"
+          "wikijs-db",
+          "netbox-postgres"
         ]
       },
       "OIDC_CLIENT_SECRET": {
@@ -16391,10 +16483,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-redis-cache",
           "netbox",
-          "netbox-redis",
-          "netbox-worker"
+          "netbox-redis-cache",
+          "netbox-worker",
+          "netbox-redis"
         ]
       },
       "REMOTE_AUTH_AUTO_CREATE_USER": {
@@ -16928,8 +17020,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       }
     },
@@ -17108,8 +17200,8 @@
         "value": "wikijs-db",
         "contexts": [
           "netbox",
-          "wikijs",
-          "netbox-worker"
+          "netbox-worker",
+          "wikijs"
         ]
       },
       "DB_PORT": {
@@ -17128,8 +17220,8 @@
         "value": "wikijs",
         "contexts": [
           "netbox",
-          "wikijs",
-          "netbox-worker"
+          "netbox-worker",
+          "wikijs"
         ]
       },
       "DB_NAME": {
@@ -17139,8 +17231,8 @@
         "value": "wikijs",
         "contexts": [
           "netbox",
-          "wikijs",
-          "netbox-worker"
+          "netbox-worker",
+          "wikijs"
         ]
       },
       "DATABASE_URL": {
@@ -17281,10 +17373,10 @@
         "value": "wikijs",
         "contexts": [
           "mailu-db",
-          "wikijs-db",
-          "netbox-postgres",
+          "postgres",
           "mail-db",
-          "postgres"
+          "wikijs-db",
+          "netbox-postgres"
         ]
       },
       "POSTGRES_USER": {
@@ -17294,10 +17386,10 @@
         "value": "wikijs",
         "contexts": [
           "mailu-db",
-          "wikijs-db",
-          "netbox-postgres",
+          "postgres",
           "mail-db",
-          "postgres"
+          "wikijs-db",
+          "netbox-postgres"
         ]
       },
       "DB_TYPE": {
@@ -17563,8 +17655,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       }
     },
@@ -17697,8 +17789,8 @@
         "source": "systemd",
         "value": "/apps/crypto-trader/trading/btc_trading_agent",
         "contexts": [
-          "kucoin-postgres-sync",
-          "kucoin-usdt-rebalance"
+          "kucoin-usdt-rebalance",
+          "kucoin-postgres-sync"
         ]
       },
       "COMPATIBILITY_METHOD": {
@@ -18024,6 +18116,15 @@
       }
     },
     "monitoring": {
+      "ABSENT_ALERT_MIN": {
+        "name": "ABSENT_ALERT_MIN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "30",
+        "contexts": [
+          "iot-presence-watchdog"
+        ]
+      },
       "GRAFANA_URL": {
         "name": "GRAFANA_URL",
         "type": "url",
@@ -18050,9 +18151,9 @@
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -18062,9 +18163,9 @@
         "value": "RPA4AllSnapshotHung",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -18074,9 +18175,9 @@
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
           "selfhealing_rules",
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -18085,9 +18186,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ALERT": {
@@ -18096,8 +18197,8 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ALERT": {
@@ -18106,8 +18207,8 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_1_RULES_0_ALERT": {
@@ -18116,8 +18217,8 @@
         "source": "yaml",
         "value": "TradingAgentDown",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ALERT": {
@@ -18126,8 +18227,8 @@
         "source": "yaml",
         "value": "TradingAgentStalled",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_ALERT": {
@@ -18136,8 +18237,8 @@
         "source": "yaml",
         "value": "TradingDecisionsGap",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ALERT": {
@@ -18146,8 +18247,8 @@
         "source": "yaml",
         "value": "TradingSelfHealExhausted",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_4_ALERT": {
@@ -18198,7 +18299,7 @@
     }
   },
   "metadata": {
-    "totalVariables": 1926,
+    "totalVariables": 1937,
     "sourceFiles": [
       ".env.openai-compatible.example",
       ".env.example.wiki",
@@ -18224,6 +18325,9 @@
       "tools/vaultwarden/docker-compose.yml",
       "tools/authentik_management/configs/docker-compose.override.yml",
       "systemd/tuya-token-selfheal.service",
+      "systemd/iot-presence-watchdog.service",
+      "systemd/protonvpn-unit-selfheal.service",
+      "systemd/ethwan-selfheal.service",
       "systemd/workstation-win11l-rdp@.service",
       "systemd/workstation-win11l-http@.service",
       "systemd/tuya-token-renewer.service",
@@ -18296,6 +18400,7 @@
       "systemd/daily-agenda-broadcast.service",
       "systemd/crypto-agent@.service",
       "systemd/coordinator.service",
+      "systemd/cloudflared-tunnel-guardian.service",
       "systemd/clear-trading-agent.service",
       "systemd/clear-agent@.service",
       "systemd/chromecast-ambilight.service",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-17T10:58:22.115228+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/ba6e0dc2-8033-402c-aa0b-e458fb4b91b1/scratchpad/cf-guardian",
+  "generated_at": "2026-07-17T12:29:23.755081+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/ba6e0dc2-8033-402c-aa0b-e458fb4b91b1/scratchpad/net-selfheal",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 174,
+    "repo_services": 179,
     "trading_instances": 12,
-    "critical_services": 68,
+    "critical_services": 70,
     "domains": {
       "identity": 4,
       "monitoring": 14,
-      "network": 18,
-      "operations": 95,
+      "network": 20,
+      "operations": 98,
       "storage": 32,
       "trading": 11
     }
@@ -462,6 +462,22 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "protonvpn-unit-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-unit-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-unit-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-unit-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "rpa4all-ddns-server.service",
       "domain": "network",
       "kind": "systemd",
@@ -862,6 +878,14 @@
       "candidate_system": "GLPI review"
     },
     {
+      "name": "ethwan-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
       "name": "final-boot-status-agent.service",
       "domain": "operations",
       "kind": "systemd",
@@ -890,6 +914,22 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -2058,6 +2098,20 @@
         "name": "protonvpn-routing-watchdog.service",
         "domain": "network",
         "source": "deploy/vpn/protonvpn-routing-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-unit-selfheal.service",
+        "domain": "network",
+        "source": "systemd/protonvpn-unit-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-unit-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/protonvpn-unit-selfheal.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-17T10:58:22.115228+00:00`
+- Generated at: `2026-07-17T12:29:23.755081+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `174`
-- Critical services flagged for MVP: `68`
+- Repo services discovered: `179`
+- Critical services flagged for MVP: `70`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,8 +12,8 @@
 
 - `identity`: 4
 - `monitoring`: 14
-- `network`: 18
-- `operations`: 95
+- `network`: 20
+- `operations`: 98
 - `storage`: 32
 - `trading`: 11
 
@@ -71,13 +71,13 @@
 - `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
 - `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
 - `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
+- `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
+- `protonvpn-unit-selfheal.timer` (network, systemd) from `systemd/protonvpn-unit-selfheal.timer`
 - `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
 - `rpa4all-vpn-ddns.service` (network, systemd) from `deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service`
 - `wireguard-nat.service` (network, systemd) from `deploy/vpn/wireguard-nat.service`
 - `disk-clean.service` (storage, systemd) from `systemd/disk-clean.service`
 - `disk-clean.timer` (storage, systemd) from `systemd/disk-clean.timer`
-- `disk-spindown.service` (storage, systemd) from `tools/homelab/disk-spindown.service`
-- `homelab-disk-backup.service` (storage, systemd) from `tools/backup/homelab-disk-backup.service`
 
 ## Serviços anotados manualmente
 

--- a/docs/variables-taxonomy/NETWORK_SELFHEAL.md
+++ b/docs/variables-taxonomy/NETWORK_SELFHEAL.md
@@ -1,0 +1,40 @@
+# Network Selfheal Suite — Variáveis
+
+Suíte criada após a semana de incidentes 11–17/07/2026 (relatório na sessão
+de 17/07): flaps crônicos do eth-wan, unit do ProtonVPN dessincronizada do
+kernel e IoTs sumindo do WiFi sem detecção.
+
+## ethwan-selfheal.service (`scripts/ethwan_selfheal`)
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `IFACE` | `eth-wan` | Interface WAN monitorada (USB RTL8153). |
+| `CHECK_INTERVAL` | `30` | Intervalo de verificação do carrier (s). Mesmo nome já usado pelo dhcp-selfheal. |
+| `LINK_DOWN_GRACE` | `20` | Segundos de link down antes da primeira ação (blips se resolvem sozinhos). |
+| `BRINGUP_SCRIPT` | `/usr/local/bin/eth-wan-bringup.sh` | Script de bringup existente, usado como nível 2 da escada. |
+| `USB_PORT` | `2-2` | Porta USB do adaptador para unbind/bind (nível 3, max 2/h). |
+| `HEAL_COOLDOWN` | `120` | Cooldown mínimo entre quaisquer ações de heal (s). |
+| `PROM_FILE` | `/var/lib/prometheus/node-exporter/ethwan_selfheal.prom` | Métricas textfile collector. |
+
+## protonvpn-unit-selfheal.service (`scripts/protonvpn_unit_selfheal`)
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `UNIT` | `wg-quick@protonvpn.service` | Unit systemd reconciliada com o estado do kernel. |
+| `WG_IFACE` | `protonvpn` | Interface WireGuard cujo handshake define "túnel vivo". |
+| `WAN_IFACE` | `eth-wan` | Interface usada no teste de internet antes de um restart real. |
+| `HANDSHAKE_MAX_AGE` | `600` | Idade máxima (s) do handshake para considerar o túnel saudável. |
+| `STATE_DIR` | `/var/lib/protonvpn-unit-selfheal` | Contadores e rate limit (1 restart/h). |
+| `PROM_FILE` | `.../protonvpn_unit_selfheal.prom` | Métricas textfile collector. |
+
+## iot-presence-watchdog.service (`tools/homelab/iot_presence_watchdog.py`)
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `BYPASS_CONF` | `/etc/iot-vpn-bypass.conf` | Fonte dos MACs monitorados (mesma allowlist do bypass VPN). |
+| `LEASES_FILE` | `/var/lib/misc/dnsmasq.leases` | Leases DHCP para presença. Mesmo nome já usado pelo dhcp-selfheal. |
+| `STATE_FILE` | `/var/lib/iot-presence/state.json` | Estado de transições p/ alertar 1x por evento. |
+| `PROM_FILE` | `.../iot_presence.prom` | Métricas por dispositivo (`iot_device_present{mac,ip}`). |
+| `ABSENT_ALERT_MIN` | `30` | Minutos ausente antes do alerta Telegram (credenciais via `EnvironmentFile` `/etc/default/eddie-common` — `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`, já catalogadas). |
+
+O watchdog de presença **não executa ação corretiva** — só observa e alerta.

--- a/scripts/ethwan_selfheal
+++ b/scripts/ethwan_selfheal
@@ -1,0 +1,129 @@
+#!/bin/bash
+# eth-wan Selfheal + Prometheus Metrics (textfile collector)
+# Monitora o link WAN (USB RTL8153) e recupera com escada de ações,
+# cada uma com rate limit — projetado após a semana 11–17/07/2026
+# (EEE flap, USB reset loop, carrier flaps crônicos).
+#
+# Escada de recuperação (só executa com link DOWN confirmado):
+#   1. re-aplica ethtool (EEE off) + bounce ip link       (max 6/h)
+#   2. eth-wan-bringup.sh (bringup completo já existente)  (max 4/h)
+#   3. USB unbind/bind do adaptador                        (max 2/h)
+# Link UP = nunca mexe. Falha de leitura de estado = só métrica.
+
+set -uo pipefail
+
+IFACE="${IFACE:-eth-wan}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-30}"
+LINK_DOWN_GRACE="${LINK_DOWN_GRACE:-20}"
+BRINGUP_SCRIPT="${BRINGUP_SCRIPT:-/usr/local/bin/eth-wan-bringup.sh}"
+USB_PORT="${USB_PORT:-2-2}"
+PROM_FILE="${PROM_FILE:-/var/lib/prometheus/node-exporter/ethwan_selfheal.prom}"
+HEAL_COOLDOWN="${HEAL_COOLDOWN:-120}"
+
+declare -A MAX_PER_HOUR=([1]=6 [2]=4 [3]=2)
+declare -A hour_count=([1]=0 [2]=0 [3]=0)
+declare -A total_count=([1]=0 [2]=0 [3]=0)
+hour_start=$(date +%s)
+last_heal=0
+down_since=0
+escalation=1
+
+log() { echo "[$(date '+%F %T')] $*"; }
+
+write_metrics() {
+  local link_up="$1" carrier_changes="$2"
+  local tmp="${PROM_FILE}.tmp"
+  mkdir -p "$(dirname "$PROM_FILE")" 2>/dev/null || return 0
+  cat > "$tmp" <<EOF
+# HELP ethwan_link_up Link físico do ${IFACE} (1=up)
+# TYPE ethwan_link_up gauge
+ethwan_link_up ${link_up}
+# HELP ethwan_carrier_changes_total Mudanças de carrier desde a criação da interface
+# TYPE ethwan_carrier_changes_total counter
+ethwan_carrier_changes_total ${carrier_changes}
+# HELP ethwan_selfheal_heals_total Ações de heal por nível da escada
+# TYPE ethwan_selfheal_heals_total counter
+ethwan_selfheal_heals_total{level="1_bounce"} ${total_count[1]}
+ethwan_selfheal_heals_total{level="2_bringup"} ${total_count[2]}
+ethwan_selfheal_heals_total{level="3_usb_rebind"} ${total_count[3]}
+# HELP ethwan_selfheal_last_check_timestamp Unix time da última verificação
+# TYPE ethwan_selfheal_last_check_timestamp gauge
+ethwan_selfheal_last_check_timestamp $(date +%s)
+EOF
+  mv "$tmp" "$PROM_FILE" 2>/dev/null || true
+}
+
+rate_ok() {
+  local level="$1" now
+  now=$(date +%s)
+  if (( now - hour_start > 3600 )); then
+    hour_start=$now
+    hour_count=([1]=0 [2]=0 [3]=0)
+  fi
+  (( hour_count[$level] < MAX_PER_HOUR[$level] ))
+}
+
+heal() {
+  local level="$1" now
+  now=$(date +%s)
+  (( now - last_heal < HEAL_COOLDOWN )) && return 1
+  rate_ok "$level" || { log "rate limit nível $level atingido — não agindo"; return 1; }
+  case "$level" in
+    1)
+      log "HEAL 1: ethtool EEE off + bounce do link"
+      ethtool --set-eee "$IFACE" eee off 2>/dev/null || true
+      ip link set "$IFACE" down 2>/dev/null; sleep 2
+      ip link set "$IFACE" up 2>/dev/null
+      ;;
+    2)
+      log "HEAL 2: bringup completo ($BRINGUP_SCRIPT)"
+      [[ -x "$BRINGUP_SCRIPT" ]] && "$BRINGUP_SCRIPT" || log "bringup script ausente"
+      ;;
+    3)
+      log "HEAL 3: USB rebind $USB_PORT"
+      if [[ -e "/sys/bus/usb/drivers/usb/$USB_PORT" ]]; then
+        echo -n "$USB_PORT" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null
+        sleep 3
+        echo -n "$USB_PORT" > /sys/bus/usb/drivers/usb/bind 2>/dev/null
+      else
+        log "porta USB $USB_PORT não encontrada — pulando rebind"
+        return 1
+      fi
+      ;;
+  esac
+  hour_count[$level]=$(( hour_count[$level] + 1 ))
+  total_count[$level]=$(( total_count[$level] + 1 ))
+  last_heal=$now
+  return 0
+}
+
+log "ethwan_selfheal iniciado (iface=$IFACE, intervalo=${CHECK_INTERVAL}s)"
+
+while true; do
+  carrier=$(cat "/sys/class/net/$IFACE/carrier" 2>/dev/null || echo "err")
+  changes=$(cat "/sys/class/net/$IFACE/carrier_changes" 2>/dev/null || echo 0)
+
+  if [[ "$carrier" == "err" ]]; then
+    # interface sumiu (re-enumeração USB em andamento) — trata como down
+    carrier=0
+  fi
+
+  now=$(date +%s)
+  if [[ "$carrier" == "1" ]]; then
+    if (( down_since > 0 )); then
+      log "link recuperado após $(( now - down_since ))s (nível atual era $escalation)"
+    fi
+    down_since=0
+    escalation=1
+    write_metrics 1 "$changes"
+  else
+    (( down_since == 0 )) && down_since=$now && log "link DOWN detectado"
+    write_metrics 0 "$changes"
+    if (( now - down_since >= LINK_DOWN_GRACE )); then
+      if heal "$escalation"; then
+        (( escalation < 3 )) && escalation=$(( escalation + 1 ))
+      fi
+    fi
+  fi
+  sleep "$CHECK_INTERVAL"
+done

--- a/scripts/protonvpn_unit_selfheal
+++ b/scripts/protonvpn_unit_selfheal
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Reconcilia a unit wg-quick@protonvpn com o estado real do kernel.
+# Incidente 15/07/2026: unit ficou "failed" por 1,5 dia com o túnel
+# perfeitamente vivo no kernel (handshake ativo) — estado cosmético
+# que confunde monitoração e bloqueia dependências.
+#
+# Regras (conservadoras):
+#   - unit ok                        → nada
+#   - unit failed + handshake fresco → systemctl reset-failed (cosmético, zero risco)
+#   - handshake velho + WAN com internet → restart real (max 1/h; o dispatcher
+#     51-protonvpn-policy-routing reaplica as regras de rota no ifup)
+#   - WAN sem internet → não age (restart seria inútil e mascararia a causa)
+
+set -uo pipefail
+
+UNIT="${UNIT:-wg-quick@protonvpn.service}"
+WG_IFACE="${WG_IFACE:-protonvpn}"
+WAN_IFACE="${WAN_IFACE:-eth-wan}"
+HANDSHAKE_MAX_AGE="${HANDSHAKE_MAX_AGE:-600}"
+STATE_DIR="${STATE_DIR:-/var/lib/protonvpn-unit-selfheal}"
+PROM_FILE="${PROM_FILE:-/var/lib/prometheus/node-exporter/protonvpn_unit_selfheal.prom}"
+
+mkdir -p "$STATE_DIR"
+log() { echo "[$(date '+%F %T')] $*"; }
+
+handshake_age() {
+  local hs
+  hs=$(wg show "$WG_IFACE" latest-handshakes 2>/dev/null | awk '{print $2}' | sort -rn | head -1)
+  [[ -n "$hs" && "$hs" != "0" ]] || { echo 999999; return; }
+  echo $(( $(date +%s) - hs ))
+}
+
+wan_has_internet() {
+  curl -s -o /dev/null --interface "$WAN_IFACE" -m 8 https://1.1.1.1 2>/dev/null
+}
+
+restart_rate_ok() {
+  local last
+  last=$(cat "$STATE_DIR/last_restart" 2>/dev/null || echo 0)
+  (( $(date +%s) - last > 3600 ))
+}
+
+unit_state=$(systemctl is-active "$UNIT" 2>/dev/null || true)
+failed=$(systemctl is-failed "$UNIT" >/dev/null 2>&1 && echo 1 || echo 0)
+age=$(handshake_age)
+action="none"
+tunnel_ok=0
+(( age < HANDSHAKE_MAX_AGE )) && tunnel_ok=1
+
+if [[ "$unit_state" == "active" && "$tunnel_ok" == "1" ]]; then
+  action="none"
+elif [[ "$failed" == "1" && "$tunnel_ok" == "1" ]]; then
+  log "unit failed mas túnel vivo (handshake ${age}s) — reset-failed cosmético"
+  systemctl reset-failed "$UNIT" && action="reset_failed"
+elif [[ "$tunnel_ok" == "0" ]]; then
+  if wan_has_internet; then
+    if restart_rate_ok; then
+      log "túnel morto (handshake ${age}s) e WAN ok — reiniciando $UNIT"
+      if systemctl restart "$UNIT"; then
+        date +%s > "$STATE_DIR/last_restart"
+        action="restart"
+      else
+        action="restart_failed"
+      fi
+    else
+      log "túnel morto mas restart em rate limit (1/h) — aguardando"
+      action="rate_limited"
+    fi
+  else
+    log "túnel morto e WAN sem internet — causa upstream, não agindo"
+    action="wan_down_skip"
+  fi
+fi
+
+restarts=$(cat "$STATE_DIR/restarts_total" 2>/dev/null || echo 0)
+resets=$(cat "$STATE_DIR/resets_total" 2>/dev/null || echo 0)
+[[ "$action" == "restart" ]] && restarts=$((restarts+1)) && echo "$restarts" > "$STATE_DIR/restarts_total"
+[[ "$action" == "reset_failed" ]] && resets=$((resets+1)) && echo "$resets" > "$STATE_DIR/resets_total"
+
+mkdir -p "$(dirname "$PROM_FILE")" 2>/dev/null
+cat > "${PROM_FILE}.tmp" <<EOF
+# HELP protonvpn_tunnel_ok Handshake WireGuard fresco (<${HANDSHAKE_MAX_AGE}s)
+# TYPE protonvpn_tunnel_ok gauge
+protonvpn_tunnel_ok ${tunnel_ok}
+# HELP protonvpn_handshake_age_seconds Idade do último handshake
+# TYPE protonvpn_handshake_age_seconds gauge
+protonvpn_handshake_age_seconds ${age}
+# HELP protonvpn_unit_selfheal_restarts_total Restarts reais aplicados
+# TYPE protonvpn_unit_selfheal_restarts_total counter
+protonvpn_unit_selfheal_restarts_total ${restarts}
+# HELP protonvpn_unit_selfheal_resets_total reset-failed cosméticos aplicados
+# TYPE protonvpn_unit_selfheal_resets_total counter
+protonvpn_unit_selfheal_resets_total ${resets}
+# HELP protonvpn_unit_selfheal_last_run_timestamp Unix time da última execução
+# TYPE protonvpn_unit_selfheal_last_run_timestamp gauge
+protonvpn_unit_selfheal_last_run_timestamp $(date +%s)
+EOF
+mv "${PROM_FILE}.tmp" "$PROM_FILE" 2>/dev/null || true
+
+log "estado: unit=$unit_state handshake=${age}s ação=$action"
+exit 0

--- a/systemd/ethwan-selfheal.service
+++ b/systemd/ethwan-selfheal.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=eth-wan Selfheal — escada de recuperação do link WAN (RTL8153) com rate limit
+Documentation=https://github.com/eddiejdi/eddie-auto-dev
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/ethwan_selfheal
+Restart=on-failure
+RestartSec=30
+
+Environment=IFACE=eth-wan
+Environment=CHECK_INTERVAL=30
+Environment=LINK_DOWN_GRACE=20
+Environment=BRINGUP_SCRIPT=/usr/local/bin/eth-wan-bringup.sh
+Environment=USB_PORT=2-2
+Environment=HEAL_COOLDOWN=120
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ethwan-selfheal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/iot-presence-watchdog.service
+++ b/systemd/iot-presence-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=IoT Presence Watchdog — observa MACs da allowlist e alerta via Telegram (nunca age)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=-/etc/default/eddie-common
+ExecStart=/usr/local/bin/iot_presence_watchdog.py
+Environment=BYPASS_CONF=/etc/iot-vpn-bypass.conf
+Environment=LEASES_FILE=/var/lib/misc/dnsmasq.leases
+Environment=ABSENT_ALERT_MIN=30
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=iot-presence-watchdog
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/iot-presence-watchdog.timer
+++ b/systemd/iot-presence-watchdog.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Roda o IoT Presence Watchdog a cada 5 minutos
+
+[Timer]
+OnBootSec=4min
+OnUnitActiveSec=5min
+Persistent=true
+Unit=iot-presence-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/protonvpn-unit-selfheal.service
+++ b/systemd/protonvpn-unit-selfheal.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Reconcilia wg-quick@protonvpn (unit) com o estado real do túnel no kernel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/local/bin/protonvpn_unit_selfheal
+Environment=UNIT=wg-quick@protonvpn.service
+Environment=WG_IFACE=protonvpn
+Environment=WAN_IFACE=eth-wan
+Environment=HANDSHAKE_MAX_AGE=600
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=protonvpn-unit-selfheal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/protonvpn-unit-selfheal.timer
+++ b/systemd/protonvpn-unit-selfheal.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Roda o reconciliador da unit do ProtonVPN a cada 5 minutos
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+Persistent=true
+Unit=protonvpn-unit-selfheal.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/tuya-token-selfheal.service
+++ b/systemd/tuya-token-selfheal.service
@@ -16,7 +16,7 @@ Environment=HA_CONFIG_ENTRIES=/home/homelab/homeassistant/config/.storage/core.c
 Environment=BRIDGE_RUNTIME_TOKENS=/var/lib/pandaplus-bridge/tuya_tokens_runtime.json
 Environment=STATE_FILE=/var/lib/tuya-selfheal/state.json
 Environment=PROM_FILE=/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom
-Environment=MAX_HEALS_24H=3
+Environment=MAX_HEALS_24H=6
 Environment=HA_BOOT_WAIT_S=300
 StandardOutput=journal
 StandardError=journal

--- a/tests/test_iot_presence_watchdog.py
+++ b/tests/test_iot_presence_watchdog.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "homelab" / "iot_presence_watchdog.py"
+)
+_SPEC = importlib.util.spec_from_file_location("iot_presence_watchdog", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+wd = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(wd)
+
+NOW = 1_784_300_000.0
+
+CONF = """ISP_GW=192.168.15.1
+DEVICE_MAC=38:A5:C9:E0:5D:D9
+DEVICE_MAC=4c:a9:19:0d:dd:bf
+MAC_IP_4ca9190dddbf=192.168.15.127
+DEVICE_MAC=4c:a9:19:0d:dd:bf
+"""
+
+
+def test_parse_allowlist_macs_dedup_lowercase() -> None:
+    assert wd.parse_allowlist_macs(CONF) == [
+        "38:a5:c9:e0:5d:d9",
+        "4c:a9:19:0d:dd:bf",
+    ]
+
+
+def test_parse_leases_ignores_expired() -> None:
+    leases = (
+        f"{int(NOW) + 3600} aa:bb:cc:dd:ee:01 192.168.15.10 dev1 *\n"
+        f"{int(NOW) - 10} aa:bb:cc:dd:ee:02 192.168.15.11 dev2 *\n"
+        "0 40:ae:30:81:c7:6e 192.168.15.113 TL-WPA4220 *\n"
+    )
+    got = wd.parse_leases(leases, now=NOW)
+    assert got == {"aa:bb:cc:dd:ee:01": "192.168.15.10"}
+
+
+def test_parse_arp_skips_failed_and_ipv6() -> None:
+    neigh = (
+        "192.168.15.105 dev eth-onboard lladdr F8:17:2D:F8:59:52 REACHABLE\n"
+        "192.168.15.104 dev eth-onboard FAILED\n"
+        "fe80::1 dev eth-wan lladdr 00:d4:9e:16:6a:19 router STALE\n"
+        "192.168.15.121 dev eth-onboard lladdr 38:a5:c9:da:4c:71 STALE\n"
+    )
+    got = wd.parse_arp(neigh)
+    assert got == {
+        "f8:17:2d:f8:59:52": "192.168.15.105",
+        "38:a5:c9:da:4c:71": "192.168.15.121",
+    }
+
+
+def test_evaluate_presence_alert_only_after_threshold() -> None:
+    macs = ["aa:bb:cc:dd:ee:01"]
+    # sumiu agora — sem alerta ainda
+    state, alerts = wd.evaluate_presence(macs, {}, {}, {}, now=NOW, absent_alert_s=1800)
+    assert alerts == []
+    assert state["devices"][macs[0]]["absent_since"] == NOW
+
+    # 31 min depois — alerta único
+    state2, alerts2 = wd.evaluate_presence(
+        macs, {}, {}, state, now=NOW + 1860, absent_alert_s=1800
+    )
+    assert len(alerts2) == 1 and "fora do WiFi" in alerts2[0]
+    assert state2["devices"][macs[0]]["alerted"] is True
+
+    # continua fora — não repete alerta
+    _, alerts3 = wd.evaluate_presence(
+        macs, {}, {}, state2, now=NOW + 3600, absent_alert_s=1800
+    )
+    assert alerts3 == []
+
+
+def test_evaluate_presence_recovery_alert_and_reset() -> None:
+    macs = ["aa:bb:cc:dd:ee:01"]
+    prev = {
+        "devices": {
+            macs[0]: {
+                "present": False,
+                "last_ip": "192.168.15.50",
+                "absent_since": NOW - 7200,
+                "alerted": True,
+            }
+        }
+    }
+    state, alerts = wd.evaluate_presence(
+        macs, {macs[0]: "192.168.15.99"}, {}, prev, now=NOW
+    )
+    assert len(alerts) == 1 and "de volta" in alerts[0]
+    dev = state["devices"][macs[0]]
+    assert dev["present"] and dev["absent_since"] == 0 and dev["alerted"] is False
+    assert dev["last_ip"] == "192.168.15.99"
+
+
+def test_render_prom_counts() -> None:
+    state = {
+        "devices": {
+            "aa:bb:cc:dd:ee:01": {"present": True, "last_ip": "192.168.15.10"},
+            "aa:bb:cc:dd:ee:02": {"present": False, "last_ip": ""},
+        },
+        "alerts_sent_total": 4,
+    }
+    out = wd.render_prom(state)
+    assert 'iot_device_present{mac="aa:bb:cc:dd:ee:01",ip="192.168.15.10"} 1' in out
+    assert 'iot_device_present{mac="aa:bb:cc:dd:ee:02",ip="unknown"} 0' in out
+    assert "iot_devices_present_count 1" in out
+    assert "iot_devices_total 2" in out
+    assert "iot_presence_alerts_sent_total 4" in out
+
+
+def test_send_telegram_noop_without_creds(monkeypatch) -> None:
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+    assert wd.send_telegram(["msg"]) is False

--- a/tools/homelab/iot_presence_watchdog.py
+++ b/tools/homelab/iot_presence_watchdog.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Watchdog de presença dos dispositivos IoT da allowlist.
+
+Incidente 16–17/07/2026: 6 dispositivos Tuya/smart sumiram do WiFi e
+ninguém percebeu por dias. Este watchdog observa (lease DHCP + ARP) os
+MACs de /etc/iot-vpn-bypass.conf e alerta via Telegram quando um
+dispositivo some por mais de ABSENT_ALERT_MIN — e quando volta.
+
+Deliberadamente **não executa nenhuma ação corretiva**: dispositivo fora
+do WiFi só se resolve fisicamente; o valor aqui é detecção rápida.
+Métricas via textfile collector para o Grafana.
+
+Credenciais do Telegram vêm do ambiente (EnvironmentFile da unit —
+/etc/default/eddie-common, fonte canônica); nada é lido/gravado aqui.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("iot-presence")
+
+BYPASS_CONF = Path(os.environ.get("BYPASS_CONF", "/etc/iot-vpn-bypass.conf"))
+LEASES_FILE = Path(os.environ.get("LEASES_FILE", "/var/lib/misc/dnsmasq.leases"))
+STATE_FILE = Path(os.environ.get("STATE_FILE", "/var/lib/iot-presence/state.json"))
+PROM_FILE = Path(
+    os.environ.get("PROM_FILE", "/var/lib/prometheus/node-exporter/iot_presence.prom")
+)
+ABSENT_ALERT_MIN = int(os.environ.get("ABSENT_ALERT_MIN", "30"))
+
+MAC_RE = re.compile(r"^DEVICE_MAC=([0-9a-fA-F:]{17})\s*$", re.MULTILINE)
+
+
+def parse_allowlist_macs(conf_text: str) -> list[str]:
+    return sorted({m.lower() for m in MAC_RE.findall(conf_text)})
+
+
+def parse_leases(leases_text: str, now: float | None = None) -> dict[str, str]:
+    """MAC→IP dos leases ainda válidos (expiry no futuro)."""
+    now = time.time() if now is None else now
+    out: dict[str, str] = {}
+    for line in leases_text.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0].isdigit() and float(parts[0]) > now:
+            out[parts[1].lower()] = parts[2]
+    return out
+
+
+def parse_arp(neigh_output: str) -> dict[str, str]:
+    """MAC→IP das entradas ARP não-FAILED (IPv4)."""
+    out: dict[str, str] = {}
+    for line in neigh_output.splitlines():
+        if "FAILED" in line or "lladdr" not in line:
+            continue
+        parts = line.split()
+        try:
+            ip = parts[0]
+            mac = parts[parts.index("lladdr") + 1].lower()
+        except (ValueError, IndexError):
+            continue
+        if ":" in ip:  # ignora IPv6 link-local
+            continue
+        out[mac] = ip
+    return out
+
+
+def evaluate_presence(
+    macs: list[str],
+    leases: dict[str, str],
+    arp: dict[str, str],
+    prev_state: dict,
+    now: float | None = None,
+    absent_alert_s: int = ABSENT_ALERT_MIN * 60,
+) -> tuple[dict, list[str]]:
+    """Retorna (novo estado, lista de mensagens de alerta).
+
+    Alerta uma única vez por transição: ausente > absent_alert_s, e no retorno.
+    """
+    now = time.time() if now is None else now
+    state = {"devices": {}, "alerts_sent_total": prev_state.get("alerts_sent_total", 0)}
+    alerts: list[str] = []
+    for mac in macs:
+        ip = leases.get(mac) or arp.get(mac) or ""
+        present = bool(ip)
+        prev = prev_state.get("devices", {}).get(mac, {})
+        absent_since = prev.get("absent_since", 0)
+        alerted = prev.get("alerted", False)
+
+        if present:
+            if alerted:
+                alerts.append(f"✅ IoT de volta: {mac} ({ip})")
+            absent_since = 0
+            alerted = False
+        else:
+            if absent_since == 0:
+                absent_since = now
+            if not alerted and now - absent_since >= absent_alert_s:
+                mins = int((now - absent_since) / 60)
+                last_ip = prev.get("last_ip", "?")
+                alerts.append(
+                    f"⚠️ IoT fora do WiFi há {mins} min: {mac} (último IP {last_ip})"
+                )
+                alerted = True
+
+        state["devices"][mac] = {
+            "present": present,
+            "last_ip": ip or prev.get("last_ip", ""),
+            "absent_since": absent_since,
+            "alerted": alerted,
+        }
+    return state, alerts
+
+
+def render_prom(state: dict) -> str:
+    lines = [
+        "# HELP iot_device_present Dispositivo da allowlist visível (lease DHCP ou ARP)",
+        "# TYPE iot_device_present gauge",
+    ]
+    for mac, info in sorted(state["devices"].items()):
+        ip = info.get("last_ip") or "unknown"
+        lines.append(
+            f'iot_device_present{{mac="{mac}",ip="{ip}"}} {1 if info["present"] else 0}'
+        )
+    present = sum(1 for i in state["devices"].values() if i["present"])
+    lines += [
+        "# HELP iot_devices_present_count Dispositivos presentes / total da allowlist",
+        "# TYPE iot_devices_present_count gauge",
+        f"iot_devices_present_count {present}",
+        "# TYPE iot_devices_total gauge",
+        f"iot_devices_total {len(state['devices'])}",
+        "# TYPE iot_presence_alerts_sent_total counter",
+        f"iot_presence_alerts_sent_total {state['alerts_sent_total']}",
+        "# TYPE iot_presence_last_run_timestamp gauge",
+        f"iot_presence_last_run_timestamp {int(time.time())}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def send_telegram(msgs: list[str]) -> bool:
+    """Envia via bot do Telegram; credenciais só do ambiente da unit."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat = os.environ.get("TELEGRAM_CHAT_ID", "")
+    if not token or not chat or not msgs:
+        return False
+    body = urllib.parse.urlencode(
+        {"chat_id": chat, "text": "📡 IoT presence\n" + "\n".join(msgs)}
+    ).encode()
+    url = "https://api.telegram.org/bot" + token + "/sendMessage"
+    try:
+        urllib.request.urlopen(url, body, timeout=10)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Falha ao enviar Telegram: %s", exc)
+        return False
+
+
+def main() -> int:
+    macs = parse_allowlist_macs(BYPASS_CONF.read_text(encoding="utf-8"))
+    leases = parse_leases(LEASES_FILE.read_text(encoding="utf-8"))
+    arp = parse_arp(
+        subprocess.run(
+            ["ip", "neigh", "show"], capture_output=True, text=True, timeout=10
+        ).stdout
+    )
+    try:
+        prev = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        prev = {}
+
+    state, alerts = evaluate_presence(macs, leases, arp, prev)
+    if alerts:
+        for a in alerts:
+            log.info(a)
+        if send_telegram(alerts):
+            state["alerts_sent_total"] += len(alerts)
+
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state), encoding="utf-8")
+    PROM_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PROM_FILE.with_suffix(".prom.tmp")
+    tmp.write_text(render_prom(state), encoding="utf-8")
+    tmp.replace(PROM_FILE)
+
+    present = sum(1 for i in state["devices"].values() if i["present"])
+    log.info("presença: %d/%d dispositivos visíveis", present, len(macs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Contexto
Relatório de incidentes 11–17/07 identificou 3 causas-raiz recorrentes sem automação de recuperação: link WAN físico instável, unit do ProtonVPN dessincronizada do kernel, e IoTs sumindo do WiFi sem detecção por dias.

## Princípio de segurança (lição do restart-loop do guardian)
Cada heal contabiliza o custo da própria ação: rate limits por nível, cooldowns, nunca age sobre estado saudável, e falha de monitoração nunca dispara ação.

## Componentes
| Selfheal | Modo | Ações | Limites |
|---|---|---|---|
| `ethwan-selfheal` | service contínuo (30s) | escada: EEE-off+bounce → bringup → USB rebind | 6/h, 4/h, 2/h + cooldown 120s |
| `protonvpn-unit-selfheal` | timer 5min | reset-failed (cosmético) ou restart real | restart 1/h; WAN sem internet = não age |
| `iot-presence-watchdog` | timer 5min | **nenhuma** — só alerta Telegram + métricas | 1 alerta por transição (30min) |
| `tuya-token-selfheal` | (existente) | — | MAX_HEALS_24H 3→6 |

Métricas textfile p/ Grafana: `ethwan_*`, `protonvpn_*`, `iot_device_present{mac,ip}`.
Deploy: `deploy-network-selfheal.yml` (runner self-hosted homelab, smoke test das 3 suítes).
Testes: 22 passed (8 novos). Variáveis catalogadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)