### PR TITLE
fix(dashboard): índice sargable no filtro de timestamp de Decisões Recentes

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-23T12:35:49.794070+00:00",
+  "generated_at": "2026-07-23T13:30:46.666415+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/d2d5545e-220c-41b3-908c-156c62e01a23/scratchpad/wt-pnlfix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T12:35:49.794070+00:00`
+- Generated at: `2026-07-23T13:30:46.666415+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `181`

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -2009,7 +2009,7 @@
       "targets": [
         {
           "format": "table",
-          "rawSql": "SELECT\n  TO_CHAR(to_timestamp(\"timestamp\") AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI') AS \"Data/Hora\",\n  COALESCE(profile, 'default') AS profile,\n  action,\n  ROUND(confidence::numeric, 3) AS conf_adj,\n  ROUND(NULLIF(features->>'raw_confidence', '')::numeric, 3) AS conf_raw,\n  ROUND(NULLIF(features->>'track_record_boost', '')::numeric, 3) AS boost,\n  ROUND(NULLIF(features->>'track_record_trs', '')::numeric, 3) AS trs,\n  price,\n  LEFT(reason, 80) AS reason,\n  executed\nFROM btc.decisions\nWHERE symbol = '$coin'\nAND profile ~* '^(${profile:pipe})$'\nAND (\n  ('${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}')\n)\nAND to_timestamp(\"timestamp\") BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY \"timestamp\" DESC\nLIMIT 50",
+          "rawSql": "SELECT\n  TO_CHAR(to_timestamp(\"timestamp\") AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI') AS \"Data/Hora\",\n  COALESCE(profile, 'default') AS profile,\n  action,\n  ROUND(confidence::numeric, 3) AS conf_adj,\n  ROUND(NULLIF(features->>'raw_confidence', '')::numeric, 3) AS conf_raw,\n  ROUND(NULLIF(features->>'track_record_boost', '')::numeric, 3) AS boost,\n  ROUND(NULLIF(features->>'track_record_trs', '')::numeric, 3) AS trs,\n  price,\n  LEFT(reason, 80) AS reason,\n  executed\nFROM btc.decisions\nWHERE symbol = '$coin'\nAND profile ~* '^(${profile:pipe})$'\nAND (\n  ('${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}')\n)\nAND \"timestamp\" BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\nORDER BY \"timestamp\" DESC\nLIMIT 50",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Resumo
- Painel "📋 Decisões Recentes" (id 71) filtrava com `to_timestamp("timestamp") BETWEEN $__timeFrom() AND $__timeTo()`. Envolver a coluna numa função invalida os índices `idx_btc_decisions_timestamp` / `idx_btc_decisions_symbol_profile_ts`, forçando sequential scan sobre `btc.decisions` (~800k+ linhas por símbolo em janelas de 90 dias).
- Confirmado via `EXPLAIN ANALYZE`: full scan ~1.9s (Parallel Seq Scan, sort com spill em disco) → index scan ~2.4ms depois de comparar `"timestamp"` (epoch double) direto com `$__unixEpochFrom()`/`$__unixEpochTo()`.
- Contribuía para a instabilidade relatada no dashboard quando o período é setado em 90d.

## Test plan
- [x] JSON validado
- [x] EXPLAIN ANALYZE confirma uso de index scan após a mudança
- [ ] Após deploy, abrir o dashboard com range de 90d e conferir que "Decisões Recentes" carrega rápido

🤖 Generated with [Claude Code](https://claude.com/claude-code)