### PR TITLE
fix(trading): stop schema DDL on Prometheus scrape (deadlocks)

### DIFF
--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -72,6 +72,64 @@ class MetricsCollector:
         cur.close()
         return conn
 
+    def conversion_metrics_snapshot(self) -> Dict:
+        """Métricas de conversão intermoedas — sem TrainingDatabase()/DDL.
+
+        Importante: NÃO instanciar TrainingDatabase aqui. O construtor antigo
+        reexecutava ALTER TABLE em btc.decisions a cada scrape do Prometheus
+        e gerava deadlocks com os agents (AccessExclusiveLock vs RowShareLock).
+        """
+        snap = {
+            "by_status": {},
+            "last_cost_pct": 0.0,
+            "last_hops": 0.0,
+            "last_savings_bps": 0.0,
+            "last_success_ts": 0.0,
+            "lock_held": 0,
+        }
+        conn = self._get_conn()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT status, COUNT(*) AS n
+                FROM conversion_requests
+                GROUP BY status
+                """
+            )
+            snap["by_status"] = {row[0]: int(row[1]) for row in cur.fetchall()}
+            cur.execute(
+                """
+                SELECT plan_json, EXTRACT(EPOCH FROM created_at) AS ts
+                FROM conversion_requests
+                WHERE status IN ('done', 'simulated')
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            )
+            last = cur.fetchone()
+            last_plan = last[0] if last else None
+            if isinstance(last_plan, str):
+                try:
+                    last_plan = json.loads(last_plan)
+                except Exception:
+                    last_plan = {}
+            last_plan = last_plan or {}
+            snap["last_cost_pct"] = float(last_plan.get("total_cost_pct") or 0)
+            snap["last_hops"] = float(last_plan.get("hops") or 0)
+            if last_plan.get("savings_vs_usdt_bps") is not None:
+                snap["last_savings_bps"] = float(last_plan.get("savings_vs_usdt_bps") or 0)
+            snap["last_success_ts"] = float(last[1]) if last else 0.0
+            cur.execute(
+                "SELECT owner IS NOT NULL AS held FROM conversion_lock WHERE id=1"
+            )
+            lock_row = cur.fetchone()
+            snap["lock_held"] = 1 if lock_row and lock_row[0] else 0
+            cur.close()
+        finally:
+            conn.close()
+        return snap
+
     def _has_shared_profile_ambiguity(self, cursor, mode_val: bool) -> bool:
         """Detecta quando mais de um profile LIVE compartilha a mesma posição do símbolo."""
         if mode_val:
@@ -1354,9 +1412,9 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                     "lock_held": 0,
                 }
                 try:
-                    from training_db import TrainingDatabase
-
-                    snap = TrainingDatabase().conversion_metrics_snapshot(profile=_profile) or snap
+                    # Use MetricsCollector connection only — never TrainingDatabase()
+                    # on the scrape hot path (DDL/deadlocks).
+                    snap = self.get_collector().conversion_metrics_snapshot() or snap
                 except Exception:
                     pass
                 output.append("# HELP btc_conversion_enabled Conversion owner enabled (1=yes)")

--- a/btc_trading_agent/training_db.py
+++ b/btc_trading_agent/training_db.py
@@ -74,6 +74,14 @@ def _get_database_url_safe() -> str:
 DATABASE_URL = _get_database_url_safe()
 SCHEMA = "btc"
 
