### PR TITLE
fix(dashboard): PnL. No Período usa Postgres em vez de delta ruidoso do Prometheus

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-23T12:27:23.886009+00:00",
+  "generated_at": "2026-07-23T12:35:49.794070+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/d2d5545e-220c-41b3-908c-156c62e01a23/scratchpad/wt-pnlfix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T12:27:23.886009+00:00`
+- Generated at: `2026-07-23T12:35:49.794070+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `181`

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -151,8 +151,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "dfc0w4yioe4u8e"
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
       },
       "fieldConfig": {
         "defaults": {
@@ -209,9 +209,37 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "max by(profile)(((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) - ((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"} offset $__range) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"} offset $__range))) or ((0 * max by(profile)((up{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (up{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"}))) unless on(profile) max by(profile)(((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"}) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"})) - ((btc_trading_total_pnl{servidor=~\"$servidor\",coin=\"$coin\",profile=~\"$profile\"} offset $__range) or (btc_trading_total_pnl{servidor=~\"$servidor\",exported_coin=\"$coin\",exported_profile=~\"$profile\"} offset $__range))))",
-          "legendFormat": "{{profile}}",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT now() AS \"time\", COALESCE(SUM(pnl), 0)::numeric(12,4) AS \"conservative\" FROM btc.trades WHERE symbol = '$coin' AND dry_run = false AND profile = 'conservative' AND 'conservative' IN (${profile:sqlstring}) AND (('${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}')) AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT now() AS \"time\", COALESCE(SUM(pnl), 0)::numeric(12,4) AS \"aggressive\" FROM btc.trades WHERE symbol = '$coin' AND dry_run = false AND profile = 'aggressive' AND 'aggressive' IN (${profile:sqlstring}) AND (('${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}')) AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT now() AS \"time\", COALESCE(SUM(pnl), 0)::numeric(12,4) AS \"shadow\" FROM btc.trades WHERE symbol = '$coin' AND dry_run = false AND profile = 'shadow' AND 'shadow' IN (${profile:sqlstring}) AND (('${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}')) AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()",
+          "refId": "C"
         }
       ],
       "title": "📈 PnL. No Período",


### PR DESCRIPTION
## Resumo
- O painel "📈 PnL. No Período" (id 2) usava `btc_trading_total_pnl - btc_trading_total_pnl offset $__range` no Prometheus, reduzido via `lastNotNull` sobre uma range query.
- Esse cálculo é ruidoso: nos pontos intermediários da série o delta carrega jitter de scrape (~$0.04-0.05 residual mesmo com PnL real do período = $0), e `lastNotNull` pode acabar pegando um desses pontos ruidosos em vez do valor correto no fim do range.
- Confirmado comparando com `btc.trades`: 0 vendas realizadas nas últimas 24h para os 3 perfis, então o valor correto era $0 — o painel mostrava $0.09/$0.13/$1.63.
- Trocado para consultar `btc.trades` diretamente (mesmo padrão do painel "PnL no Período" ao lado), exato por construção.

## Test plan
- [x] JSON validado
- [ ] Após deploy, conferir que os dois painéis "PnL" batem no mesmo período

🤖 Generated with [Claude Code](https://claude.com/claude-code)