### PR TITLE
feat(trading): rollup horário de track record para o painel Grafana

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-23T13:30:46.666415+00:00",
+  "generated_at": "2026-07-23T13:43:08.323211+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/d2d5545e-220c-41b3-908c-156c62e01a23/scratchpad/wt-pnlfix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 181,
+    "repo_services": 183,
     "trading_instances": 12,
     "critical_services": 70,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 20,
-      "operations": 100,
+      "operations": 102,
       "storage": 32,
       "trading": 11
     }
@@ -826,6 +826,22 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/daily-agenda-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T13:30:46.666415+00:00`
+- Generated at: `2026-07-23T13:43:08.323211+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `181`
+- Repo services discovered: `183`
 - Critical services flagged for MVP: `70`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 20
-- `operations`: 100
+- `operations`: 102
 - `storage`: 32
 - `trading`: 11
 

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -1546,7 +1546,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(timestamp, $__interval)) AS \"time\",\n  profile || ' TRS' AS metric,\n  avg((features->>'track_record_trs')::double precision) AS value\nFROM btc.decisions\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND features ? 'track_record_trs'\n  AND NULLIF(features->>'track_record_trs', '') IS NOT NULL\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\nGROUP BY 1, 2\nORDER BY 1",
+          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(extract(epoch from bucket_hour)::bigint, $__interval)) AS \"time\",\n  profile || ' TRS' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_trs * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM btc.decisions_track_record_hourly\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -1560,7 +1560,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(timestamp, $__interval)) AS \"time\",\n  profile || ' boost' AS metric,\n  avg((features->>'track_record_boost')::double precision) AS value\nFROM btc.decisions\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND features ? 'track_record_boost'\n  AND NULLIF(features->>'track_record_boost', '') IS NOT NULL\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND timestamp BETWEEN $__unixEpochFrom() AND $__unixEpochTo()\nGROUP BY 1, 2\nORDER BY 1",
+          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(extract(epoch from bucket_hour)::bigint, $__interval)) AS \"time\",\n  profile || ' boost' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_boost * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM btc.decisions_track_record_hourly\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1",
           "refId": "B",
           "timeColumns": [
             "time"

--- a/scripts/decisions_track_record_rollup.py
+++ b/scripts/decisions_track_record_rollup.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Rollup horário de track_record_trs/track_record_boost → PostgreSQL.
+
+Pré-computa médias horárias de btc.decisions.features->>'track_record_trs'
+e 'track_record_boost' em btc.decisions_track_record_hourly, evitando que
+o dashboard Grafana precise agregar sobre milhões de linhas JSONB toda
+vez que o período é ampliado (ex.: 90 dias levava ~2s por query e
+contribuía para instabilidade do dashboard — ver PR de correção do
+painel "Decisões Recentes").
+
+Uso:
+    python3 decisions_track_record_rollup.py                  # refresh incremental (últimas 3h)
+    python3 decisions_track_record_rollup.py --hours-back 6   # janela de refresh maior
+    python3 decisions_track_record_rollup.py --backfill 2160  # backfill único de 90 dias
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import psycopg2
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("decisions_track_record_rollup")
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+SCHEMA = "btc"
+
+
+def ensure_table(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {SCHEMA}.decisions_track_record_hourly (
+                symbol TEXT NOT NULL,
+                profile TEXT NOT NULL,
+                servidor TEXT NOT NULL,
+                bucket_hour TIMESTAMPTZ NOT NULL,
+                avg_trs DOUBLE PRECISION,
+                avg_boost DOUBLE PRECISION,
+                sample_count INTEGER NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (symbol, profile, servidor, bucket_hour)
+            )
+        """)
+        cur.execute(f"""
+            CREATE INDEX IF NOT EXISTS idx_decisions_trh_bucket
+            ON {SCHEMA}.decisions_track_record_hourly (bucket_hour)
+        """)
+
+
+def refresh(conn, since: datetime) -> int:
+    """Recalcula e faz upsert dos buckets horários desde `since` até agora.
+
+    Reprocessa a janela inteira (não só linhas novas) porque o bucket da
+    hora corrente segue recebendo decisões até a hora fechar — refazer o
+    upsert idempotente é mais simples e seguro do que rastrear um high-water
+    mark de linha processada.
+    """
+    since_epoch = since.timestamp()
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {SCHEMA}.decisions_track_record_hourly
+                (symbol, profile, servidor, bucket_hour, avg_trs, avg_boost, sample_count, updated_at)
+            SELECT
+                symbol,
+                profile,
+                servidor,
+                date_trunc('hour', to_timestamp("timestamp")) AS bucket_hour,
+                avg(NULLIF(features->>'track_record_trs', '')::double precision) AS avg_trs,
+                avg(NULLIF(features->>'track_record_boost', '')::double precision) AS avg_boost,
+                count(*) AS sample_count,
+                now() AS updated_at
+            FROM {SCHEMA}.decisions
+            WHERE "timestamp" >= %(since_epoch)s
+              AND profile IS NOT NULL
+              AND (features ? 'track_record_trs' OR features ? 'track_record_boost')
+            GROUP BY symbol, profile, servidor, date_trunc('hour', to_timestamp("timestamp"))
+            ON CONFLICT (symbol, profile, servidor, bucket_hour) DO UPDATE SET
+                avg_trs = EXCLUDED.avg_trs,
+                avg_boost = EXCLUDED.avg_boost,
+                sample_count = EXCLUDED.sample_count,
+                updated_at = EXCLUDED.updated_at
+            """,
+            {"since_epoch": since_epoch},
+        )
+        return cur.rowcount
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Rollup horário de track record → Postgres")
+    parser.add_argument(
+        "--hours-back", type=int, default=3,
+        help="Janela de refresh incremental em horas (default: 3, cobre atraso + fechamento de hora)",
+    )
+    parser.add_argument(
+        "--backfill", type=int,
+        help="Backfill único em horas a partir de agora (ex: 2160 = 90 dias). Sobrepõe --hours-back.",
+    )
+    args = parser.parse_args()
+
+    if not DATABASE_URL:
+        logger.error("❌ DATABASE_URL não configurado no ambiente")
+        return 1
+
+    window_hours = args.backfill or args.hours_back
+    since = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+
+    logger.info(f"🔄 Rollup track record — janela de {window_hours}h (desde {since.isoformat()})")
+
+    try:
+        conn = psycopg2.connect(DATABASE_URL)
+        conn.autocommit = False
+    except Exception as e:
+        logger.error(f"❌ Falha ao conectar no PostgreSQL: {e}", exc_info=True)
+        return 1
+
+    try:
+        ensure_table(conn)
+        rows = refresh(conn, since)
+        conn.commit()
+        logger.info(f"✅ {rows} buckets horários atualizados")
+    except Exception as e:
+        conn.rollback()
+        logger.error(f"❌ Falha no refresh do rollup: {e}", exc_info=True)
+        return 1
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy_decisions_track_record_rollup.sh
+++ b/scripts/deploy_decisions_track_record_rollup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Deploy do rollup horário de track_record_trs/track_record_boost no homelab.
+#
+# Cria/atualiza btc.decisions_track_record_hourly e o timer que a mantém
+# atualizada, evitando que o painel Grafana "Track Record" precise agregar
+# sobre milhões de linhas JSONB de btc.decisions a cada carregamento.
+set -euo pipefail
+
+HOMELAB="${1:-homelab@192.168.15.2}"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BACKFILL_HOURS="${BACKFILL_HOURS:-2200}"  # ~91 dias, cobre o range usado no dashboard
+
+echo "=== Deploy decisions-track-record-rollup → ${HOMELAB} ==="
+
+echo "[1/4] Copiando script de rollup..."
+scp "${REPO_DIR}/scripts/decisions_track_record_rollup.py" "${HOMELAB}:/tmp/decisions_track_record_rollup.py"
+ssh "$HOMELAB" "
+  sudo install -o btc-trading -g btc-trading -m 755 /tmp/decisions_track_record_rollup.py \
+    /apps/crypto-trader/trading/scripts/decisions_track_record_rollup.py
+"
+
+echo "[2/4] Instalando unit + timer..."
+scp "${REPO_DIR}/systemd/decisions-track-record-rollup.service" "${HOMELAB}:/tmp/decisions-track-record-rollup.service"
+scp "${REPO_DIR}/systemd/decisions-track-record-rollup.timer" "${HOMELAB}:/tmp/decisions-track-record-rollup.timer"
+ssh "$HOMELAB" "
+  sudo cp /tmp/decisions-track-record-rollup.service /etc/systemd/system/decisions-track-record-rollup.service
+  sudo cp /tmp/decisions-track-record-rollup.timer /etc/systemd/system/decisions-track-record-rollup.timer
+  sudo systemctl daemon-reload
+"
+
+echo "[3/4] Backfill único (${BACKFILL_HOURS}h) — pode levar alguns minutos..."
+ssh "$HOMELAB" "
+  sudo systemd-run --uid=btc-trading --gid=btc-trading \
+    --working-directory=/apps/crypto-trader/trading \
+    --property=EnvironmentFile=-/apps/crypto-trader/envfiles/trading-database.env \
+    --setenv=PYTHONPATH=/apps/crypto-trader/trading \
+    --wait --pipe \
+    /apps/crypto-trader/.venv/bin/python /apps/crypto-trader/trading/scripts/decisions_track_record_rollup.py --backfill ${BACKFILL_HOURS}
+"
+
+echo "[4/4] Habilitando timer de refresh incremental..."
+ssh "$HOMELAB" "
+  sudo systemctl enable --now decisions-track-record-rollup.timer
+  systemctl is-active decisions-track-record-rollup.timer
+"
+
+echo ""
+echo "Deploy concluído. Refresh incremental a cada 20min via timer."
+echo "Logs: sudo journalctl -u decisions-track-record-rollup.service -f"

--- a/systemd/decisions-track-record-rollup.service
+++ b/systemd/decisions-track-record-rollup.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Rollup horário de track_record_trs/track_record_boost → PostgreSQL
+After=network.target postgresql.service
+
+[Service]
+Type=oneshot
+User=btc-trading
+Group=btc-trading
+WorkingDirectory=/apps/crypto-trader/trading
+EnvironmentFile=-/apps/crypto-trader/envfiles/trading-database.env
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONDONTWRITEBYTECODE=1
+Environment=HOME=/apps/crypto-trader
+Environment=PYTHONPATH=/apps/crypto-trader/trading
+
+ExecStart=/apps/crypto-trader/.venv/bin/python /apps/crypto-trader/trading/scripts/decisions_track_record_rollup.py --hours-back 3
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=decisions-track-record-rollup
+
+TimeoutStartSec=300
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true

--- a/systemd/decisions-track-record-rollup.timer
+++ b/systemd/decisions-track-record-rollup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer do rollup horário de track record (a cada 20 minutos)
+
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=20min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_decisions_track_record_rollup.py
+++ b/tests/test_decisions_track_record_rollup.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Testes unitários para scripts/decisions_track_record_rollup.py.
+
+Cobre: ensure_table, refresh, main, parsing de argumentos e tratamento
+de erros. Todas as dependências externas (DB) são mockadas.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Garantir que scripts/ está no sys.path
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from decisions_track_record_rollup import SCHEMA, ensure_table, main, refresh
+
+
+@pytest.fixture
+def mock_conn():
+    """Conexão PostgreSQL mockada com cursor context manager."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.rowcount = 7
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+class TestEnsureTable:
+    def test_creates_rollup_table_with_correct_schema(self, mock_conn: tuple) -> None:
+        conn, cursor = mock_conn
+        ensure_table(conn)
+
+        assert cursor.execute.call_count == 2
+        create_sql = cursor.execute.call_args_list[0][0][0]
+        assert "CREATE TABLE IF NOT EXISTS" in create_sql
+        assert f"{SCHEMA}.decisions_track_record_hourly" in create_sql
+        assert "symbol TEXT NOT NULL" in create_sql
+        assert "profile TEXT NOT NULL" in create_sql
+        assert "servidor TEXT NOT NULL" in create_sql
+        assert "bucket_hour TIMESTAMPTZ NOT NULL" in create_sql
+        assert "PRIMARY KEY (symbol, profile, servidor, bucket_hour)" in create_sql
+
+    def test_creates_bucket_index(self, mock_conn: tuple) -> None:
+        conn, cursor = mock_conn
+        ensure_table(conn)
+
+        index_sql = cursor.execute.call_args_list[1][0][0]
+        assert "CREATE INDEX IF NOT EXISTS" in index_sql
+        assert "bucket_hour" in index_sql
+
+
+class TestRefresh:
+    def test_upserts_with_since_param(self, mock_conn: tuple) -> None:
+        conn, cursor = mock_conn
+        since = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        rows = refresh(conn, since)
+
+        assert rows == 7
+        cursor.execute.assert_called_once()
+        sql, params = cursor.execute.call_args[0]
+        assert "ON CONFLICT (symbol, profile, servidor, bucket_hour) DO UPDATE" in sql
+        assert "track_record_trs" in sql
+        assert "track_record_boost" in sql
+        assert params["since_epoch"] == pytest.approx(since.timestamp())
+
+    def test_filters_by_timestamp_and_profile(self, mock_conn: tuple) -> None:
+        conn, cursor = mock_conn
+        since = datetime.now(timezone.utc)
+
+        refresh(conn, since)
+
+        sql = cursor.execute.call_args[0][0]
+        assert '"timestamp" >= %(since_epoch)s' in sql
+        assert "profile IS NOT NULL" in sql
+
+
+class TestMain:
+    @patch("decisions_track_record_rollup.psycopg2.connect")
+    @patch("decisions_track_record_rollup.refresh", return_value=42)
+    @patch("decisions_track_record_rollup.ensure_table")
+    @patch("decisions_track_record_rollup.DATABASE_URL", "postgresql://u:p@host/db")
+    def test_main_default_args(
+        self,
+        mock_ensure: MagicMock,
+        mock_refresh: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_connect.return_value = mock_conn
+
+        with patch("sys.argv", ["decisions_track_record_rollup.py"]):
+            result = main()
+
+        assert result == 0
+        mock_ensure.assert_called_once()
+        mock_refresh.assert_called_once()
+        mock_conn.commit.assert_called_once()
+        mock_conn.close.assert_called_once()
+
+    @patch("decisions_track_record_rollup.psycopg2.connect")
+    @patch("decisions_track_record_rollup.refresh", return_value=1)
+    @patch("decisions_track_record_rollup.ensure_table")
+    @patch("decisions_track_record_rollup.DATABASE_URL", "postgresql://u:p@host/db")
+    def test_main_backfill_overrides_hours_back(
+        self,
+        mock_ensure: MagicMock,
+        mock_refresh: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        mock_connect.return_value = MagicMock()
+
+        with patch(
+            "sys.argv",
+            ["decisions_track_record_rollup.py", "--backfill", "2160", "--hours-back", "3"],
+        ):
+            main()
+
+        since_arg = mock_refresh.call_args[0][1]
+        expected = datetime.now(timezone.utc) - timedelta(hours=2160)
+        assert abs((since_arg - expected).total_seconds()) < 5
+
+    @patch("decisions_track_record_rollup.DATABASE_URL", None)
+    def test_main_missing_database_url(self) -> None:
+        with patch("sys.argv", ["decisions_track_record_rollup.py"]):
+            result = main()
+
+        assert result == 1
+
+    @patch("decisions_track_record_rollup.psycopg2.connect")
+    @patch("decisions_track_record_rollup.DATABASE_URL", "postgresql://u:p@host/db")
+    def test_main_db_connection_failure(self, mock_connect: MagicMock) -> None:
+        mock_connect.side_effect = Exception("Connection refused")
+
+        with patch("sys.argv", ["decisions_track_record_rollup.py"]):
+            result = main()
+
+        assert result == 1
+
+    @patch("decisions_track_record_rollup.psycopg2.connect")
+    @patch("decisions_track_record_rollup.refresh", side_effect=Exception("boom"))
+    @patch("decisions_track_record_rollup.ensure_table")
+    @patch("decisions_track_record_rollup.DATABASE_URL", "postgresql://u:p@host/db")
+    def test_main_rolls_back_on_refresh_failure(
+        self,
+        mock_ensure: MagicMock,
+        mock_refresh: MagicMock,
+        mock_connect: MagicMock,
+    ) -> None:
+        mock_conn = MagicMock()
+        mock_connect.return_value = mock_conn
+
+        with patch("sys.argv", ["decisions_track_record_rollup.py"]):
+            result = main()
+
+        assert result == 1
+        mock_conn.rollback.assert_called_once()
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Resumo
- O painel "📈 Track Record — TRS & Boost ao longo do tempo" (id 208) fazia `avg((features->>'track_record_trs')::double precision)` direto sobre `btc.decisions`, ~2s por query (2x por load) em ranges de 90 dias, escaneando ~800k-1M+ linhas JSONB por símbolo (Parallel Seq Scan com sort em disco). Contribuía para a instabilidade relatada no dashboard.
- Diferente do fix de sargability do painel 71, aqui o problema é volume real de dados que precisa ser lido para o `avg()` — não dá pra resolver só com índice.
- Adiciona `btc.decisions_track_record_hourly`: rollup horário por `(symbol, profile, servidor)` com `avg_trs`, `avg_boost`, `sample_count`.
- `scripts/decisions_track_record_rollup.py`: popula/atualiza o rollup via upsert idempotente (`ON CONFLICT DO UPDATE`), reprocessando uma janela (default 3h) a cada execução para cobrir atraso + fechamento de hora corrente. `--backfill N` para popular histórico.
- `systemd/decisions-track-record-rollup.{service,timer}`: timer a cada 20min, `User=btc-trading` (padrão dos jobs de trading/Postgres do repo, ex. `candle-collector`).
- `scripts/deploy_decisions_track_record_rollup.sh`: instala script + units, roda backfill único (~91 dias) e habilita o timer.
- Painel 208 passa a consultar a tabela de rollup, com média ponderada por `sample_count` (para grouping em janelas maiores que 1h ficar correto).

## Test plan
- [x] `pytest tests/test_decisions_track_record_rollup.py` (9 testes, mocks de DB)
- [x] JSON do dashboard validado
- [x] Query de agregação e a query do painel validadas manualmente no Postgres (read-only)
- [ ] Após `scripts/deploy_decisions_track_record_rollup.sh`, conferir painel 208 em 90d carregando rápido e com dados

🤖 Generated with [Claude Code](https://claude.com/claude-code)