### PR TITLE
fix(dashboard): PnL Total respeita período selecionado + renomeado

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-23T12:02:22.739624+00:00",
+  "generated_at": "2026-07-23T12:27:23.886009+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/d2d5545e-220c-41b3-908c-156c62e01a23/scratchpad/wt-pnlfix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T12:02:22.739624+00:00`
+- Generated at: `2026-07-23T12:27:23.886009+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `181`

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -209,12 +209,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "max by(profile)((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) or ((0 * max by(profile)((up{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (up{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"}))) unless on(profile) max by(profile)((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})))",
+          "expr": "max by(profile)(((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) - ((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"} offset $__range) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"} offset $__range))) or ((0 * max by(profile)((up{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (up{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"}))) unless on(profile) max by(profile)(((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) - ((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"} offset $__range) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"} offset $__range))))",
           "legendFormat": "{{profile}}",
           "refId": "A"
         }
       ],
-      "title": "📈 PnL Total",
+      "title": "📈 PnL. No Período",
       "type": "stat"
     },
     {


### PR DESCRIPTION
## Resumo
- Painel "📈 PnL Total" (btc-trading-monitor, id 2) usava o valor cumulativo all-time do gauge `btc_trading_total_pnl`, ignorando o período (`from`/`to`) selecionado no dashboard.
- Agora calcula o delta dentro da janela: `valor atual - valor no início do range` via `offset $__range`, mantendo o fallback de zero só quando a série estiver mesmo ausente (mesma lógica `unless on(profile)` do fix anterior #228).
- Título alterado para "📈 PnL. No Período" para refletir o novo comportamento.

## Test plan
- [x] JSON validado
- [ ] Após deploy, conferir painel respeitando o range do dashboard (ex.: últimas 24h vs 7d dão valores diferentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)