### PR TITLE
fix(trading): harden KuCoin credentials on deploy restart

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -227,36 +227,159 @@ def _format_market_order_notification(
     return "\n".join(lines)
 
 
-def _load_credentials():
-    """Carrega credenciais KuCoin com prioridade: Agent Secrets > env vars."""
-    try:
-        from secrets_helper import get_kucoin_credentials_with_source
+def _agent_identity() -> dict[str, str]:
+    """Identidade do processo (symbol/profile/unit) para alertas e logs."""
+    config_name = (
+        os.getenv("COIN_CONFIG_FILE")
+        or os.getenv("BTC_CONFIG_FILE")
+        or ""
+    ).strip()
+    unit = ""
+    if config_name:
+        stem = Path(config_name).name
+        if stem.startswith("config_") and stem.endswith(".json"):
+            unit = stem[len("config_") : -len(".json")]
+        else:
+            unit = Path(stem).stem
 
-        api_key, api_secret, api_passphrase, source = get_kucoin_credentials_with_source()
-    except ImportError:
-        api_key = os.getenv("KUCOIN_API_KEY", "") or os.getenv("API_KEY", "")
-        api_secret = os.getenv("KUCOIN_API_SECRET", "") or os.getenv("API_SECRET", "")
-        api_passphrase = os.getenv("KUCOIN_API_PASSPHRASE", "") or os.getenv("API_PASSPHRASE", "")
-        source = "env"
+    symbol = (os.getenv("COIN_SYMBOL") or "").strip().upper()
+    profile = (os.getenv("TRADING_PROFILE") or "").strip().lower()
+    if unit and ("_" in unit):
+        # ETH_USDT_conservative → symbol=ETH-USDT, profile=conservative
+        parts = unit.rsplit("_", 1)
+        if len(parts) == 2 and parts[1] in {"conservative", "aggressive", "shadow", "default"}:
+            if not profile:
+                profile = parts[1]
+            if not symbol:
+                symbol = parts[0].replace("_", "-")
 
-    if api_key and api_secret and api_passphrase:
-        logger.info(f"🔑 KuCoin credentials loaded from {source} (key: {api_key[:8]}...{api_key[-4:]})")
-        if not source.startswith("agent-secrets"):
-            _send_telegram_alert(
-                f"🚨 *BTC Trading Agent — Fallback de Credenciais*\n\n"
-                f"As credenciais KuCoin foram carregadas com fallback.\n"
-                f"*Origem:* {source}\n"
-                f"*Ação:* Verificar a integração do Agent Secrets no homelab."
+    if not symbol and "-" in unit:
+        symbol = unit
+    label = unit or symbol or profile or "unknown"
+    return {
+        "unit": unit or label,
+        "symbol": symbol or "?",
+        "profile": profile or "?",
+        "label": label,
+        "systemd": f"crypto-agent@{unit}" if unit else "crypto-agent",
+    }
+
+
+def _load_credentials(
+    *,
+    max_attempts: int = 4,
+    base_delay_sec: float = 0.75,
+    sleep_fn=time.sleep,
+):
+    """Carrega credenciais KuCoin com prioridade: Agent Secrets > env vars.
+
+    Em restart em massa o Secrets Agent pode falhar transitóriamente — retenta
+    com backoff antes de alertar no Telegram. O título do alerta inclui o
+    agent real (não "BTC" genérico).
+    """
+    identity = _agent_identity()
+    agent_label = identity["label"]
+    symbol = identity["symbol"]
+    profile = identity["profile"]
+    unit_name = identity["systemd"]
+
+    api_key = api_secret = api_passphrase = ""
+    source = "none"
+    last_error: Exception | None = None
+
+    for attempt in range(1, max(1, int(max_attempts)) + 1):
+        try:
+            from secrets_helper import clear_secret_cache, get_kucoin_credentials_with_source
+
+            # Evita reusar cache parcial/vazio de tentativas anteriores sob race.
+            if attempt > 1:
+                clear_secret_cache()
+            api_key, api_secret, api_passphrase, source = get_kucoin_credentials_with_source()
+        except ImportError:
+            api_key = os.getenv("KUCOIN_API_KEY", "") or os.getenv("API_KEY", "")
+            api_secret = os.getenv("KUCOIN_API_SECRET", "") or os.getenv("API_SECRET", "")
+            api_passphrase = os.getenv("KUCOIN_API_PASSPHRASE", "") or os.getenv("API_PASSPHRASE", "")
+            source = "env"
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                "⚠️ Credenciais KuCoin tentativa %s/%s falhou (%s/%s): %s",
+                attempt,
+                max_attempts,
+                symbol,
+                profile,
+                exc,
             )
-    else:
-        logger.error("❌ Nenhuma credencial KuCoin encontrada (Agent Secrets nem env vars)")
-        _send_telegram_alert(
-            "🔴 *BTC Trading Agent — ERRO CRÍTICO*\n\n"
-            "Nenhuma credencial KuCoin disponível!\n"
-            "Nem o Agent Secrets nem as env vars possuem as chaves.\n"
-            "*O agente NÃO conseguirá operar.*"
-        )
+            api_key = api_secret = api_passphrase = ""
+            source = f"error:{type(exc).__name__}"
 
+        if api_key and api_secret and api_passphrase:
+            if attempt > 1:
+                logger.info(
+                    "🔑 KuCoin credentials loaded from %s after %s attempt(s) "
+                    "(%s / %s) (key: %s...%s)",
+                    source,
+                    attempt,
+                    symbol,
+                    profile,
+                    api_key[:8],
+                    api_key[-4:],
+                )
+            else:
+                logger.info(
+                    "🔑 KuCoin credentials loaded from %s (%s / %s) (key: %s...%s)",
+                    source,
+                    symbol,
+                    profile,
+                    api_key[:8],
+                    api_key[-4:],
+                )
+            if not str(source).startswith("agent-secrets"):
+                _send_telegram_alert(
+                    f"🚨 *Trading Agent — Fallback de Credenciais*\n\n"
+                    f"• Agent: `{agent_label}`\n"
+                    f"• Par: `{symbol}`\n"
+                    f"• Profile: `{profile}`\n"
+                    f"• Unit: `{unit_name}`\n"
+                    f"• Origem: `{source}`\n"
+                    f"• Ação: verificar Secrets Agent / env no homelab."
+                )
+            return api_key, api_secret, api_passphrase
+
+        if attempt < max_attempts:
+            delay = float(base_delay_sec) * attempt
+            logger.warning(
+                "⚠️ Credenciais KuCoin incompletas tentativa %s/%s (%s / %s, source=%s) "
+                "— retry em %.1fs",
+                attempt,
+                max_attempts,
+                symbol,
+                profile,
+                source,
+                delay,
+            )
+            sleep_fn(delay)
+
+    logger.error(
+        "❌ Nenhuma credencial KuCoin encontrada após %s tentativas "
+        "(%s / %s, unit=%s, last_error=%s)",
+        max_attempts,
+        symbol,
+        profile,
+        unit_name,
+        last_error,
+    )
+    _send_telegram_alert(
+        "🔴 *Trading Agent — ERRO CRÍTICO*\n\n"
+        "Nenhuma credencial KuCoin disponível após retries.\n"
+        f"• Agent: `{agent_label}`\n"
+        f"• Par: `{symbol}`\n"
+        f"• Profile: `{profile}`\n"
+        f"• Unit: `{unit_name}`\n"
+        f"• Tentativas: `{max_attempts}`\n"
+        "Nem o Agent Secrets nem as env vars devolveram as 3 chaves.\n"
+        "*Este processo NÃO conseguirá operar em live.*"
+    )
     return api_key, api_secret, api_passphrase
 
 

--- a/btc_trading_agent/secrets_helper.py
+++ b/btc_trading_agent/secrets_helper.py
@@ -28,6 +28,11 @@ _cache: dict[str, str] = {}
 _sa_client: Optional[object] = None
 
 
+def clear_secret_cache() -> None:
+    """Limpa cache de secrets (útil em retry após race no Secrets Agent)."""
+    _cache.clear()
+
+
 def _iter_kucoin_secret_names() -> tuple[str, ...]:
     """Retorna os nomes de secret aceitos para as credenciais KuCoin."""
     custom = os.getenv("KUCOIN_SECRET_NAMES", "").strip()

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-18T23:08:02.022751+00:00",
+  "generated_at": "2026-07-18T23:19:39.944977+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-18T23:08:02.022751+00:00`
+- Generated at: `2026-07-18T23:19:39.944977+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `179`

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -564,7 +564,22 @@ sudo systemctl enable rss-sentiment-exporter.service 2>/dev/null || true
 sudo systemctl try-restart rss-sentiment-exporter.service 2>/dev/null || true
 
 sudo systemctl daemon-reload
-sudo systemctl restart "${AGENT_SERVICES[@]}"
+
+# Restart escalonado: restart em massa sobrecarrega o Secrets Agent e gera
+# falsos "Nenhuma credencial KuCoin" (ex.: ETH_USDT_conservative no deploy #225).
+AGENT_RESTART_STAGGER_SEC="${AGENT_RESTART_STAGGER_SEC:-2}"
+echo "♻️ Reiniciando agents com stagger ${AGENT_RESTART_STAGGER_SEC}s..."
+idx=0
+for svc in "${AGENT_SERVICES[@]}"; do
+  idx=$((idx + 1))
+  echo "  [${idx}/${#AGENT_SERVICES[@]}] restart ${svc}"
+  sudo systemctl restart "${svc}" || {
+    echo "⚠️  falha ao reiniciar ${svc} — seguindo" >&2
+  }
+  if [[ "${idx}" -lt "${#AGENT_SERVICES[@]}" ]]; then
+    sleep "${AGENT_RESTART_STAGGER_SEC}"
+  fi
+done
 
 if systemctl is-active --quiet "${LEGACY_EXPORTER_SERVICES[@]}"; then
   echo "ℹ️ Legacy BTC exporter detectado; desativando autocoinbot-exporter para evitar drift de métricas"
@@ -573,7 +588,19 @@ sudo systemctl stop "${LEGACY_EXPORTER_SERVICES[@]}" 2>/dev/null || true
 sudo systemctl disable "${LEGACY_EXPORTER_SERVICES[@]}" 2>/dev/null || true
 sudo systemctl reset-failed "${LEGACY_EXPORTER_SERVICES[@]}" 2>/dev/null || true
 
-sudo systemctl restart "${EXPORTER_SERVICES[@]}"
+EXPORTER_RESTART_STAGGER_SEC="${EXPORTER_RESTART_STAGGER_SEC:-1}"
+echo "♻️ Reiniciando exporters com stagger ${EXPORTER_RESTART_STAGGER_SEC}s..."
+eidx=0
+for svc in "${EXPORTER_SERVICES[@]}"; do
+  eidx=$((eidx + 1))
+  echo "  [${eidx}/${#EXPORTER_SERVICES[@]}] restart ${svc}"
+  sudo systemctl restart "${svc}" || {
+    echo "⚠️  falha ao reiniciar ${svc} — seguindo" >&2
+  }
+  if [[ "${eidx}" -lt "${#EXPORTER_SERVICES[@]}" ]]; then
+    sleep "${EXPORTER_RESTART_STAGGER_SEC}"
+  fi
+done
 EXPORTER_STATUS_SERVICES=("${EXPORTER_SERVICES[@]}")
 
 sleep 5

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -61,6 +61,18 @@ def test_script_restarts_all_crypto_exporters_using_shared_exporter_code() -> No
         assert unit in content
 
 
+def test_script_staggers_agent_and_exporter_restarts() -> None:
+    """Restart em massa sobrecarrega Secrets Agent; deploy deve escalonar."""
+    content = _load_script()
+    assert "AGENT_RESTART_STAGGER_SEC" in content
+    assert "EXPORTER_RESTART_STAGGER_SEC" in content
+    assert 'for svc in "${AGENT_SERVICES[@]}"; do' in content
+    assert 'sudo systemctl restart "${svc}"' in content
+    # Não deve mais reiniciar o array inteiro de uma vez
+    assert 'sudo systemctl restart "${AGENT_SERVICES[@]}"' not in content
+    assert 'sudo systemctl restart "${EXPORTER_SERVICES[@]}"' not in content
+
+
 def test_script_restarts_all_crypto_agents_that_share_runtime_code() -> None:
     """Todos os perfis que rodam o trading_agent.py compartilhado devem ser
     reiniciados no deploy — senão ficam com código antigo em memória (foi o que

--- a/tests/test_kucoin_api.py
+++ b/tests/test_kucoin_api.py
@@ -329,7 +329,7 @@ class TestLoadCredentials:
             ),
             patch("kucoin_api._send_telegram_alert") as mock_tg,
         ):
-            creds = kucoin_api._load_credentials()
+            creds = kucoin_api._load_credentials(max_attempts=1)
 
         assert creds == ("key123456", "secret789", "pass")
         mock_tg.assert_not_called()
@@ -342,10 +342,64 @@ class TestLoadCredentials:
             ),
             patch("kucoin_api._send_telegram_alert") as mock_tg,
         ):
-            creds = kucoin_api._load_credentials()
+            creds = kucoin_api._load_credentials(max_attempts=1)
 
         assert creds == ("key123456", "secret789", "pass")
         mock_tg.assert_called_once()
+        msg = mock_tg.call_args.args[0]
+        assert "Fallback de Credenciais" in msg
+        assert "BTC Trading Agent —" not in msg  # título genérico BTC removido
+
+    def test_retry_antes_de_alertar_critico(self) -> None:
+        calls = {"n": 0}
+
+        def _side_effect():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return ("", "", "", "none")
+            return ("key123456", "secret789", "pass", "agent-secrets:kucoin/homelab")
+
+        with (
+            patch(
+                "secrets_helper.get_kucoin_credentials_with_source",
+                side_effect=_side_effect,
+            ),
+            patch("secrets_helper.clear_secret_cache") as mock_clear,
+            patch("kucoin_api._send_telegram_alert") as mock_tg,
+        ):
+            creds = kucoin_api._load_credentials(
+                max_attempts=4,
+                base_delay_sec=0.01,
+                sleep_fn=lambda _s: None,
+            )
+
+        assert creds == ("key123456", "secret789", "pass")
+        assert calls["n"] == 3
+        assert mock_clear.call_count >= 1
+        mock_tg.assert_not_called()
+
+    def test_alerta_critico_inclui_identity_do_agent(self, monkeypatch) -> None:
+        monkeypatch.setenv("COIN_CONFIG_FILE", "config_ETH_USDT_conservative.json")
+        with (
+            patch(
+                "secrets_helper.get_kucoin_credentials_with_source",
+                return_value=("", "", "", "none"),
+            ),
+            patch("kucoin_api._send_telegram_alert") as mock_tg,
+        ):
+            creds = kucoin_api._load_credentials(
+                max_attempts=2,
+                base_delay_sec=0.01,
+                sleep_fn=lambda _s: None,
+            )
+
+        assert creds == ("", "", "")
+        mock_tg.assert_called_once()
+        msg = mock_tg.call_args.args[0]
+        assert "ETH_USDT_conservative" in msg or "ETH-USDT" in msg
+        assert "conservative" in msg
+        assert "crypto-agent@ETH_USDT_conservative" in msg
+        assert "BTC Trading Agent — ERRO CRÍTICO" not in msg
 
 
 # ========================= get_price =========================


### PR DESCRIPTION
## Summary
- `_load_credentials` retenta com backoff (default 4×) e limpa cache do Secrets Agent entre tentativas antes de alertar.
- Alertas Telegram passam a identificar **agent real** (`ETH-USDT` / `conservative` / unit), em vez do título genérico “BTC Trading Agent”.
- Deploy escalona `systemctl restart` de agents (2s) e exporters (1s) para não saturar o Secrets Agent no restart em massa.

## Context
No deploy do #225, `ETH_USDT_conservative` falhou uma vez ao ler `api_secret` sob carga e disparou falso crítico; no retry do systemd as credenciais subiram normalmente.

## Test plan
- [x] `pytest tests/test_kucoin_api.py::TestLoadCredentials tests/test_deploy_btc_trading_profiles_script.py::test_script_staggers_agent_and_exporter_restarts tests/test_btc_secrets_helper.py`
- [ ] Merge → Deploy BTC Trading Profiles
- [ ] Confirmar que restart escalonado não gera alerta crítico em massa