### PR TITLE
fix(dashboard): corrige PnL negativo mascarado como zero no painel PnL Total

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-18T23:19:39.944977+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-07-23T12:02:22.739624+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/d2d5545e-220c-41b3-908c-156c62e01a23/scratchpad/wt-pnlfix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 179,
+    "repo_services": 181,
     "trading_instances": 12,
     "critical_services": 70,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 20,
-      "operations": 98,
+      "operations": 100,
       "storage": 32,
       "trading": 11
     }
@@ -1226,6 +1226,22 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-18T23:19:39.944977+00:00`
+- Generated at: `2026-07-23T12:02:22.739624+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `179`
+- Repo services discovered: `181`
 - Critical services flagged for MVP: `70`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 20
-- `operations`: 98
+- `operations`: 100
 - `storage`: 32
 - `trading`: 11
 

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -209,7 +209,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "max by(profile)((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"}))",
+          "expr": "max by(profile)((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) or ((0 * max by(profile)((up{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (up{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"}))) unless on(profile) max by(profile)((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})))",
           "legendFormat": "{{profile}}",
           "refId": "A"
         }


### PR DESCRIPTION
## Resumo
- O painel "📈 PnL Total" (btc-trading-monitor, id 2) usava `max by(profile)` sobre `(pnl real) or (0 * up-fallback)`. Isso faz o `max` externo escolher o maior valor entre o PnL real e o 0 injetado como fallback de "sem dado".
- Qualquer perfil com PnL negativo era mascarado como `$0.0000` (confirmado: aggressive -1.0840, conservative -3.2014 vs Prometheus; shadow +9.7235 aparecia certo por ser positivo).
- Trocado o combinador de `max`/`or` para `unless on(profile)`, garantindo que o fallback de zero só entre quando a métrica real estiver de fato ausente para aquele perfil.

## Test plan
- [x] JSON validado (`python3 -c "import json; json.load(...)"`)
- [x] Valores reais confirmados via Prometheus (`btc_trading_total_pnl{coin="BTC-USDT"}`): aggressive -1.084, conservative -3.2014, shadow 9.7235
- [ ] Após deploy, conferir painel no Grafana mostrando os três valores reais (incluindo negativos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)