+# Bump when PROFILE_MIGRATION_SQL / table DDL in _ensure_schema changes.
+# Hot-path callers (exporters) must not re-run ALTER TABLE every scrape.
+SCHEMA_VERSION = 1
+
+# Process-local cache: after a successful ensure for a DSN, skip entirely.
+# Prevents ~1s of DDL + AccessExclusiveLock on btc.decisions per scrape.
+_SCHEMA_ENSURED_DSNS: set = set()
+
 
 PROFILE_MIGRATION_SQL = f"""
 CREATE TABLE IF NOT EXISTS {SCHEMA}.ai_plans (
@@ -185,12 +193,13 @@ ALTER TABLE {SCHEMA}.ai_plans
 class TrainingDatabase:
     """Gerenciador do banco de dados de treinamento (PostgreSQL)"""
 
-    def __init__(self, dsn: str = None):
+    def __init__(self, dsn: str = None, ensure_schema: bool = True):
         self.dsn = dsn or DATABASE_URL
         self._pool = psycopg2.pool.ThreadedConnectionPool(
             minconn=1, maxconn=5, dsn=self.dsn
         )
-        self._ensure_schema()
+        if ensure_schema:
+            self._ensure_schema()
 
     def close(self):
         """Fecha pool de conexões"""
@@ -211,238 +220,301 @@ class TrainingDatabase:
         finally:
             self._pool.putconn(conn)
 
+    def _mark_schema_ensured(self) -> None:
+        dsn_key = self.dsn or ""
+        if dsn_key:
+            _SCHEMA_ENSURED_DSNS.add(dsn_key)
+
     def _ensure_schema(self):
-        """Garante que o schema e tabelas existem"""
+        """Garante que o schema e tabelas existem.
+
+        Fast-path:
+        1. Process-local cache — zero DB after first success in this process.
+        2. btc.schema_meta.version — skip ALTER/CREATE INDEX when already applied.
+        Without these, Prometheus exporters were re-running PROFILE_MIGRATION_SQL
+        (AccessExclusiveLock on btc.decisions ~3.8GB) every scrape → deadlocks.
+        """
+        dsn_key = self.dsn or ""
+        if dsn_key and dsn_key in _SCHEMA_ENSURED_DSNS:
+            return
+
+        # Only mark process cache after the connection context commits successfully.
+        ready = False
         with self._get_conn() as conn:
             cur = conn.cursor()
             # Serializa a migração entre agentes que sobem simultaneamente
             # (deploy reinicia os 3 profiles juntos → DeadlockDetected nos
             # ALTER TABLE concorrentes). Lock liberado no commit/rollback.
             cur.execute("SELECT pg_advisory_xact_lock(hashtext('btc_ensure_schema'))")
+
+            # Another thread in this process may have finished while we waited.
+            if dsn_key and dsn_key in _SCHEMA_ENSURED_DSNS:
+                return
+
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
 
+            # Version gate (cheap). Must exist before we can skip heavy DDL.
             cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.trades (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    symbol TEXT NOT NULL,
-                    side TEXT NOT NULL,
-                    price DOUBLE PRECISION NOT NULL,
-                    size DOUBLE PRECISION,
-                    funds DOUBLE PRECISION,
-                    order_id TEXT,
-                    status TEXT DEFAULT 'executed',
-                    pnl DOUBLE PRECISION,
-                    pnl_pct DOUBLE PRECISION,
-                    dry_run BOOLEAN DEFAULT FALSE,
-                    metadata JSONB,
-                    created_at TIMESTAMPTZ DEFAULT NOW()
-                )
-            """)
-
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.decisions (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    symbol TEXT NOT NULL,
-                    action TEXT NOT NULL,
-                    confidence DOUBLE PRECISION NOT NULL,
-                    price DOUBLE PRECISION NOT NULL,
-                    reason TEXT,
-                    executed BOOLEAN DEFAULT FALSE,
-                    trade_id INTEGER REFERENCES {SCHEMA}.trades(id),
-                    features JSONB
-                )
-            """)
-
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.market_states (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    symbol TEXT NOT NULL,
-                    price DOUBLE PRECISION NOT NULL,
-                    bid DOUBLE PRECISION,
-                    ask DOUBLE PRECISION,
-                    spread DOUBLE PRECISION,
-                    orderbook_imbalance DOUBLE PRECISION,
-                    trade_flow DOUBLE PRECISION,
-                    rsi DOUBLE PRECISION,
-                    momentum DOUBLE PRECISION,
-                    volatility DOUBLE PRECISION,
-                    trend DOUBLE PRECISION,
-                    volume DOUBLE PRECISION
-                )
-            """)
-
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.learning_rewards (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    symbol TEXT NOT NULL,
-                    state_hash TEXT NOT NULL,
-                    action INTEGER NOT NULL,
-                    reward DOUBLE PRECISION NOT NULL,
-                    next_state_hash TEXT,
-                    episode INTEGER DEFAULT 0
-                )
-            """)
-
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.performance_stats (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    symbol TEXT NOT NULL,
-                    period TEXT NOT NULL,
-                    total_trades INTEGER DEFAULT 0,
-                    winning_trades INTEGER DEFAULT 0,
-                    total_pnl DOUBLE PRECISION DEFAULT 0,
-                    max_drawdown DOUBLE PRECISION DEFAULT 0,
-                    sharpe_ratio DOUBLE PRECISION,
-                    win_rate DOUBLE PRECISION,
-                    avg_trade_pnl DOUBLE PRECISION,
-                    metadata JSONB
-                )
-            """)
-
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.candles (
-                    id SERIAL PRIMARY KEY,
-                    timestamp BIGINT NOT NULL,
-                    symbol TEXT NOT NULL,
-                    ktype TEXT NOT NULL,
-                    open DOUBLE PRECISION NOT NULL,
-                    high DOUBLE PRECISION NOT NULL,
-                    low DOUBLE PRECISION NOT NULL,
-                    close DOUBLE PRECISION NOT NULL,
-                    volume DOUBLE PRECISION NOT NULL,
-                    UNIQUE(timestamp, symbol, ktype)
-                )
-            """)
-
-            # Log bruto das chamadas ao LLM (prompt + resposta) para servir de
-            # dataset de fine-tuning. As tabelas ai_trade_controls/ai_trade_windows/
-            # ai_plans guardam a saída já parseada, mas NÃO o prompt/CONTEXT exato
-            # enviado ao Ollama nem o texto livre do plano — que é o que o SFT precisa.
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.llm_calls (
-                    id SERIAL PRIMARY KEY,
-                    timestamp DOUBLE PRECISION NOT NULL,
-                    call_type TEXT NOT NULL,
-                    symbol TEXT NOT NULL,
-                    profile TEXT NOT NULL DEFAULT 'default',
-                    trigger TEXT,
-                    model TEXT,
-                    host TEXT,
-                    prompt TEXT NOT NULL,
-                    response_text TEXT,
-                    response_json JSONB,
-                    latency_ms DOUBLE PRECISION,
-                    metadata JSONB,
-                    servidor TEXT NOT NULL DEFAULT 'homelab',
-                    created_at TIMESTAMPTZ DEFAULT NOW()
-                )
-            """)
-
-            # Config de runtime do log de LLM, controlada pelo painel (ligar/desligar
-            # e parametrizar). Linha única (id=1). Os agentes leem com cache curto.
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.llm_log_config (
+                CREATE TABLE IF NOT EXISTS {SCHEMA}.schema_meta (
                     id INTEGER PRIMARY KEY DEFAULT 1,
-                    enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                    log_controls BOOLEAN NOT NULL DEFAULT TRUE,
-                    log_window BOOLEAN NOT NULL DEFAULT TRUE,
-                    log_plan BOOLEAN NOT NULL DEFAULT TRUE,
-                    sample_rate DOUBLE PRECISION NOT NULL DEFAULT 1.0,
-                    max_prompt_chars INTEGER NOT NULL DEFAULT 0,
-                    prune_days INTEGER NOT NULL DEFAULT 90,
+                    version INTEGER NOT NULL DEFAULT 0,
                     updated_at TIMESTAMPTZ DEFAULT NOW(),
-                    updated_by TEXT,
-                    CONSTRAINT llm_log_config_singleton CHECK (id = 1)
+                    CONSTRAINT schema_meta_singleton CHECK (id = 1)
                 )
             """)
-            cur.execute(f"""
-                INSERT INTO {SCHEMA}.llm_log_config (id) VALUES (1)
-                ON CONFLICT (id) DO NOTHING
-            """)
-
-            # Compatibilidade: releases recentes passaram a usar colunas/tabelas
-            # com "profile"; manter isso aqui evita depender de migration manual.
-            cur.execute(PROFILE_MIGRATION_SQL)
-
-            # Conversão intermoedas (owner USDT_BRL)
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_requests (
-                    id SERIAL PRIMARY KEY,
-                    created_at TIMESTAMPTZ DEFAULT NOW(),
-                    requested_by TEXT,
-                    asset_in TEXT NOT NULL,
-                    asset_out TEXT NOT NULL,
-                    amount_in DOUBLE PRECISION NOT NULL,
-                    min_out DOUBLE PRECISION,
-                    status TEXT NOT NULL DEFAULT 'pending',
-                    plan_json JSONB,
-                    result_json JSONB,
-                    dry_run BOOLEAN DEFAULT TRUE,
-                    profile TEXT DEFAULT 'conservative',
-                    symbol_owner TEXT DEFAULT 'USDT-BRL'
+            cur.execute(
+                f"INSERT INTO {SCHEMA}.schema_meta (id, version) VALUES (1, 0) "
+                f"ON CONFLICT (id) DO NOTHING"
+            )
+            cur.execute(f"SELECT version FROM {SCHEMA}.schema_meta WHERE id = 1")
+            row = cur.fetchone()
+            current_version = int(row[0]) if row else 0
+            if current_version >= SCHEMA_VERSION:
+                ready = True
+                logger.debug(
+                    "PostgreSQL schema btc.* already at version %s — skip migration",
+                    current_version,
                 )
-            """)
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_legs (
-                    id SERIAL PRIMARY KEY,
-                    request_id INTEGER REFERENCES {SCHEMA}.conversion_requests(id),
-                    leg_index INTEGER NOT NULL,
-                    symbol TEXT NOT NULL,
-                    side TEXT NOT NULL,
-                    amount_in DOUBLE PRECISION,
-                    amount_out DOUBLE PRECISION,
-                    fee DOUBLE PRECISION,
-                    order_id TEXT,
-                    status TEXT,
-                    created_at TIMESTAMPTZ DEFAULT NOW()
+            else:
+                self._apply_schema_migration(cur)
+                ready = True
+                logger.info(
+                    "✅ PostgreSQL schema btc.* initialized (version %s)",
+                    SCHEMA_VERSION,
                 )
-            """)
-            cur.execute(f"""
-                CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_lock (
-                    id INTEGER PRIMARY KEY DEFAULT 1,
-                    owner TEXT,
-                    held_at TIMESTAMPTZ,
-                    CONSTRAINT conversion_lock_singleton CHECK (id = 1)
-                )
-            """)
-            cur.execute(f"""
-                INSERT INTO {SCHEMA}.conversion_lock (id) VALUES (1)
-                ON CONFLICT (id) DO NOTHING
-            """)
 
-            # Índices
-            indices = [
-                f"CREATE INDEX IF NOT EXISTS idx_btc_trades_symbol ON {SCHEMA}.trades(symbol)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_trades_symbol_profile ON {SCHEMA}.trades(symbol, profile)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_trades_timestamp ON {SCHEMA}.trades(timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_trades_dry_run ON {SCHEMA}.trades(dry_run)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_timestamp ON {SCHEMA}.decisions(timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_symbol ON {SCHEMA}.decisions(symbol)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_symbol_profile ON {SCHEMA}.decisions(symbol, profile)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_market_states_timestamp ON {SCHEMA}.market_states(timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_market_states_symbol ON {SCHEMA}.market_states(symbol, timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_candles_lookup ON {SCHEMA}.candles(symbol, ktype, timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_learning_rewards_symbol ON {SCHEMA}.learning_rewards(symbol)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_ai_plans_symbol_profile_ts ON {SCHEMA}.ai_plans(symbol, profile, timestamp DESC)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_profile_allocations_symbol_ts ON {SCHEMA}.profile_allocations(symbol, timestamp DESC)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_ai_trade_controls_symbol_profile_ts ON {SCHEMA}.ai_trade_controls(symbol, profile, timestamp DESC)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_ai_trade_windows_symbol_profile_ts ON {SCHEMA}.ai_trade_windows(symbol, profile, timestamp DESC)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_llm_calls_type_symbol_profile_ts ON {SCHEMA}.llm_calls(call_type, symbol, profile, timestamp DESC)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_llm_calls_timestamp ON {SCHEMA}.llm_calls(timestamp)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_requests_status ON {SCHEMA}.conversion_requests(status)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_requests_assets ON {SCHEMA}.conversion_requests(asset_in, asset_out)",
-                f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_legs_request ON {SCHEMA}.conversion_legs(request_id)",
-            ]
-            for idx in indices:
-                cur.execute(idx)
+        if ready:
+            self._mark_schema_ensured()
 
-            conn.commit()
-            logger.info("✅ PostgreSQL schema btc.* initialized")
+    def _apply_schema_migration(self, cur) -> None:
+        """Heavy DDL — only when schema_meta.version < SCHEMA_VERSION."""
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.trades (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                price DOUBLE PRECISION NOT NULL,
+                size DOUBLE PRECISION,
+                funds DOUBLE PRECISION,
+                order_id TEXT,
+                status TEXT DEFAULT 'executed',
+                pnl DOUBLE PRECISION,
+                pnl_pct DOUBLE PRECISION,
+                dry_run BOOLEAN DEFAULT FALSE,
+                metadata JSONB,
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.decisions (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                symbol TEXT NOT NULL,
+                action TEXT NOT NULL,
+                confidence DOUBLE PRECISION NOT NULL,
+                price DOUBLE PRECISION NOT NULL,
+                reason TEXT,
+                executed BOOLEAN DEFAULT FALSE,
+                trade_id INTEGER REFERENCES {SCHEMA}.trades(id),
+                features JSONB
+            )
+        """)
+
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.market_states (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                symbol TEXT NOT NULL,
+                price DOUBLE PRECISION NOT NULL,
+                bid DOUBLE PRECISION,
+                ask DOUBLE PRECISION,
+                spread DOUBLE PRECISION,
+                orderbook_imbalance DOUBLE PRECISION,
+                trade_flow DOUBLE PRECISION,
+                rsi DOUBLE PRECISION,
+                momentum DOUBLE PRECISION,
+                volatility DOUBLE PRECISION,
+                trend DOUBLE PRECISION,
+                volume DOUBLE PRECISION
+            )
+        """)
+
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.learning_rewards (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                symbol TEXT NOT NULL,
+                state_hash TEXT NOT NULL,
+                action INTEGER NOT NULL,
+                reward DOUBLE PRECISION NOT NULL,
+                next_state_hash TEXT,
+                episode INTEGER DEFAULT 0
+            )
+        """)
+
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.performance_stats (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                symbol TEXT NOT NULL,
+                period TEXT NOT NULL,
+                total_trades INTEGER DEFAULT 0,
+                winning_trades INTEGER DEFAULT 0,
+                total_pnl DOUBLE PRECISION DEFAULT 0,
+                max_drawdown DOUBLE PRECISION DEFAULT 0,
+                sharpe_ratio DOUBLE PRECISION,
+                win_rate DOUBLE PRECISION,
+                avg_trade_pnl DOUBLE PRECISION,
+                metadata JSONB
+            )
+        """)
+
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.candles (
+                id SERIAL PRIMARY KEY,
+                timestamp BIGINT NOT NULL,
+                symbol TEXT NOT NULL,
+                ktype TEXT NOT NULL,
+                open DOUBLE PRECISION NOT NULL,
+                high DOUBLE PRECISION NOT NULL,
+                low DOUBLE PRECISION NOT NULL,
+                close DOUBLE PRECISION NOT NULL,
+                volume DOUBLE PRECISION NOT NULL,
+                UNIQUE(timestamp, symbol, ktype)
+            )
+        """)
+
+        # Log bruto das chamadas ao LLM (prompt + resposta) para servir de
+        # dataset de fine-tuning. As tabelas ai_trade_controls/ai_trade_windows/
+        # ai_plans guardam a saída já parseada, mas NÃO o prompt/CONTEXT exato
+        # enviado ao Ollama nem o texto livre do plano — que é o que o SFT precisa.
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.llm_calls (
+                id SERIAL PRIMARY KEY,
+                timestamp DOUBLE PRECISION NOT NULL,
+                call_type TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                profile TEXT NOT NULL DEFAULT 'default',
+                trigger TEXT,
+                model TEXT,
+                host TEXT,
+                prompt TEXT NOT NULL,
+                response_text TEXT,
+                response_json JSONB,
+                latency_ms DOUBLE PRECISION,
+                metadata JSONB,
+                servidor TEXT NOT NULL DEFAULT 'homelab',
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+
+        # Config de runtime do log de LLM, controlada pelo painel (ligar/desligar
+        # e parametrizar). Linha única (id=1). Os agentes leem com cache curto.
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.llm_log_config (
+                id INTEGER PRIMARY KEY DEFAULT 1,
+                enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                log_controls BOOLEAN NOT NULL DEFAULT TRUE,
+                log_window BOOLEAN NOT NULL DEFAULT TRUE,
+                log_plan BOOLEAN NOT NULL DEFAULT TRUE,
+                sample_rate DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+                max_prompt_chars INTEGER NOT NULL DEFAULT 0,
+                prune_days INTEGER NOT NULL DEFAULT 90,
+                updated_at TIMESTAMPTZ DEFAULT NOW(),
+                updated_by TEXT,
+                CONSTRAINT llm_log_config_singleton CHECK (id = 1)
+            )
+        """)
+        cur.execute(f"""
+            INSERT INTO {SCHEMA}.llm_log_config (id) VALUES (1)
+            ON CONFLICT (id) DO NOTHING
+        """)
+
+        # Compatibilidade: releases recentes passaram a usar colunas/tabelas
+        # com "profile"; manter isso aqui evita depender de migration manual.
+        cur.execute(PROFILE_MIGRATION_SQL)
+
+        # Conversão intermoedas (owner USDT_BRL)
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_requests (
+                id SERIAL PRIMARY KEY,
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                requested_by TEXT,
+                asset_in TEXT NOT NULL,
+                asset_out TEXT NOT NULL,
+                amount_in DOUBLE PRECISION NOT NULL,
+                min_out DOUBLE PRECISION,
+                status TEXT NOT NULL DEFAULT 'pending',
+                plan_json JSONB,
+                result_json JSONB,
+                dry_run BOOLEAN DEFAULT TRUE,
+                profile TEXT DEFAULT 'conservative',
+                symbol_owner TEXT DEFAULT 'USDT-BRL'
+            )
+        """)
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_legs (
+                id SERIAL PRIMARY KEY,
+                request_id INTEGER REFERENCES {SCHEMA}.conversion_requests(id),
+                leg_index INTEGER NOT NULL,
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                amount_in DOUBLE PRECISION,
+                amount_out DOUBLE PRECISION,
+                fee DOUBLE PRECISION,
+                order_id TEXT,
+                status TEXT,
+                created_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.conversion_lock (
+                id INTEGER PRIMARY KEY DEFAULT 1,
+                owner TEXT,
+                held_at TIMESTAMPTZ,
+                CONSTRAINT conversion_lock_singleton CHECK (id = 1)
+            )
+        """)
+        cur.execute(f"""
+            INSERT INTO {SCHEMA}.conversion_lock (id) VALUES (1)
+            ON CONFLICT (id) DO NOTHING
+        """)
+
+        indices = [
+            f"CREATE INDEX IF NOT EXISTS idx_btc_trades_symbol ON {SCHEMA}.trades(symbol)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_trades_symbol_profile ON {SCHEMA}.trades(symbol, profile)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_trades_timestamp ON {SCHEMA}.trades(timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_trades_dry_run ON {SCHEMA}.trades(dry_run)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_timestamp ON {SCHEMA}.decisions(timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_symbol ON {SCHEMA}.decisions(symbol)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_decisions_symbol_profile ON {SCHEMA}.decisions(symbol, profile)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_market_states_timestamp ON {SCHEMA}.market_states(timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_market_states_symbol ON {SCHEMA}.market_states(symbol, timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_candles_lookup ON {SCHEMA}.candles(symbol, ktype, timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_learning_rewards_symbol ON {SCHEMA}.learning_rewards(symbol)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_ai_plans_symbol_profile_ts ON {SCHEMA}.ai_plans(symbol, profile, timestamp DESC)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_profile_allocations_symbol_ts ON {SCHEMA}.profile_allocations(symbol, timestamp DESC)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_ai_trade_controls_symbol_profile_ts ON {SCHEMA}.ai_trade_controls(symbol, profile, timestamp DESC)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_ai_trade_windows_symbol_profile_ts ON {SCHEMA}.ai_trade_windows(symbol, profile, timestamp DESC)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_llm_calls_type_symbol_profile_ts ON {SCHEMA}.llm_calls(call_type, symbol, profile, timestamp DESC)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_llm_calls_timestamp ON {SCHEMA}.llm_calls(timestamp)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_requests_status ON {SCHEMA}.conversion_requests(status)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_requests_assets ON {SCHEMA}.conversion_requests(asset_in, asset_out)",
+            f"CREATE INDEX IF NOT EXISTS idx_btc_conversion_legs_request ON {SCHEMA}.conversion_legs(request_id)",
+        ]
+        for idx in indices:
+            cur.execute(idx)
+
+        cur.execute(
+            f"""
+            UPDATE {SCHEMA}.schema_meta
+            SET version = %s, updated_at = NOW()
+            WHERE id = 1
+            """,
+            (SCHEMA_VERSION,),
+        )
 
     # ====================== TRADES ======================
     def record_trade(self, symbol: str, side: str, price: float,

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-18T23:19:39.944977+00:00",
+  "generated_at": "2026-07-19T13:56:23.357329+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-18T23:19:39.944977+00:00`
+- Generated at: `2026-07-19T13:56:23.357329+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `179`

--- a/tests/test_training_db_schema_ensure_gate.py
+++ b/tests/test_training_db_schema_ensure_gate.py
@@ -1,0 +1,98 @@
+"""Regression: schema ensure must not re-run heavy DDL when already current.
+
+Background: crypto-exporter created TrainingDatabase() on every Prometheus scrape,
+re-running PROFILE_MIGRATION_SQL (ALTER TABLE on btc.decisions) → deadlocks with
+trading agents holding RowShareLock on trades/decisions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import training_db as tdb
+
+
+def _reset_schema_cache() -> None:
+    tdb._SCHEMA_ENSURED_DSNS.clear()
+
+
+def test_ensure_schema_skips_when_process_cache_hit() -> None:
+    _reset_schema_cache()
+    db = object.__new__(tdb.TrainingDatabase)
+    db.dsn = "postgresql://test/cache-hit"
+    tdb._SCHEMA_ENSURED_DSNS.add(db.dsn)
+
+    with patch.object(db, "_get_conn") as get_conn:
+        db._ensure_schema()
+        get_conn.assert_not_called()
+
+
+def test_ensure_schema_skips_migration_when_version_current() -> None:
+    _reset_schema_cache()
+    db = object.__new__(tdb.TrainingDatabase)
+    db.dsn = "postgresql://test/version-current"
+
+    cur = MagicMock()
+    # SELECT version → already at SCHEMA_VERSION
+    cur.fetchone.return_value = (tdb.SCHEMA_VERSION,)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    class _CM:
+        def __enter__(self):
+            return conn
+
+        def __exit__(self, *args):
+            return False
+
+    with patch.object(db, "_get_conn", return_value=_CM()):
+        with patch.object(db, "_apply_schema_migration") as apply_mig:
+            db._ensure_schema()
+            apply_mig.assert_not_called()
+
+    assert db.dsn in tdb._SCHEMA_ENSURED_DSNS
+
+    # Second call: process cache only
+    with patch.object(db, "_get_conn") as get_conn:
+        db._ensure_schema()
+        get_conn.assert_not_called()
+
+
+def test_ensure_schema_runs_migration_when_version_stale() -> None:
+    _reset_schema_cache()
+    db = object.__new__(tdb.TrainingDatabase)
+    db.dsn = "postgresql://test/version-stale"
+
+    cur = MagicMock()
+    cur.fetchone.return_value = (0,)  # stale
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+
+    class _CM:
+        def __enter__(self):
+            return conn
+
+        def __exit__(self, *args):
+            return False
+
+    with patch.object(db, "_get_conn", return_value=_CM()):
+        with patch.object(db, "_apply_schema_migration") as apply_mig:
+            db._ensure_schema()
+            apply_mig.assert_called_once_with(cur)
+
+    assert db.dsn in tdb._SCHEMA_ENSURED_DSNS
+
+
+def test_exporter_conversion_snapshot_does_not_import_training_db() -> None:
+    """Scrape path must query conversion_* via MetricsCollector only."""
+    from pathlib import Path
+
+    src = Path("btc_trading_agent/prometheus_exporter.py").read_text(encoding="utf-8")
+    # Method body present
+    assert "def conversion_metrics_snapshot(self)" in src
+    assert "FROM conversion_requests" in src
+    # Old deadlock path removed from scrape
+    assert "TrainingDatabase().conversion_metrics_snapshot" not in src
+    assert "get_collector().conversion_metrics_snapshot()" in src


### PR DESCRIPTION
## Summary
- Root cause: `crypto-exporter` called `TrainingDatabase()` on every `/metrics` scrape (~30s), re-running `PROFILE_MIGRATION_SQL` with `ALTER TABLE` on `btc.decisions` (~3.8GB) → `AccessExclusiveLock` deadlocks against agents writing `trades`/`decisions` (~1400 schema inits/hour, hundreds of loop deadlocks).
- Gate `_ensure_schema` with process-local cache + `btc.schema_meta.version` so heavy DDL runs only when version is stale.
- Move conversion metrics scrape to `MetricsCollector.conversion_metrics_snapshot()` (plain SELECT, no DDL).

## Test plan
- [x] `pytest tests/test_training_db_schema_ensure_gate.py`
- [ ] Deploy to homelab, restart exporters/agents
- [ ] Confirm `journalctl -u 'crypto-exporter@*' --since '5 min ago' | grep -c 'schema btc'` → ~0 after boot
- [ ] Confirm `journalctl -u 'crypto-agent@*' --since '10 min ago' | grep -c 'deadlock detected'` → ~0