### PR TITLE
fix(selfheal): refresh proativo do token Tuya (elimina blackout ~2h)

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,9 +1,156 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-17T09:28:59.137891",
+  "generatedAt": "2026-07-23T16:36:25.115514",
   "environment": "production",
   "categories": {
     "services": {
+      "WIKI_API": {
+        "name": "WIKI_API",
+        "type": "url",
+        "source": ".env",
+        "value": "http://192.168.15.2:3009/graphql",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 3
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 2
+          },
+          {
+            "file": ".env",
+            "line": 3
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_PUBLIC": {
+        "name": "WIKI_PUBLIC",
+        "type": "url",
+        "source": ".env",
+        "value": "https://wiki.rpa4all.com",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 4
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 3
+          },
+          {
+            "file": ".env",
+            "line": 4
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_API": {
+        "name": "WIKI_OLLAMA_API",
+        "type": "url",
+        "source": ".env",
+        "value": "http://192.168.15.2:11437/api",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 6
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 5
+          },
+          {
+            "file": ".env",
+            "line": 6
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_MODEL": {
+        "name": "WIKI_OLLAMA_MODEL",
+        "type": "string",
+        "source": ".env",
+        "value": "qwen3:8b",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 7
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 6
+          },
+          {
+            "file": ".env",
+            "line": 7
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_LOCALE": {
+        "name": "WIKI_LOCALE",
+        "type": "string",
+        "source": ".env",
+        "value": "en",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 8
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 7
+          },
+          {
+            "file": ".env",
+            "line": 8
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_TIMEOUT": {
+        "name": "WIKI_TIMEOUT",
+        "type": "integer",
+        "source": ".env",
+        "value": "90",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 9
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 8
+          },
+          {
+            "file": ".env",
+            "line": 9
+          }
+        ],
+        "contexts": []
+      },
+      "PAGES_FILE": {
+        "name": "PAGES_FILE",
+        "type": "string",
+        "source": ".env",
+        "value": "wiki_pages.json",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 10
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 9
+          },
+          {
+            "file": ".env",
+            "line": 10
+          }
+        ],
+        "contexts": []
+      },
       "OPENAI_COMPATIBLE_ENABLED": {
         "name": "OPENAI_COMPATIBLE_ENABLED",
         "type": "string",
@@ -74,102 +221,83 @@
         "value": "5",
         "locations": [
           {
+            "file": ".env",
+            "line": 22
+          },
+          {
             "file": ".env.openai-compatible.example",
             "line": 39
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_API": {
-        "name": "WIKI_API",
-        "type": "url",
-        "source": ".env",
-        "value": "http://<homelab-ip>:3009/graphql",
-        "locations": [
+          },
           {
-            "file": ".env.example.wiki",
-            "line": 2
+            "file": ".env",
+            "line": 22
           }
         ],
         "contexts": []
       },
-      "WIKI_PUBLIC": {
-        "name": "WIKI_PUBLIC",
-        "type": "url",
-        "source": ".env",
-        "value": "https://wiki.rpa4all.com",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 3
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_API": {
-        "name": "WIKI_OLLAMA_API",
-        "type": "url",
-        "source": ".env",
-        "value": "http://<homelab-ip>:11437/api",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 5
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_MODEL": {
-        "name": "WIKI_OLLAMA_MODEL",
+      "NEXTCLOUD_URL": {
+        "name": "NEXTCLOUD_URL",
         "type": "string",
-        "source": ".env",
-        "value": "qwen3:8b",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 6
-          }
-        ],
-        "contexts": []
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
+          "configure_authentik_nextcloud_oidc"
+        ]
       },
-      "WIKI_LOCALE": {
-        "name": "WIKI_LOCALE",
+      "NEXTCLOUD_ADMIN_USER": {
+        "name": "NEXTCLOUD_ADMIN_USER",
         "type": "string",
-        "source": ".env",
-        "value": "en",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 7
-          }
-        ],
-        "contexts": []
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
       },
-      "WIKI_TIMEOUT": {
-        "name": "WIKI_TIMEOUT",
-        "type": "integer",
-        "source": ".env",
-        "value": "90",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 8
-          }
-        ],
-        "contexts": []
-      },
-      "PAGES_FILE": {
-        "name": "PAGES_FILE",
+      "NEXTCLOUD_CONTAINER": {
+        "name": "NEXTCLOUD_CONTAINER",
         "type": "string",
-        "source": ".env",
-        "value": "wiki_pages.json",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 9
-          }
-        ],
-        "contexts": []
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_AGENT_ENABLED": {
+        "name": "NEXTCLOUD_AGENT_ENABLED",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_GPU": {
+        "name": "NEXTCLOUD_OLLAMA_GPU",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_TIMEOUT": {
+        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_DEFAULT_DRY_RUN": {
+        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
       },
       "GEMINI_ENABLED": {
         "name": "GEMINI_ENABLED",
@@ -199,11 +327,11 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-backend",
+          "mailu-postfix",
           "mailu-roundcube",
           "mailu-frontend",
           "mailu-dovecot",
-          "mailu-postfix"
+          "mailu-backend"
         ]
       },
       "ADMIN_EMAIL": {
@@ -620,8 +748,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_BASE_PATH:-}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "NETBOX_LOGIN_REQUIRED": {
@@ -829,6 +957,19 @@
           "glpi"
         ]
       },
+      "METRICS_PORT": {
+        "name": "METRICS_PORT",
+        "type": "integer",
+        "source": ".env",
+        "value": "9099",
+        "locations": [
+          {
+            "file": "btc_trading_agent/BTC_USDT_shadow.env",
+            "line": 1
+          }
+        ],
+        "contexts": []
+      },
       "LTFS_SERVICE": {
         "name": "LTFS_SERVICE",
         "type": "string",
@@ -1011,19 +1152,6 @@
         ],
         "contexts": []
       },
-      "METRICS_PORT": {
-        "name": "METRICS_PORT",
-        "type": "integer",
-        "source": ".env",
-        "value": "9099",
-        "locations": [
-          {
-            "file": "btc_trading_agent/BTC_USDT_shadow.env",
-            "line": 1
-          }
-        ],
-        "contexts": []
-      },
       "ANONYMIZED_TELEMETRY": {
         "name": "ANONYMIZED_TELEMETRY",
         "type": "boolean",
@@ -1063,69 +1191,6 @@
           }
         ],
         "contexts": []
-      },
-      "HA_ACTIVE": {
-        "name": "HA_ACTIVE",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "false",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_ISSUER": {
-        "name": "OIDC_ISSUER",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "http://authentik-server:9000",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_CLIENT_ID": {
-        "name": "OIDC_CLIENT_ID",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "wikijs-3cd3a4331641a2b7",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_REDIRECT_URI": {
-        "name": "OIDC_REDIRECT_URI",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "http://192.168.15.2:3009/auth/oauth2/callback",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_USERINFO_ENDPOINT": {
-        "name": "OIDC_USERINFO_ENDPOINT",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "http://authentik-server:9000/application/o/userinfo/",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_DISCOVERY": {
-        "name": "OIDC_DISCOVERY",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "http://authentik-server:9000/application/o/.well-known/openid-configuration",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_SCOPE": {
-        "name": "OIDC_SCOPE",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "openid profile email",
-        "contexts": [
-          "wikijs"
-        ]
       },
       "HOSTNAME": {
         "name": "HOSTNAME",
@@ -1253,60 +1318,6 @@
           "postfix-exporter"
         ]
       },
-      "cluster.name": {
-        "name": "cluster.name",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "shared-cluster",
-        "contexts": [
-          "opensearch-node1"
-        ]
-      },
-      "node.name": {
-        "name": "node.name",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "shared-opensearch-node1",
-        "contexts": [
-          "opensearch-node1"
-        ]
-      },
-      "discovery.type": {
-        "name": "discovery.type",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "single-node",
-        "contexts": [
-          "opensearch-node1"
-        ]
-      },
-      "bootstrap.memory_lock": {
-        "name": "bootstrap.memory_lock",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "true",
-        "contexts": [
-          "opensearch-node1"
-        ]
-      },
-      "OPENSEARCH_JAVA_OPTS": {
-        "name": "OPENSEARCH_JAVA_OPTS",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "-Xms1g -Xmx1g",
-        "contexts": [
-          "opensearch-node1"
-        ]
-      },
-      "OPENSEARCH_HOSTS": {
-        "name": "OPENSEARCH_HOSTS",
-        "type": "json",
-        "source": "docker-compose",
-        "value": "[\"https://shared-opensearch:9200\"]",
-        "contexts": [
-          "opensearch-dashboards"
-        ]
-      },
       "TLS_FLAVOR": {
         "name": "TLS_FLAVOR",
         "type": "string",
@@ -1423,8 +1434,8 @@
         "contexts": [
           "glpi",
           "glpi-db",
-          "netbox-postgres",
-          "grafana"
+          "grafana",
+          "netbox-postgres"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -1434,6 +1445,302 @@
         "value": "America/Sao_Paulo",
         "contexts": [
           "grafana"
+        ]
+      },
+      "cluster.name": {
+        "name": "cluster.name",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "shared-cluster",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "node.name": {
+        "name": "node.name",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "shared-opensearch-node1",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "discovery.type": {
+        "name": "discovery.type",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "single-node",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "bootstrap.memory_lock": {
+        "name": "bootstrap.memory_lock",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "true",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "OPENSEARCH_JAVA_OPTS": {
+        "name": "OPENSEARCH_JAVA_OPTS",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "-Xms1g -Xmx1g",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "OPENSEARCH_HOSTS": {
+        "name": "OPENSEARCH_HOSTS",
+        "type": "json",
+        "source": "docker-compose",
+        "value": "[\"https://shared-opensearch:9200\"]",
+        "contexts": [
+          "opensearch-dashboards"
+        ]
+      },
+      "HA_ACTIVE": {
+        "name": "HA_ACTIVE",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "false",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_ISSUER": {
+        "name": "OIDC_ISSUER",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "http://authentik-server:9000",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_CLIENT_ID": {
+        "name": "OIDC_CLIENT_ID",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "wikijs-3cd3a4331641a2b7",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_REDIRECT_URI": {
+        "name": "OIDC_REDIRECT_URI",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "http://192.168.15.2:3009/auth/oauth2/callback",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_USERINFO_ENDPOINT": {
+        "name": "OIDC_USERINFO_ENDPOINT",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "http://authentik-server:9000/application/o/userinfo/",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_DISCOVERY": {
+        "name": "OIDC_DISCOVERY",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "http://authentik-server:9000/application/o/.well-known/openid-configuration",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_SCOPE": {
+        "name": "OIDC_SCOPE",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "openid profile email",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "ROCKET_WORKERS": {
+        "name": "ROCKET_WORKERS",
+        "type": "integer",
+        "source": "docker-compose",
+        "value": "4",
+        "contexts": [
+          "vaultwarden"
+        ]
+      },
+      "ALLOWED_HOSTS": {
+        "name": "ALLOWED_HOSTS",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_ALLOWED_HOSTS:-*}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "CORS_ORIGIN_ALLOW_ALL": {
+        "name": "CORS_ORIGIN_ALLOW_ALL",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "True",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "CSRF_TRUSTED_ORIGINS": {
+        "name": "CSRF_TRUSTED_ORIGINS",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_FROM": {
+        "name": "EMAIL_FROM",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_PORT": {
+        "name": "EMAIL_PORT",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_EMAIL_PORT:-25}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_SERVER": {
+        "name": "EMAIL_SERVER",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_EMAIL_SERVER:-localhost}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_TIMEOUT": {
+        "name": "EMAIL_TIMEOUT",
+        "type": "integer",
+        "source": "docker-compose",
+        "value": "5",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_USE_SSL": {
+        "name": "EMAIL_USE_SSL",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_EMAIL_USE_SSL:-false}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "EMAIL_USE_TLS": {
+        "name": "EMAIL_USE_TLS",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_EMAIL_USE_TLS:-false}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "GRAPHQL_ENABLED": {
+        "name": "GRAPHQL_ENABLED",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "true",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "LOGIN_REQUIRED": {
+        "name": "LOGIN_REQUIRED",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_LOGIN_REQUIRED:-true}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "LOGOUT_REDIRECT_URL": {
+        "name": "LOGOUT_REDIRECT_URL",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "METRICS_ENABLED": {
+        "name": "METRICS_ENABLED",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "true",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "SUPERUSER_EMAIL": {
+        "name": "SUPERUSER_EMAIL",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "SUPERUSER_NAME": {
+        "name": "SUPERUSER_NAME",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "SKIP_SUPERUSER": {
+        "name": "SKIP_SUPERUSER",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${NETBOX_SKIP_SUPERUSER:-false}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "TIME_ZONE": {
+        "name": "TIME_ZONE",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
         ]
       },
       "BAUDRATE": {
@@ -1481,246 +1788,178 @@
           "printshare"
         ]
       },
-      "ALLOWED_HOSTS": {
-        "name": "ALLOWED_HOSTS",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_ALLOWED_HOSTS:-*}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "CORS_ORIGIN_ALLOW_ALL": {
-        "name": "CORS_ORIGIN_ALLOW_ALL",
+      "PYTHONUNBUFFERED": {
+        "name": "PYTHONUNBUFFERED",
         "type": "boolean",
-        "source": "docker-compose",
-        "value": "True",
+        "source": "systemd",
+        "value": "1",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator",
+          "candle-collector",
+          "daily-agenda-broadcast",
+          "eddie-calendar",
+          "daily-agenda-panel",
+          "kucoin-usdt-rebalance",
+          "marketing-api",
+          "notebook-power-agent",
+          "trading-analyst-weekly-retrain",
+          "diretor",
+          "bn-acervo-agent",
+          "marketing-daily-report",
+          "meeting-translator",
+          "kucoin-postgres-sync",
+          "rss-sentiment-exporter",
+          "banking-metrics-exporter",
+          "trading-daily-report",
+          "crypto-agent@",
+          "eddie-telegram-bot",
+          "decisions-track-record-rollup",
+          "marketing-x-posts",
+          "clear-trading-agent",
+          "coordinator",
+          "tape-component-quality-exporter",
+          "agent-network-exporter",
+          "marketing-email-drip",
+          "approval-gateway",
+          "eddie-expurgo"
         ]
       },
-      "CSRF_TRUSTED_ORIGINS": {
-        "name": "CSRF_TRUSTED_ORIGINS",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
+      "PYTHONPATH": {
+        "name": "PYTHONPATH",
+        "type": "path",
+        "source": "systemd",
+        "value": "/home/homelab/eddie-auto-dev",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "tape-component-quality-exporter",
+          "ollama-finetune",
+          "candle-collector",
+          "marketing-daily-report",
+          "rss-sentiment-exporter",
+          "decisions-track-record-rollup",
+          "marketing-email-drip",
+          "marketing-x-posts",
+          "clear-trading-agent",
+          "llm-log-panel",
+          "marketing-api"
         ]
       },
-      "EMAIL_FROM": {
-        "name": "EMAIL_FROM",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
+      "X_AGENT_URL": {
+        "name": "X_AGENT_URL",
+        "type": "url",
+        "source": "systemd",
+        "value": "http://localhost:8515",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "marketing-x-posts"
         ]
       },
-      "EMAIL_PORT": {
-        "name": "EMAIL_PORT",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_EMAIL_PORT:-25}",
+      "OLLAMA_GPU0_HOST": {
+        "name": "OLLAMA_GPU0_HOST",
+        "type": "url",
+        "source": "systemd",
+        "value": "http://192.168.15.2:11434",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator"
         ]
       },
-      "EMAIL_SERVER": {
-        "name": "EMAIL_SERVER",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_EMAIL_SERVER:-localhost}",
+      "OLLAMA_GPU1_HOST": {
+        "name": "OLLAMA_GPU1_HOST",
+        "type": "url",
+        "source": "systemd",
+        "value": "http://192.168.15.2:11435",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator"
         ]
       },
-      "EMAIL_TIMEOUT": {
-        "name": "EMAIL_TIMEOUT",
+      "GPU_COORD_PORT": {
+        "name": "GPU_COORD_PORT",
         "type": "integer",
-        "source": "docker-compose",
-        "value": "5",
+        "source": "systemd",
+        "value": "11437",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator"
         ]
       },
-      "EMAIL_USE_SSL": {
-        "name": "EMAIL_USE_SSL",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_EMAIL_USE_SSL:-false}",
+      "GPU_COORD_BUSY_WAIT_SEC": {
+        "name": "GPU_COORD_BUSY_WAIT_SEC",
+        "type": "integer",
+        "source": "systemd",
+        "value": "10",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator"
         ]
       },
-      "EMAIL_USE_TLS": {
-        "name": "EMAIL_USE_TLS",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_EMAIL_USE_TLS:-false}",
+      "GPU_COORD_REQUEST_TIMEOUT_SEC": {
+        "name": "GPU_COORD_REQUEST_TIMEOUT_SEC",
+        "type": "integer",
+        "source": "systemd",
+        "value": "180",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "ollama-gpu-coordinator"
         ]
       },
-      "GRAPHQL_ENABLED": {
-        "name": "GRAPHQL_ENABLED",
+      "PYTHONDONTWRITEBYTECODE": {
+        "name": "PYTHONDONTWRITEBYTECODE",
         "type": "boolean",
-        "source": "docker-compose",
-        "value": "true",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "LOGIN_REQUIRED": {
-        "name": "LOGIN_REQUIRED",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_LOGIN_REQUIRED:-true}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "LOGOUT_REDIRECT_URL": {
-        "name": "LOGOUT_REDIRECT_URL",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "METRICS_ENABLED": {
-        "name": "METRICS_ENABLED",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "true",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "SUPERUSER_EMAIL": {
-        "name": "SUPERUSER_EMAIL",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "SUPERUSER_NAME": {
-        "name": "SUPERUSER_NAME",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "SKIP_SUPERUSER": {
-        "name": "SKIP_SUPERUSER",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${NETBOX_SKIP_SUPERUSER:-false}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "TIME_ZONE": {
-        "name": "TIME_ZONE",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "ROCKET_WORKERS": {
-        "name": "ROCKET_WORKERS",
-        "type": "integer",
-        "source": "docker-compose",
-        "value": "4",
-        "contexts": [
-          "vaultwarden"
-        ]
-      },
-      "HA_CONTAINER": {
-        "name": "HA_CONTAINER",
-        "type": "string",
         "source": "systemd",
-        "value": "homeassistant",
+        "value": "1",
         "contexts": [
-          "tuya-token-selfheal"
+          "ollama-finetune",
+          "candle-collector",
+          "decisions-track-record-rollup",
+          "rss-sentiment-exporter",
+          "llm-log-panel"
         ]
       },
-      "HA_CONFIG_ENTRIES": {
-        "name": "HA_CONFIG_ENTRIES",
+      "HOME": {
+        "name": "HOME",
         "type": "path",
         "source": "systemd",
-        "value": "/home/homelab/homeassistant/config/.storage/core.config_entries",
+        "value": "/apps/crypto-trader",
         "contexts": [
-          "tuya-token-selfheal"
+          "crypto-agent@",
+          "ollama-finetune",
+          "candle-collector",
+          "decisions-track-record-rollup",
+          "rss-sentiment-exporter",
+          "llm-log-panel"
         ]
       },
-      "STATE_FILE": {
-        "name": "STATE_FILE",
+      "PATH": {
+        "name": "PATH",
         "type": "path",
         "source": "systemd",
-        "value": "/var/lib/tuya-selfheal/state.json",
+        "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "contexts": [
-          "tuya-token-selfheal"
+          "specialized_agents-dashboard",
+          "homelab-dashboard",
+          "crypto-agent@",
+          "tape-component-quality-exporter",
+          "github-agent",
+          "eddie-whatsapp-bot",
+          "kucoin-usdt-rebalance",
+          "kucoin-postgres-sync",
+          "rpa4all-validation",
+          "job-monitor"
         ]
       },
-      "PROM_FILE": {
-        "name": "PROM_FILE",
-        "type": "path",
-        "source": "systemd",
-        "value": "/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom",
-        "contexts": [
-          "tuya-token-selfheal"
-        ]
-      },
-      "MAX_HEALS_24H": {
-        "name": "MAX_HEALS_24H",
+      "CHECK_INTERVAL": {
+        "name": "CHECK_INTERVAL",
         "type": "integer",
         "source": "systemd",
-        "value": "6",
+        "value": "30",
         "contexts": [
-          "tuya-token-selfheal"
+          "grafana-selfheal",
+          "ethwan-selfheal",
+          "dhcp-selfheal"
         ]
       },
-      "HA_BOOT_WAIT_S": {
-        "name": "HA_BOOT_WAIT_S",
-        "type": "integer",
+      "DHCP_SERVICE": {
+        "name": "DHCP_SERVICE",
+        "type": "string",
         "source": "systemd",
-        "value": "300",
+        "value": "homelab-lan-dhcp.service",
         "contexts": [
-          "tuya-token-selfheal"
-        ]
-      },
-      "BYPASS_CONF": {
-        "name": "BYPASS_CONF",
-        "type": "path",
-        "source": "systemd",
-        "value": "/etc/iot-vpn-bypass.conf",
-        "contexts": [
-          "iot-presence-watchdog"
+          "dhcp-selfheal"
         ]
       },
       "LEASES_FILE": {
@@ -1733,40 +1972,172 @@
           "dhcp-selfheal"
         ]
       },
-      "UNIT": {
-        "name": "UNIT",
-        "type": "string",
+      "FIX_NFTABLES": {
+        "name": "FIX_NFTABLES",
+        "type": "path",
         "source": "systemd",
-        "value": "wg-quick@protonvpn.service",
+        "value": "/usr/local/bin/fix-dhcp-nftables.sh",
         "contexts": [
-          "protonvpn-unit-selfheal"
+          "dhcp-selfheal"
         ]
       },
-      "WG_IFACE": {
-        "name": "WG_IFACE",
+      "DHCP_RANGE_START": {
+        "name": "DHCP_RANGE_START",
         "type": "string",
         "source": "systemd",
-        "value": "protonvpn",
+        "value": "192.168.15.60",
         "contexts": [
-          "protonvpn-unit-selfheal"
+          "dhcp-selfheal"
         ]
       },
-      "WAN_IFACE": {
-        "name": "WAN_IFACE",
+      "DHCP_RANGE_END": {
+        "name": "DHCP_RANGE_END",
         "type": "string",
         "source": "systemd",
-        "value": "eth-wan",
+        "value": "192.168.15.200",
         "contexts": [
-          "protonvpn-unit-selfheal"
+          "dhcp-selfheal"
         ]
       },
-      "HANDSHAKE_MAX_AGE": {
-        "name": "HANDSHAKE_MAX_AGE",
+      "MAX_STUCK_SECONDS": {
+        "name": "MAX_STUCK_SECONDS",
         "type": "integer",
         "source": "systemd",
-        "value": "600",
+        "value": "300",
         "contexts": [
-          "protonvpn-unit-selfheal"
+          "dhcp-selfheal"
+        ]
+      },
+      "MAX_RESTARTS_HOUR": {
+        "name": "MAX_RESTARTS_HOUR",
+        "type": "integer",
+        "source": "systemd",
+        "value": "5",
+        "contexts": [
+          "grafana-selfheal",
+          "dhcp-selfheal"
+        ]
+      },
+      "AGENDA_YOUTUBE_CHANNEL_ID": {
+        "name": "AGENDA_YOUTUBE_CHANNEL_ID",
+        "type": "string",
+        "source": "systemd",
+        "value": "UCEyYr2YE1HLDTKT4cnMefmw",
+        "contexts": [
+          "daily-agenda-broadcast",
+          "daily-agenda-panel"
+        ]
+      },
+      "CLEAR_CONFIG_FILE": {
+        "name": "CLEAR_CONFIG_FILE",
+        "type": "string",
+        "source": "systemd",
+        "value": "config_%I.json",
+        "contexts": [
+          "clear-agent@",
+          "clear-trading-agent"
+        ]
+      },
+      "ROUTE_NAME": {
+        "name": "ROUTE_NAME",
+        "type": "string",
+        "source": "systemd",
+        "value": "tape_sg1",
+        "contexts": [
+          "homelab-tape-log-drain-sg1",
+          "homelab-tape-log-drain-nextcloud"
+        ]
+      },
+      "ROUTE_TARGET_ROOT": {
+        "name": "ROUTE_TARGET_ROOT",
+        "type": "path",
+        "source": "systemd",
+        "value": "/mnt/tape_sg1/logs",
+        "contexts": [
+          "homelab-tape-log-drain-sg1",
+          "homelab-tape-log-drain-nextcloud"
+        ]
+      },
+      "WHATSAPP_NUMBER": {
+        "name": "WHATSAPP_NUMBER",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "WAHA_URL": {
+        "name": "WAHA_URL",
+        "type": "url",
+        "source": "systemd",
+        "value": "http://localhost:3004",
+        "contexts": [
+          "eddie-expurgo",
+          "eddie-whatsapp-bot"
+        ]
+      },
+      "ADMIN_NUMBERS": {
+        "name": "ADMIN_NUMBERS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "OLLAMA_PORT": {
+        "name": "OLLAMA_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "11434",
+        "contexts": [
+          "github-agent"
+        ]
+      },
+      "FAIL_THRESHOLD": {
+        "name": "FAIL_THRESHOLD",
+        "type": "integer",
+        "source": "systemd",
+        "value": "3",
+        "contexts": [
+          "grafana-selfheal"
+        ]
+      },
+      "TEXTFILE_DIR": {
+        "name": "TEXTFILE_DIR",
+        "type": "path",
+        "source": "systemd",
+        "value": "/var/lib/prometheus/node-exporter",
+        "contexts": [
+          "grafana-selfheal"
+        ]
+      },
+      "BANKING_EXPORTER_PORT": {
+        "name": "BANKING_EXPORTER_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "9102",
+        "contexts": [
+          "banking-metrics-exporter"
+        ]
+      },
+      "LLM_LOG_PANEL_HOST": {
+        "name": "LLM_LOG_PANEL_HOST",
+        "type": "string",
+        "source": "systemd",
+        "value": "0.0.0.0",
+        "contexts": [
+          "llm-log-panel"
+        ]
+      },
+      "LLM_LOG_PANEL_PORT": {
+        "name": "LLM_LOG_PANEL_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "8092",
+        "contexts": [
+          "llm-log-panel"
         ]
       },
       "IFACE": {
@@ -1776,17 +2147,6 @@
         "value": "eth-wan",
         "contexts": [
           "ethwan-selfheal"
-        ]
-      },
-      "CHECK_INTERVAL": {
-        "name": "CHECK_INTERVAL",
-        "type": "integer",
-        "source": "systemd",
-        "value": "30",
-        "contexts": [
-          "grafana-selfheal",
-          "ethwan-selfheal",
-          "dhcp-selfheal"
         ]
       },
       "LINK_DOWN_GRACE": {
@@ -1825,84 +2185,112 @@
           "ethwan-selfheal"
         ]
       },
-      "PYTHONUNBUFFERED": {
-        "name": "PYTHONUNBUFFERED",
+      "BYPASS_CONF": {
+        "name": "BYPASS_CONF",
+        "type": "path",
+        "source": "systemd",
+        "value": "/etc/iot-vpn-bypass.conf",
+        "contexts": [
+          "iot-presence-watchdog"
+        ]
+      },
+      "DAILY_AGENDA_PANEL_HOST": {
+        "name": "DAILY_AGENDA_PANEL_HOST",
+        "type": "string",
+        "source": "systemd",
+        "value": "0.0.0.0",
+        "contexts": [
+          "daily-agenda-panel"
+        ]
+      },
+      "DAILY_AGENDA_PANEL_PORT": {
+        "name": "DAILY_AGENDA_PANEL_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "8093",
+        "contexts": [
+          "daily-agenda-panel"
+        ]
+      },
+      "OLLAMA_WARM_MODEL_GPU0": {
+        "name": "OLLAMA_WARM_MODEL_GPU0",
+        "type": "string",
+        "source": "systemd",
+        "value": "trading-analyst:latest",
+        "contexts": [
+          "ollama-warmup"
+        ]
+      },
+      "OLLAMA_WARM_MODEL_GPU1": {
+        "name": "OLLAMA_WARM_MODEL_GPU1",
+        "type": "string",
+        "source": "systemd",
+        "value": "gemma3:1b",
+        "contexts": [
+          "ollama-warmup"
+        ]
+      },
+      "BN_ACERVO_DEBUG_LOG_PATH": {
+        "name": "BN_ACERVO_DEBUG_LOG_PATH",
+        "type": "path",
+        "source": "systemd",
+        "value": "/tmp/bn-acervo-dev-8513.log",
+        "contexts": [
+          "bn-acervo-agent"
+        ]
+      },
+      "BN_ACERVO_HTTP_TRUST_ENV": {
+        "name": "BN_ACERVO_HTTP_TRUST_ENV",
         "type": "boolean",
         "source": "systemd",
-        "value": "1",
+        "value": "false",
         "contexts": [
-          "eddie-calendar",
-          "bn-acervo-agent",
-          "crypto-agent@",
-          "kucoin-postgres-sync",
-          "daily-agenda-broadcast",
-          "tape-component-quality-exporter",
-          "diretor",
-          "rss-sentiment-exporter",
-          "trading-analyst-weekly-retrain",
-          "meeting-translator",
-          "daily-agenda-panel",
-          "ollama-gpu-coordinator",
-          "notebook-power-agent",
-          "eddie-expurgo",
-          "kucoin-usdt-rebalance",
-          "marketing-x-posts",
-          "marketing-email-drip",
-          "agent-network-exporter",
-          "eddie-telegram-bot",
-          "coordinator",
-          "candle-collector",
-          "clear-trading-agent",
-          "banking-metrics-exporter",
-          "marketing-api",
-          "trading-daily-report",
-          "marketing-daily-report",
-          "approval-gateway"
+          "bn-acervo-agent"
         ]
       },
-      "NARRATOR_STATE_FILE": {
-        "name": "NARRATOR_STATE_FILE",
+      "VIRTUAL_ENV": {
+        "name": "VIRTUAL_ENV",
         "type": "path",
         "source": "systemd",
-        "value": "/var/lib/tape-quality/narrator_state.json",
+        "value": "/home/homelab/docling_venv",
         "contexts": [
-          "tape-quality-ollama-narrator"
+          "job-monitor"
         ]
       },
-      "PYTHONPATH": {
-        "name": "PYTHONPATH",
-        "type": "path",
+      "CHECK_INTERVAL_MINUTES": {
+        "name": "CHECK_INTERVAL_MINUTES",
+        "type": "integer",
         "source": "systemd",
-        "value": "/var/db/ltfs-tools/libs",
+        "value": "60",
         "contexts": [
-          "llm-log-panel",
-          "marketing-x-posts",
-          "rss-sentiment-exporter",
-          "marketing-api",
-          "marketing-email-drip",
-          "clear-trading-agent",
-          "candle-collector",
-          "marketing-daily-report",
-          "tape-component-quality-exporter",
-          "ollama-finetune"
+          "job-monitor"
         ]
       },
-      "PATH": {
-        "name": "PATH",
-        "type": "path",
+      "COMPATIBILITY_THRESHOLD": {
+        "name": "COMPATIBILITY_THRESHOLD",
+        "type": "float",
         "source": "systemd",
-        "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "value": "20.0",
         "contexts": [
-          "kucoin-usdt-rebalance",
-          "github-agent",
-          "specialized_agents-dashboard",
-          "job-monitor",
-          "eddie-whatsapp-bot",
-          "homelab-dashboard",
-          "rpa4all-validation",
-          "kucoin-postgres-sync",
-          "crypto-agent@",
-          "tape-component-quality-exporter"
+          "job-monitor"
+        ]
+      },
+      "MAX_CHATS_PER_RUN": {
+        "name": "MAX_CHATS_PER_RUN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "300",
+        "contexts": [
+          "job-monitor"
+        ]
+      },
+      "MESSAGES_PER_CHAT": {
+        "name": "MESSAGES_PER_CHAT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "60",
+        "contexts": [
+          "job-monitor"
         ]
       },
       "OLLAMA_SENTIMENT_MODEL": {
@@ -1941,84 +2329,141 @@
           "rss-sentiment-exporter"
         ]
       },
-      "PYTHONDONTWRITEBYTECODE": {
-        "name": "PYTHONDONTWRITEBYTECODE",
-        "type": "boolean",
+      "OLLAMA_HOST_GPU0": {
+        "name": "OLLAMA_HOST_GPU0",
+        "type": "url",
         "source": "systemd",
-        "value": "1",
+        "value": "http://192.168.15.2:11434",
         "contexts": [
-          "llm-log-panel",
-          "ollama-finetune",
-          "candle-collector",
-          "rss-sentiment-exporter"
-        ]
-      },
-      "HOME": {
-        "name": "HOME",
-        "type": "path",
-        "source": "systemd",
-        "value": "/apps/crypto-trader",
-        "contexts": [
-          "llm-log-panel",
-          "rss-sentiment-exporter",
-          "crypto-agent@",
-          "candle-collector",
           "ollama-finetune"
-        ]
-      },
-      "WAIT_SECONDS": {
-        "name": "WAIT_SECONDS",
-        "type": "integer",
-        "source": "systemd",
-        "value": "20",
-        "contexts": [
-          "protonvpn-boot-selfheal"
-        ]
-      },
-      "MAX_ATTEMPTS": {
-        "name": "MAX_ATTEMPTS",
-        "type": "integer",
-        "source": "systemd",
-        "value": "3",
-        "contexts": [
-          "protonvpn-boot-selfheal"
-        ]
-      },
-      "RETRY_DELAY": {
-        "name": "RETRY_DELAY",
-        "type": "integer",
-        "source": "systemd",
-        "value": "15",
-        "contexts": [
-          "protonvpn-boot-selfheal"
-        ]
-      },
-      "OLLAMA_WARM_MODEL_GPU0": {
-        "name": "OLLAMA_WARM_MODEL_GPU0",
-        "type": "string",
-        "source": "systemd",
-        "value": "trading-analyst:latest",
-        "contexts": [
-          "ollama-warmup"
-        ]
-      },
-      "OLLAMA_WARM_MODEL_GPU1": {
-        "name": "OLLAMA_WARM_MODEL_GPU1",
-        "type": "string",
-        "source": "systemd",
-        "value": "gemma3:1b",
-        "contexts": [
-          "ollama-warmup"
         ]
       },
       "CUDA_VISIBLE_DEVICES": {
         "name": "CUDA_VISIBLE_DEVICES",
         "type": "boolean",
         "source": "systemd",
-        "value": "1",
+        "value": "0",
         "contexts": [
           "ollama-finetune",
           "ollama-gpu1"
+        ]
+      },
+      "PYTORCH_CUDA_ALLOC_CONF": {
+        "name": "PYTORCH_CUDA_ALLOC_CONF",
+        "type": "string",
+        "source": "systemd",
+        "value": "expandable_segments:True",
+        "contexts": [
+          "ollama-finetune"
+        ]
+      },
+      "GMAIL_DATA_DIR": {
+        "name": "GMAIL_DATA_DIR",
+        "type": "path",
+        "source": "systemd",
+        "value": "/home/homelab/myClaude/gmail_data",
+        "contexts": [
+          "eddie-expurgo"
+        ]
+      },
+      "ADMIN_CHAT_ID": {
+        "name": "ADMIN_CHAT_ID",
+        "type": "integer",
+        "source": "systemd",
+        "value": "948686300",
+        "contexts": [
+          "eddie-expurgo",
+          "eddie-calendar"
+        ]
+      },
+      "ADMIN_PHONE": {
+        "name": "ADMIN_PHONE",
+        "type": "integer",
+        "source": "systemd",
+        "value": "5511999999999",
+        "contexts": [
+          "eddie-expurgo"
+        ]
+      },
+      "TG_LONG_POLL": {
+        "name": "TG_LONG_POLL",
+        "type": "integer",
+        "source": "systemd",
+        "value": "30",
+        "contexts": [
+          "approval-gateway"
+        ]
+      },
+      "INTENT_EXP_MIN": {
+        "name": "INTENT_EXP_MIN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "10",
+        "contexts": [
+          "approval-gateway"
+        ]
+      },
+      "NARRATOR_STATE_FILE": {
+        "name": "NARRATOR_STATE_FILE",
+        "type": "path",
+        "source": "systemd",
+        "value": "/var/lib/tape-quality/narrator_state.json",
+        "contexts": [
+          "tape-quality-ollama-narrator"
+        ]
+      },
+      "MEETING_TRANSLATOR_PORT": {
+        "name": "MEETING_TRANSLATOR_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "8712",
+        "contexts": [
+          "meeting-translator"
+        ]
+      },
+      "EXTENDED_METRICS_PORT": {
+        "name": "EXTENDED_METRICS_PORT",
+        "type": "integer",
+        "source": "systemd",
+        "value": "9106",
+        "contexts": [
+          "eddie_central_extended_metrics"
+        ]
+      },
+      "UNIT": {
+        "name": "UNIT",
+        "type": "string",
+        "source": "systemd",
+        "value": "wg-quick@protonvpn.service",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "WG_IFACE": {
+        "name": "WG_IFACE",
+        "type": "string",
+        "source": "systemd",
+        "value": "protonvpn",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "WAN_IFACE": {
+        "name": "WAN_IFACE",
+        "type": "string",
+        "source": "systemd",
+        "value": "eth-wan",
+        "contexts": [
+          "protonvpn-unit-selfheal"
+        ]
+      },
+      "HANDSHAKE_MAX_AGE": {
+        "name": "HANDSHAKE_MAX_AGE",
+        "type": "integer",
+        "source": "systemd",
+        "value": "600",
+        "contexts": [
+          "protonvpn-unit-selfheal"
         ]
       },
       "OLLAMA_LLM_LIBRARY": {
@@ -2156,270 +2601,121 @@
           "ollama-gpu1"
         ]
       },
-      "OLLAMA_GPU0_HOST": {
-        "name": "OLLAMA_GPU0_HOST",
-        "type": "url",
-        "source": "systemd",
-        "value": "http://192.168.15.2:11434",
-        "contexts": [
-          "ollama-gpu-coordinator"
-        ]
-      },
-      "OLLAMA_GPU1_HOST": {
-        "name": "OLLAMA_GPU1_HOST",
-        "type": "url",
-        "source": "systemd",
-        "value": "http://192.168.15.2:11435",
-        "contexts": [
-          "ollama-gpu-coordinator"
-        ]
-      },
-      "GPU_COORD_PORT": {
-        "name": "GPU_COORD_PORT",
+      "WAIT_SECONDS": {
+        "name": "WAIT_SECONDS",
         "type": "integer",
         "source": "systemd",
-        "value": "11437",
+        "value": "20",
         "contexts": [
-          "ollama-gpu-coordinator"
+          "protonvpn-boot-selfheal"
         ]
       },
-      "GPU_COORD_BUSY_WAIT_SEC": {
-        "name": "GPU_COORD_BUSY_WAIT_SEC",
+      "MAX_ATTEMPTS": {
+        "name": "MAX_ATTEMPTS",
         "type": "integer",
         "source": "systemd",
-        "value": "10",
+        "value": "3",
         "contexts": [
-          "ollama-gpu-coordinator"
+          "protonvpn-boot-selfheal"
         ]
       },
-      "GPU_COORD_REQUEST_TIMEOUT_SEC": {
-        "name": "GPU_COORD_REQUEST_TIMEOUT_SEC",
+      "RETRY_DELAY": {
+        "name": "RETRY_DELAY",
         "type": "integer",
         "source": "systemd",
-        "value": "180",
+        "value": "15",
         "contexts": [
-          "ollama-gpu-coordinator"
+          "protonvpn-boot-selfheal"
         ]
       },
-      "OLLAMA_HOST_GPU0": {
-        "name": "OLLAMA_HOST_GPU0",
-        "type": "url",
-        "source": "systemd",
-        "value": "http://192.168.15.2:11434",
-        "contexts": [
-          "ollama-finetune"
-        ]
-      },
-      "PYTORCH_CUDA_ALLOC_CONF": {
-        "name": "PYTORCH_CUDA_ALLOC_CONF",
+      "HA_CONTAINER": {
+        "name": "HA_CONTAINER",
         "type": "string",
         "source": "systemd",
-        "value": "expandable_segments:True",
+        "value": "homeassistant",
         "contexts": [
-          "ollama-finetune"
+          "tuya-token-selfheal"
         ]
       },
-      "MEETING_TRANSLATOR_PORT": {
-        "name": "MEETING_TRANSLATOR_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "8712",
-        "contexts": [
-          "meeting-translator"
-        ]
-      },
-      "X_AGENT_URL": {
-        "name": "X_AGENT_URL",
-        "type": "url",
-        "source": "systemd",
-        "value": "http://localhost:8515",
-        "contexts": [
-          "marketing-x-posts"
-        ]
-      },
-      "LLM_LOG_PANEL_HOST": {
-        "name": "LLM_LOG_PANEL_HOST",
-        "type": "string",
-        "source": "systemd",
-        "value": "0.0.0.0",
-        "contexts": [
-          "llm-log-panel"
-        ]
-      },
-      "LLM_LOG_PANEL_PORT": {
-        "name": "LLM_LOG_PANEL_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "8092",
-        "contexts": [
-          "llm-log-panel"
-        ]
-      },
-      "VIRTUAL_ENV": {
-        "name": "VIRTUAL_ENV",
+      "HA_CONFIG_ENTRIES": {
+        "name": "HA_CONFIG_ENTRIES",
         "type": "path",
         "source": "systemd",
-        "value": "/home/homelab/docling_venv",
+        "value": "/home/homelab/homeassistant/config/.storage/core.config_entries",
         "contexts": [
-          "job-monitor"
+          "tuya-token-selfheal"
         ]
       },
-      "CHECK_INTERVAL_MINUTES": {
-        "name": "CHECK_INTERVAL_MINUTES",
+      "STATE_FILE": {
+        "name": "STATE_FILE",
+        "type": "path",
+        "source": "systemd",
+        "value": "/var/lib/tuya-selfheal/state.json",
+        "contexts": [
+          "tuya-token-selfheal"
+        ]
+      },
+      "PROM_FILE": {
+        "name": "PROM_FILE",
+        "type": "path",
+        "source": "systemd",
+        "value": "/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom",
+        "contexts": [
+          "tuya-token-selfheal"
+        ]
+      },
+      "MAX_HEALS_24H": {
+        "name": "MAX_HEALS_24H",
         "type": "integer",
         "source": "systemd",
-        "value": "60",
+        "value": "24",
         "contexts": [
-          "job-monitor"
+          "tuya-token-selfheal"
         ]
       },
-      "COMPATIBILITY_THRESHOLD": {
-        "name": "COMPATIBILITY_THRESHOLD",
-        "type": "float",
-        "source": "systemd",
-        "value": "20.0",
-        "contexts": [
-          "job-monitor"
-        ]
-      },
-      "MAX_CHATS_PER_RUN": {
-        "name": "MAX_CHATS_PER_RUN",
+      "HA_BOOT_WAIT_S": {
+        "name": "HA_BOOT_WAIT_S",
         "type": "integer",
         "source": "systemd",
         "value": "300",
         "contexts": [
-          "job-monitor"
+          "tuya-token-selfheal"
         ]
       },
-      "MESSAGES_PER_CHAT": {
-        "name": "MESSAGES_PER_CHAT",
+      "TUYA_SELFHEAL_HOT_WAIT_S": {
+        "name": "TUYA_SELFHEAL_HOT_WAIT_S",
         "type": "integer",
         "source": "systemd",
-        "value": "60",
+        "value": "90",
         "contexts": [
-          "job-monitor"
+          "tuya-token-selfheal"
         ]
       },
-      "ROUTE_NAME": {
-        "name": "ROUTE_NAME",
+      "HEAL_SOFT_THRESHOLD_MIN": {
+        "name": "HEAL_SOFT_THRESHOLD_MIN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "45",
+        "contexts": [
+          "tuya-token-selfheal"
+        ]
+      },
+      "TUYA_CLIENT_ID": {
+        "name": "TUYA_CLIENT_ID",
         "type": "string",
         "source": "systemd",
-        "value": "tape_sg1",
+        "value": "HA_3y9q4ak7g4ephrvke",
         "contexts": [
-          "homelab-tape-log-drain-nextcloud",
-          "homelab-tape-log-drain-sg1"
+          "tuya-token-selfheal"
         ]
       },
-      "ROUTE_TARGET_ROOT": {
-        "name": "ROUTE_TARGET_ROOT",
+      "TUYA_SHARING_SITE": {
+        "name": "TUYA_SHARING_SITE",
         "type": "path",
         "source": "systemd",
-        "value": "/mnt/tape_sg1/logs",
+        "value": "/home/homelab/myClaude/.venv/lib/python3.12/site-packages",
         "contexts": [
-          "homelab-tape-log-drain-nextcloud",
-          "homelab-tape-log-drain-sg1"
-        ]
-      },
-      "FAIL_THRESHOLD": {
-        "name": "FAIL_THRESHOLD",
-        "type": "integer",
-        "source": "systemd",
-        "value": "3",
-        "contexts": [
-          "grafana-selfheal"
-        ]
-      },
-      "MAX_RESTARTS_HOUR": {
-        "name": "MAX_RESTARTS_HOUR",
-        "type": "integer",
-        "source": "systemd",
-        "value": "3",
-        "contexts": [
-          "grafana-selfheal",
-          "dhcp-selfheal"
-        ]
-      },
-      "TEXTFILE_DIR": {
-        "name": "TEXTFILE_DIR",
-        "type": "path",
-        "source": "systemd",
-        "value": "/var/lib/prometheus/node-exporter",
-        "contexts": [
-          "grafana-selfheal"
-        ]
-      },
-      "OLLAMA_PORT": {
-        "name": "OLLAMA_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "11434",
-        "contexts": [
-          "github-agent"
-        ]
-      },
-      "EXTENDED_METRICS_PORT": {
-        "name": "EXTENDED_METRICS_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "9106",
-        "contexts": [
-          "eddie_central_extended_metrics"
-        ]
-      },
-      "WHATSAPP_NUMBER": {
-        "name": "WHATSAPP_NUMBER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "WAHA_URL": {
-        "name": "WAHA_URL",
-        "type": "url",
-        "source": "systemd",
-        "value": "http://localhost:3004",
-        "contexts": [
-          "eddie-expurgo",
-          "eddie-whatsapp-bot"
-        ]
-      },
-      "ADMIN_NUMBERS": {
-        "name": "ADMIN_NUMBERS",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "GMAIL_DATA_DIR": {
-        "name": "GMAIL_DATA_DIR",
-        "type": "path",
-        "source": "systemd",
-        "value": "/home/homelab/myClaude/gmail_data",
-        "contexts": [
-          "eddie-expurgo"
-        ]
-      },
-      "ADMIN_CHAT_ID": {
-        "name": "ADMIN_CHAT_ID",
-        "type": "integer",
-        "source": "systemd",
-        "value": "948686300",
-        "contexts": [
-          "eddie-calendar",
-          "eddie-expurgo"
-        ]
-      },
-      "ADMIN_PHONE": {
-        "name": "ADMIN_PHONE",
-        "type": "integer",
-        "source": "systemd",
-        "value": "5511999999999",
-        "contexts": [
-          "eddie-expurgo"
+          "tuya-token-selfheal"
         ]
       },
       "WAHA_API": {
@@ -2447,134 +2743,6 @@
         "value": "7",
         "contexts": [
           "eddie-calendar"
-        ]
-      },
-      "DHCP_SERVICE": {
-        "name": "DHCP_SERVICE",
-        "type": "string",
-        "source": "systemd",
-        "value": "homelab-lan-dhcp.service",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "FIX_NFTABLES": {
-        "name": "FIX_NFTABLES",
-        "type": "path",
-        "source": "systemd",
-        "value": "/usr/local/bin/fix-dhcp-nftables.sh",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "DHCP_RANGE_START": {
-        "name": "DHCP_RANGE_START",
-        "type": "string",
-        "source": "systemd",
-        "value": "192.168.15.60",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "DHCP_RANGE_END": {
-        "name": "DHCP_RANGE_END",
-        "type": "string",
-        "source": "systemd",
-        "value": "192.168.15.200",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "MAX_STUCK_SECONDS": {
-        "name": "MAX_STUCK_SECONDS",
-        "type": "integer",
-        "source": "systemd",
-        "value": "300",
-        "contexts": [
-          "dhcp-selfheal"
-        ]
-      },
-      "DAILY_AGENDA_PANEL_HOST": {
-        "name": "DAILY_AGENDA_PANEL_HOST",
-        "type": "string",
-        "source": "systemd",
-        "value": "0.0.0.0",
-        "contexts": [
-          "daily-agenda-panel"
-        ]
-      },
-      "DAILY_AGENDA_PANEL_PORT": {
-        "name": "DAILY_AGENDA_PANEL_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "8093",
-        "contexts": [
-          "daily-agenda-panel"
-        ]
-      },
-      "AGENDA_YOUTUBE_CHANNEL_ID": {
-        "name": "AGENDA_YOUTUBE_CHANNEL_ID",
-        "type": "string",
-        "source": "systemd",
-        "value": "UCEyYr2YE1HLDTKT4cnMefmw",
-        "contexts": [
-          "daily-agenda-panel",
-          "daily-agenda-broadcast"
-        ]
-      },
-      "CLEAR_CONFIG_FILE": {
-        "name": "CLEAR_CONFIG_FILE",
-        "type": "string",
-        "source": "systemd",
-        "value": "config_PETR4.json",
-        "contexts": [
-          "clear-trading-agent",
-          "clear-agent@"
-        ]
-      },
-      "BN_ACERVO_DEBUG_LOG_PATH": {
-        "name": "BN_ACERVO_DEBUG_LOG_PATH",
-        "type": "path",
-        "source": "systemd",
-        "value": "/tmp/bn-acervo-dev-8513.log",
-        "contexts": [
-          "bn-acervo-agent"
-        ]
-      },
-      "BN_ACERVO_HTTP_TRUST_ENV": {
-        "name": "BN_ACERVO_HTTP_TRUST_ENV",
-        "type": "boolean",
-        "source": "systemd",
-        "value": "false",
-        "contexts": [
-          "bn-acervo-agent"
-        ]
-      },
-      "BANKING_EXPORTER_PORT": {
-        "name": "BANKING_EXPORTER_PORT",
-        "type": "integer",
-        "source": "systemd",
-        "value": "9102",
-        "contexts": [
-          "banking-metrics-exporter"
-        ]
-      },
-      "TG_LONG_POLL": {
-        "name": "TG_LONG_POLL",
-        "type": "integer",
-        "source": "systemd",
-        "value": "30",
-        "contexts": [
-          "approval-gateway"
-        ]
-      },
-      "INTENT_EXP_MIN": {
-        "name": "INTENT_EXP_MIN",
-        "type": "integer",
-        "source": "systemd",
-        "value": "10",
-        "contexts": [
-          "approval-gateway"
         ]
       },
       "HF_INFERENCE_ENABLED": {
@@ -2640,70 +2808,6 @@
           "config"
         ]
       },
-      "NEXTCLOUD_AGENT_ENABLED": {
-        "name": "NEXTCLOUD_AGENT_ENABLED",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_URL": {
-        "name": "NEXTCLOUD_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "configure_authentik_nextcloud_oidc",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_USER": {
-        "name": "NEXTCLOUD_ADMIN_USER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_CONTAINER": {
-        "name": "NEXTCLOUD_CONTAINER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_GPU": {
-        "name": "NEXTCLOUD_OLLAMA_GPU",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_TIMEOUT": {
-        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_DEFAULT_DRY_RUN": {
-        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
       "REMOTE_ORCHESTRATOR_ENABLED": {
         "name": "REMOTE_ORCHESTRATOR_ENABLED",
         "type": "string",
@@ -2759,6 +2863,24 @@
           "config"
         ]
       },
+      "DEV_AGENT_PROJECTS_DIR": {
+        "name": "DEV_AGENT_PROJECTS_DIR",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "DEV_AGENT_TRAINING_DIR": {
+        "name": "DEV_AGENT_TRAINING_DIR",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
       "ROUTER_URL": {
         "name": "ROUTER_URL",
         "type": "string",
@@ -2784,33 +2906,6 @@
         "value": null,
         "contexts": [
           "router_network_config"
-        ]
-      },
-      "DEV_AGENT_PROJECTS_DIR": {
-        "name": "DEV_AGENT_PROJECTS_DIR",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "DEV_AGENT_TRAINING_DIR": {
-        "name": "DEV_AGENT_TRAINING_DIR",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "OPENWEBUI_URL": {
-        "name": "OPENWEBUI_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "configure_diretor_model"
         ]
       },
       "PANDAPLUS_DEVICE_ID": {
@@ -2867,16 +2962,25 @@
           "configure_authentik_nas_ldap"
         ]
       },
+      "OPENWEBUI_URL": {
+        "name": "OPENWEBUI_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "configure_diretor_model"
+        ]
+      },
       "GROUPS_0_NAME": {
         "name": "GROUPS_0_NAME",
         "type": "string",
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2886,10 +2990,10 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2899,10 +3003,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -2911,10 +3015,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2924,10 +3028,10 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2946,10 +3050,10 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2959,10 +3063,10 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -2990,10 +3094,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -3002,10 +3106,10 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3015,10 +3119,10 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3037,10 +3141,10 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3050,10 +3154,10 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3081,10 +3185,10 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -3093,10 +3197,10 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3106,10 +3210,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3128,10 +3232,10 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3141,10 +3245,10 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
           "rules",
           "alert_rules",
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -3163,10 +3267,10 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -3175,10 +3279,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -3187,10 +3291,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -3208,10 +3312,10 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -3220,10 +3324,10 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -3241,9 +3345,9 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_FOR": {
@@ -3252,9 +3356,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -3263,9 +3367,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -3283,9 +3387,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -3294,9 +3398,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -3314,8 +3418,8 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_FOR": {
@@ -3324,9 +3428,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -3335,9 +3439,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -3355,9 +3459,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -3366,9 +3470,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
+          "ltfs-selfheal-rules",
           "rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -3386,8 +3490,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "GLOBAL_EVALUATION_INTERVAL": {
@@ -3396,8 +3500,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_0_JOB_NAME": {
@@ -3406,8 +3510,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_1_JOB_NAME": {
@@ -3416,8 +3520,8 @@
         "source": "yaml",
         "value": "node-exporter",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_1_STATIC_CONFIGS_0_LABELS_INSTANCE": {
@@ -3435,8 +3539,8 @@
         "source": "yaml",
         "value": "cadvisor",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_2_SCRAPE_INTERVAL": {
@@ -3463,8 +3567,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_conservative",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_INTERVAL": {
@@ -3473,8 +3577,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_TIMEOUT": {
@@ -3492,8 +3596,8 @@
         "source": "yaml",
         "value": "btc_usdt_conservative",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -3520,8 +3624,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_aggressive",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_INTERVAL": {
@@ -3530,8 +3634,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_TIMEOUT": {
@@ -3549,8 +3653,8 @@
         "source": "yaml",
         "value": "btc_usdt_aggressive",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -4322,7 +4426,7 @@
         "name": "SCRAPE_CONFIGS_20_JOB_NAME",
         "type": "string",
         "source": "yaml",
-        "value": "ollama-nas-rtx2060",
+        "value": "crypto-exporter-usdt_brl_conservative",
         "contexts": [
           "prometheus"
         ]
@@ -4331,43 +4435,43 @@
         "name": "SCRAPE_CONFIGS_20_SCRAPE_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "15s",
+        "value": "30s",
         "contexts": [
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU",
+      "SCRAPE_CONFIGS_20_SCRAPE_TIMEOUT": {
+        "name": "SCRAPE_CONFIGS_20_SCRAPE_TIMEOUT",
         "type": "string",
         "source": "yaml",
-        "value": "rtx2060super",
+        "value": "25s",
         "contexts": [
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM",
+      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_INSTANCE": {
+        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_INSTANCE",
         "type": "string",
         "source": "yaml",
-        "value": "8gb",
+        "value": "usdt_brl_conservative",
         "contexts": [
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST",
+      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_PROFILE": {
+        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_PROFILE",
         "type": "string",
         "source": "yaml",
-        "value": "nas",
+        "value": "conservative",
         "contexts": [
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT",
+      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_SERVIDOR": {
+        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_SERVIDOR",
         "type": "string",
         "source": "yaml",
-        "value": "nas",
+        "value": "homelab",
         "contexts": [
           "prometheus"
         ]
@@ -4376,7 +4480,7 @@
         "name": "SCRAPE_CONFIGS_21_JOB_NAME",
         "type": "string",
         "source": "yaml",
-        "value": "ollama-gpu-coordinator",
+        "value": "crypto-exporter-usdt_brl_aggressive",
         "contexts": [
           "prometheus"
         ]
@@ -4385,13 +4489,121 @@
         "name": "SCRAPE_CONFIGS_21_SCRAPE_INTERVAL",
         "type": "string",
         "source": "yaml",
+        "value": "30s",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_21_SCRAPE_TIMEOUT": {
+        "name": "SCRAPE_CONFIGS_21_SCRAPE_TIMEOUT",
+        "type": "string",
+        "source": "yaml",
+        "value": "25s",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_INSTANCE": {
+        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_INSTANCE",
+        "type": "string",
+        "source": "yaml",
+        "value": "usdt_brl_aggressive",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_PROFILE": {
+        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_PROFILE",
+        "type": "string",
+        "source": "yaml",
+        "value": "aggressive",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVIDOR": {
+        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVIDOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "homelab",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_JOB_NAME": {
+        "name": "SCRAPE_CONFIGS_22_JOB_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "ollama-nas-rtx2060",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_SCRAPE_INTERVAL": {
+        "name": "SCRAPE_CONFIGS_22_SCRAPE_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "15s",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_GPU": {
+        "name": "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_GPU",
+        "type": "string",
+        "source": "yaml",
+        "value": "rtx2060super",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_VRAM": {
+        "name": "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_VRAM",
+        "type": "string",
+        "source": "yaml",
+        "value": "8gb",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_HOST": {
+        "name": "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_HOST",
+        "type": "string",
+        "source": "yaml",
+        "value": "nas",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_ENDPOINT": {
+        "name": "SCRAPE_CONFIGS_22_STATIC_CONFIGS_0_LABELS_ENDPOINT",
+        "type": "string",
+        "source": "yaml",
+        "value": "nas",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_23_JOB_NAME": {
+        "name": "SCRAPE_CONFIGS_23_JOB_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "ollama-gpu-coordinator",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_23_SCRAPE_INTERVAL": {
+        "name": "SCRAPE_CONFIGS_23_SCRAPE_INTERVAL",
+        "type": "string",
+        "source": "yaml",
         "value": "10s",
         "contexts": [
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE",
+      "SCRAPE_CONFIGS_23_STATIC_CONFIGS_0_LABELS_SERVICE": {
+        "name": "SCRAPE_CONFIGS_23_STATIC_CONFIGS_0_LABELS_SERVICE",
         "type": "string",
         "source": "yaml",
         "value": "gpu-coordinator",
@@ -4399,8 +4611,8 @@
           "prometheus"
         ]
       },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST",
+      "SCRAPE_CONFIGS_23_STATIC_CONFIGS_0_LABELS_HOST": {
+        "name": "SCRAPE_CONFIGS_23_STATIC_CONFIGS_0_LABELS_HOST",
         "type": "string",
         "source": "yaml",
         "value": "homelab",
@@ -4414,9 +4626,9 @@
         "source": "yaml",
         "value": "trading_agent_alerts",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -4425,9 +4637,9 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -4436,8 +4648,8 @@
         "source": "yaml",
         "value": "trading_agent_up == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_FOR": {
@@ -4446,9 +4658,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -4457,9 +4669,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -4477,9 +4689,9 @@
         "source": "yaml",
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -4488,9 +4700,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -4508,8 +4720,8 @@
         "source": "yaml",
         "value": "trading_agent_stalled == 1",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_FOR": {
@@ -4518,9 +4730,9 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -4529,9 +4741,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -4549,9 +4761,9 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -4560,9 +4772,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -4580,8 +4792,8 @@
         "source": "yaml",
         "value": "trading_agent_last_decision_age_seconds > 900",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_FOR": {
@@ -4590,9 +4802,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -4601,9 +4813,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -4621,9 +4833,9 @@
         "source": "yaml",
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -4632,9 +4844,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -4643,8 +4855,8 @@
         "source": "yaml",
         "value": "trading_agent_consecutive_failures > 6",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_FOR": {
@@ -4653,8 +4865,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_SEVERITY": {
@@ -4663,8 +4875,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_COMPONENT": {
@@ -4682,8 +4894,8 @@
         "source": "yaml",
         "value": "\ud83d\udea8 Trading Agent {{ $labels.symbol }} \u2014 Self-Heal FAILED",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -4692,8 +4904,8 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} failed health checks {{ $value | humanize }} times. Auto-restart n\u00e3o conseguiu recuperar. Interven\u00e7\u00e3o manual necess\u00e1ria.",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -4720,8 +4932,8 @@
         "source": "yaml",
         "value": "up{job=\"crypto-exporters\"} == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_FOR": {
@@ -4784,8 +4996,8 @@
         "source": "yaml",
         "value": "increase(trading_selfheal_actions_total{action=\"ollama_error\"}[1h]) > 5",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_5_FOR": {
@@ -4848,8 +5060,8 @@
         "source": "yaml",
         "value": "rate(trading_agent_restart_total[1h]) > 3",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_6_FOR": {
@@ -5050,6 +5262,195 @@
           "inventory_homelab"
         ]
       },
+      "GLOBAL_RESOLVE_TIMEOUT": {
+        "name": "GLOBAL_RESOLVE_TIMEOUT",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_RECEIVER": {
+        "name": "ROUTE_RECEIVER",
+        "type": "string",
+        "source": "yaml",
+        "value": "default",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_GROUP_WAIT": {
+        "name": "ROUTE_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "30s",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_GROUP_INTERVAL": {
+        "name": "ROUTE_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_REPEAT_INTERVAL": {
+        "name": "ROUTE_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "3h",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_0_RECEIVER": {
+        "name": "ROUTE_ROUTES_0_RECEIVER",
+        "type": "string",
+        "source": "yaml",
+        "value": "telegram-selfhealing",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_0_GROUP_WAIT": {
+        "name": "ROUTE_ROUTES_0_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "10s",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_0_GROUP_INTERVAL": {
+        "name": "ROUTE_ROUTES_0_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_0_REPEAT_INTERVAL": {
+        "name": "ROUTE_ROUTES_0_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "1h",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_0_CONTINUE": {
+        "name": "ROUTE_ROUTES_0_CONTINUE",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_1_RECEIVER": {
+        "name": "ROUTE_ROUTES_1_RECEIVER",
+        "type": "string",
+        "source": "yaml",
+        "value": "telegram-selfhealing",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_1_GROUP_WAIT": {
+        "name": "ROUTE_ROUTES_1_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "15s",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_1_GROUP_INTERVAL": {
+        "name": "ROUTE_ROUTES_1_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_1_REPEAT_INTERVAL": {
+        "name": "ROUTE_ROUTES_1_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "1h",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_2_RECEIVER": {
+        "name": "ROUTE_ROUTES_2_RECEIVER",
+        "type": "string",
+        "source": "yaml",
+        "value": "telegram-critical",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_2_GROUP_WAIT": {
+        "name": "ROUTE_ROUTES_2_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "10s",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_2_GROUP_INTERVAL": {
+        "name": "ROUTE_ROUTES_2_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "ROUTE_ROUTES_2_REPEAT_INTERVAL": {
+        "name": "ROUTE_ROUTES_2_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "30m",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_0_NAME": {
+        "name": "RECEIVERS_0_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "default",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_NAME": {
+        "name": "RECEIVERS_1_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "telegram-selfhealing",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_NAME": {
+        "name": "RECEIVERS_2_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "telegram-critical",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
       "GROUPS_0_RULES_0_LABELS_ACTION": {
         "name": "GROUPS_0_RULES_0_LABELS_ACTION",
         "type": "string",
@@ -5200,8 +5601,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -5210,8 +5611,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -5220,8 +5621,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -5230,8 +5631,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -5240,8 +5641,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -5250,8 +5651,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -5269,8 +5670,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -5279,8 +5680,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -5289,8 +5690,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -5299,8 +5700,8 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -5309,8 +5710,8 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "APIVERSION": {
@@ -5319,379 +5720,282 @@
         "source": "yaml",
         "value": "1",
         "contexts": [
+          "authentik-http",
           "datasources",
-          "policies",
-          "contactpoints",
-          "rules",
           "dashboards",
-          "authentik-http"
+          "rules",
+          "policies",
+          "contactpoints"
         ]
       },
-      "DELETEDATASOURCES_0_NAME": {
-        "name": "DELETEDATASOURCES_0_NAME",
-        "type": "string",
-        "source": "yaml",
-        "value": "Authentik HTTP",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DELETEDATASOURCES_0_ORGID": {
-        "name": "DELETEDATASOURCES_0_ORGID",
+      "POLICIES_0_ORGID": {
+        "name": "POLICIES_0_ORGID",
         "type": "boolean",
         "source": "yaml",
         "value": "1",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_NAME": {
-        "name": "DATASOURCES_0_NAME",
+      "POLICIES_0_RECEIVER": {
+        "name": "POLICIES_0_RECEIVER",
         "type": "string",
         "source": "yaml",
-        "value": "Prometheus",
+        "value": "eddie-telegram",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_UID": {
-        "name": "DATASOURCES_0_UID",
+      "POLICIES_0_GROUP_WAIT": {
+        "name": "POLICIES_0_GROUP_WAIT",
         "type": "string",
         "source": "yaml",
-        "value": "dfc0w4yioe4u8e",
+        "value": "30s",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_TYPE": {
-        "name": "DATASOURCES_0_TYPE",
+      "POLICIES_0_GROUP_INTERVAL": {
+        "name": "POLICIES_0_GROUP_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "prometheus",
+        "value": "5m",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_ACCESS": {
-        "name": "DATASOURCES_0_ACCESS",
+      "POLICIES_0_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_REPEAT_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "proxy",
+        "value": "4h",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_ORGID": {
-        "name": "DATASOURCES_0_ORGID",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "1",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_0_URL": {
-        "name": "DATASOURCES_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "http://prometheus:9090",
-        "contexts": [
-          "authentik-http",
-          "datasources"
-        ]
-      },
-      "DATASOURCES_0_ISDEFAULT": {
-        "name": "DATASOURCES_0_ISDEFAULT",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "True",
-        "contexts": [
-          "authentik-http",
-          "datasources"
-        ]
-      },
-      "DATASOURCES_0_JSONDATA_TIMEINTERVAL": {
-        "name": "DATASOURCES_0_JSONDATA_TIMEINTERVAL",
+      "POLICIES_0_ROUTES_0_RECEIVER": {
+        "name": "POLICIES_0_ROUTES_0_RECEIVER",
         "type": "string",
         "source": "yaml",
-        "value": "15s",
+        "value": "eddie-ltfs-webhook",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_0_READONLY": {
-        "name": "DATASOURCES_0_READONLY",
+      "POLICIES_0_ROUTES_0_GROUP_WAIT": {
+        "name": "POLICIES_0_ROUTES_0_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "10s",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_0_GROUP_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_0_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "2m",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_0_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_0_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "30m",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_0_CONTINUE": {
+        "name": "POLICIES_0_ROUTES_0_CONTINUE",
         "type": "boolean",
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_NAME": {
-        "name": "DATASOURCES_1_NAME",
+      "POLICIES_0_ROUTES_1_RECEIVER": {
+        "name": "POLICIES_0_ROUTES_1_RECEIVER",
         "type": "string",
         "source": "yaml",
-        "value": "Eddie Bus PostgreSQL",
+        "value": "eddie-telegram",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_UID": {
-        "name": "DATASOURCES_1_UID",
+      "POLICIES_0_ROUTES_1_GROUP_WAIT": {
+        "name": "POLICIES_0_ROUTES_1_GROUP_WAIT",
         "type": "string",
         "source": "yaml",
-        "value": "cfbzi6b6m5gcgb",
+        "value": "10s",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_TYPE": {
-        "name": "DATASOURCES_1_TYPE",
+      "POLICIES_0_ROUTES_1_GROUP_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_1_GROUP_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "grafana-postgresql-datasource",
+        "value": "2m",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_ACCESS": {
-        "name": "DATASOURCES_1_ACCESS",
+      "POLICIES_0_ROUTES_1_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_1_REPEAT_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "proxy",
+        "value": "30m",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_ORGID": {
-        "name": "DATASOURCES_1_ORGID",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "1",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_1_URL": {
-        "name": "DATASOURCES_1_URL",
-        "type": "string",
-        "source": "yaml",
-        "value": "172.17.0.1:5433",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_1_USER": {
-        "name": "DATASOURCES_1_USER",
-        "type": "string",
-        "source": "yaml",
-        "value": "postgres",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_1_JSONDATA_SSLMODE": {
-        "name": "DATASOURCES_1_JSONDATA_SSLMODE",
-        "type": "string",
-        "source": "yaml",
-        "value": "disable",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_1_JSONDATA_TIMESCALEDB": {
-        "name": "DATASOURCES_1_JSONDATA_TIMESCALEDB",
+      "POLICIES_0_ROUTES_1_CONTINUE": {
+        "name": "POLICIES_0_ROUTES_1_CONTINUE",
         "type": "boolean",
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_1_READONLY": {
-        "name": "DATASOURCES_1_READONLY",
+      "POLICIES_0_ROUTES_2_RECEIVER": {
+        "name": "POLICIES_0_ROUTES_2_RECEIVER",
+        "type": "string",
+        "source": "yaml",
+        "value": "eddie-telegram",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_2_GROUP_WAIT": {
+        "name": "POLICIES_0_ROUTES_2_GROUP_WAIT",
+        "type": "string",
+        "source": "yaml",
+        "value": "30s",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_2_GROUP_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_2_GROUP_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_2_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_2_REPEAT_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "1h",
+        "contexts": [
+          "policies"
+        ]
+      },
+      "POLICIES_0_ROUTES_2_CONTINUE": {
+        "name": "POLICIES_0_ROUTES_2_CONTINUE",
         "type": "boolean",
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_NAME": {
-        "name": "DATASOURCES_2_NAME",
+      "POLICIES_0_ROUTES_3_RECEIVER": {
+        "name": "POLICIES_0_ROUTES_3_RECEIVER",
         "type": "string",
         "source": "yaml",
-        "value": "BTC Trading PostgreSQL",
+        "value": "eddie-telegram",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_UID": {
-        "name": "DATASOURCES_2_UID",
+      "POLICIES_0_ROUTES_3_GROUP_WAIT": {
+        "name": "POLICIES_0_ROUTES_3_GROUP_WAIT",
         "type": "string",
         "source": "yaml",
-        "value": "btc-trading-pg",
+        "value": "30s",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_TYPE": {
-        "name": "DATASOURCES_2_TYPE",
+      "POLICIES_0_ROUTES_3_GROUP_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_3_GROUP_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "grafana-postgresql-datasource",
+        "value": "5m",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_ACCESS": {
-        "name": "DATASOURCES_2_ACCESS",
+      "POLICIES_0_ROUTES_3_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_3_REPEAT_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "proxy",
+        "value": "4h",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_ORGID": {
-        "name": "DATASOURCES_2_ORGID",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "1",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_2_URL": {
-        "name": "DATASOURCES_2_URL",
-        "type": "string",
-        "source": "yaml",
-        "value": "172.17.0.1:5433",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_2_USER": {
-        "name": "DATASOURCES_2_USER",
-        "type": "string",
-        "source": "yaml",
-        "value": "postgres",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_2_JSONDATA_SSLMODE": {
-        "name": "DATASOURCES_2_JSONDATA_SSLMODE",
-        "type": "string",
-        "source": "yaml",
-        "value": "disable",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "DATASOURCES_2_JSONDATA_TIMESCALEDB": {
-        "name": "DATASOURCES_2_JSONDATA_TIMESCALEDB",
+      "POLICIES_0_ROUTES_3_CONTINUE": {
+        "name": "POLICIES_0_ROUTES_3_CONTINUE",
         "type": "boolean",
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "datasources"
+          "policies"
         ]
       },
-      "DATASOURCES_2_READONLY": {
-        "name": "DATASOURCES_2_READONLY",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "True",
-        "contexts": [
-          "datasources"
-        ]
-      },
-      "PROVIDERS_0_NAME": {
-        "name": "PROVIDERS_0_NAME",
+      "POLICIES_0_ROUTES_4_RECEIVER": {
+        "name": "POLICIES_0_ROUTES_4_RECEIVER",
         "type": "string",
         "source": "yaml",
-        "value": "eddie-dashboards",
+        "value": "eddie-telegram",
         "contexts": [
-          "dashboards"
+          "policies"
         ]
       },
-      "PROVIDERS_0_ORGID": {
-        "name": "PROVIDERS_0_ORGID",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "1",
-        "contexts": [
-          "dashboards"
-        ]
-      },
-      "PROVIDERS_0_FOLDER": {
-        "name": "PROVIDERS_0_FOLDER",
+      "POLICIES_0_ROUTES_4_GROUP_WAIT": {
+        "name": "POLICIES_0_ROUTES_4_GROUP_WAIT",
         "type": "string",
         "source": "yaml",
-        "value": "Eddie Auto-Dev",
+        "value": "30s",
         "contexts": [
-          "dashboards"
+          "policies"
         ]
       },
-      "PROVIDERS_0_TYPE": {
-        "name": "PROVIDERS_0_TYPE",
+      "POLICIES_0_ROUTES_4_GROUP_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_4_GROUP_INTERVAL",
         "type": "string",
         "source": "yaml",
-        "value": "file",
+        "value": "5m",
         "contexts": [
-          "dashboards"
+          "policies"
         ]
       },
-      "PROVIDERS_0_DISABLEDELETION": {
-        "name": "PROVIDERS_0_DISABLEDELETION",
-        "type": "boolean",
+      "POLICIES_0_ROUTES_4_REPEAT_INTERVAL": {
+        "name": "POLICIES_0_ROUTES_4_REPEAT_INTERVAL",
+        "type": "string",
         "source": "yaml",
-        "value": "True",
+        "value": "2h",
         "contexts": [
-          "dashboards"
+          "policies"
         ]
       },
-      "PROVIDERS_0_EDITABLE": {
-        "name": "PROVIDERS_0_EDITABLE",
+      "POLICIES_0_ROUTES_4_CONTINUE": {
+        "name": "POLICIES_0_ROUTES_4_CONTINUE",
         "type": "boolean",
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "dashboards"
-        ]
-      },
-      "PROVIDERS_0_ALLOWUIUPDATES": {
-        "name": "PROVIDERS_0_ALLOWUIUPDATES",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "dashboards"
-        ]
-      },
-      "PROVIDERS_0_UPDATEINTERVALSECONDS": {
-        "name": "PROVIDERS_0_UPDATEINTERVALSECONDS",
-        "type": "integer",
-        "source": "yaml",
-        "value": "30",
-        "contexts": [
-          "dashboards"
-        ]
-      },
-      "PROVIDERS_0_OPTIONS_PATH": {
-        "name": "PROVIDERS_0_OPTIONS_PATH",
-        "type": "path",
-        "source": "yaml",
-        "value": "/etc/grafana/provisioning/dashboards",
-        "contexts": [
-          "dashboards"
+          "policies"
         ]
       },
       "GROUPS_0_ORGID": {
@@ -14361,276 +14665,6 @@
           "rules"
         ]
       },
-      "POLICIES_0_ORGID": {
-        "name": "POLICIES_0_ORGID",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "1",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_RECEIVER": {
-        "name": "POLICIES_0_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-telegram",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_GROUP_WAIT": {
-        "name": "POLICIES_0_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "30s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_GROUP_INTERVAL": {
-        "name": "POLICIES_0_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "4h",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_0_RECEIVER": {
-        "name": "POLICIES_0_ROUTES_0_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-ltfs-webhook",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_0_GROUP_WAIT": {
-        "name": "POLICIES_0_ROUTES_0_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "10s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_0_GROUP_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_0_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "2m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_0_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_0_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "30m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_0_CONTINUE": {
-        "name": "POLICIES_0_ROUTES_0_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_1_RECEIVER": {
-        "name": "POLICIES_0_ROUTES_1_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-telegram",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_1_GROUP_WAIT": {
-        "name": "POLICIES_0_ROUTES_1_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "10s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_1_GROUP_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_1_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "2m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_1_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_1_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "30m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_1_CONTINUE": {
-        "name": "POLICIES_0_ROUTES_1_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_2_RECEIVER": {
-        "name": "POLICIES_0_ROUTES_2_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-telegram",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_2_GROUP_WAIT": {
-        "name": "POLICIES_0_ROUTES_2_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "30s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_2_GROUP_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_2_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_2_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_2_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "1h",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_2_CONTINUE": {
-        "name": "POLICIES_0_ROUTES_2_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_3_RECEIVER": {
-        "name": "POLICIES_0_ROUTES_3_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-telegram",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_3_GROUP_WAIT": {
-        "name": "POLICIES_0_ROUTES_3_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "30s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_3_GROUP_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_3_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_3_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_3_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "4h",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_3_CONTINUE": {
-        "name": "POLICIES_0_ROUTES_3_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_4_RECEIVER": {
-        "name": "POLICIES_0_ROUTES_4_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "eddie-telegram",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_4_GROUP_WAIT": {
-        "name": "POLICIES_0_ROUTES_4_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "30s",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_4_GROUP_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_4_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_4_REPEAT_INTERVAL": {
-        "name": "POLICIES_0_ROUTES_4_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "2h",
-        "contexts": [
-          "policies"
-        ]
-      },
-      "POLICIES_0_ROUTES_4_CONTINUE": {
-        "name": "POLICIES_0_ROUTES_4_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "False",
-        "contexts": [
-          "policies"
-        ]
-      },
       "CONTACTPOINTS_0_ORGID": {
         "name": "CONTACTPOINTS_0_ORGID",
         "type": "boolean",
@@ -14764,6 +14798,373 @@
         "value": "http://192.168.15.2:5001/alerts",
         "contexts": [
           "contactpoints"
+        ]
+      },
+      "PROVIDERS_0_NAME": {
+        "name": "PROVIDERS_0_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "eddie-dashboards",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_ORGID": {
+        "name": "PROVIDERS_0_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_FOLDER": {
+        "name": "PROVIDERS_0_FOLDER",
+        "type": "string",
+        "source": "yaml",
+        "value": "Eddie Auto-Dev",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_TYPE": {
+        "name": "PROVIDERS_0_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "file",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_DISABLEDELETION": {
+        "name": "PROVIDERS_0_DISABLEDELETION",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_EDITABLE": {
+        "name": "PROVIDERS_0_EDITABLE",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_ALLOWUIUPDATES": {
+        "name": "PROVIDERS_0_ALLOWUIUPDATES",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_UPDATEINTERVALSECONDS": {
+        "name": "PROVIDERS_0_UPDATEINTERVALSECONDS",
+        "type": "integer",
+        "source": "yaml",
+        "value": "30",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "PROVIDERS_0_OPTIONS_PATH": {
+        "name": "PROVIDERS_0_OPTIONS_PATH",
+        "type": "path",
+        "source": "yaml",
+        "value": "/etc/grafana/provisioning/dashboards",
+        "contexts": [
+          "dashboards"
+        ]
+      },
+      "DELETEDATASOURCES_0_NAME": {
+        "name": "DELETEDATASOURCES_0_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "Authentik HTTP",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DELETEDATASOURCES_0_ORGID": {
+        "name": "DELETEDATASOURCES_0_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_NAME": {
+        "name": "DATASOURCES_0_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "Prometheus",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_UID": {
+        "name": "DATASOURCES_0_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "dfc0w4yioe4u8e",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_TYPE": {
+        "name": "DATASOURCES_0_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "prometheus",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_ACCESS": {
+        "name": "DATASOURCES_0_ACCESS",
+        "type": "string",
+        "source": "yaml",
+        "value": "proxy",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_ORGID": {
+        "name": "DATASOURCES_0_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_URL": {
+        "name": "DATASOURCES_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "http://prometheus:9090",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_ISDEFAULT": {
+        "name": "DATASOURCES_0_ISDEFAULT",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_JSONDATA_TIMEINTERVAL": {
+        "name": "DATASOURCES_0_JSONDATA_TIMEINTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "15s",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_0_READONLY": {
+        "name": "DATASOURCES_0_READONLY",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "authentik-http",
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_NAME": {
+        "name": "DATASOURCES_1_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "Eddie Bus PostgreSQL",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_UID": {
+        "name": "DATASOURCES_1_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "cfbzi6b6m5gcgb",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_TYPE": {
+        "name": "DATASOURCES_1_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "grafana-postgresql-datasource",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_ACCESS": {
+        "name": "DATASOURCES_1_ACCESS",
+        "type": "string",
+        "source": "yaml",
+        "value": "proxy",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_ORGID": {
+        "name": "DATASOURCES_1_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_URL": {
+        "name": "DATASOURCES_1_URL",
+        "type": "string",
+        "source": "yaml",
+        "value": "172.17.0.1:5433",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_USER": {
+        "name": "DATASOURCES_1_USER",
+        "type": "string",
+        "source": "yaml",
+        "value": "postgres",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_JSONDATA_SSLMODE": {
+        "name": "DATASOURCES_1_JSONDATA_SSLMODE",
+        "type": "string",
+        "source": "yaml",
+        "value": "disable",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_JSONDATA_TIMESCALEDB": {
+        "name": "DATASOURCES_1_JSONDATA_TIMESCALEDB",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_1_READONLY": {
+        "name": "DATASOURCES_1_READONLY",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_NAME": {
+        "name": "DATASOURCES_2_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "BTC Trading PostgreSQL",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_UID": {
+        "name": "DATASOURCES_2_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "btc-trading-pg",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_TYPE": {
+        "name": "DATASOURCES_2_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "grafana-postgresql-datasource",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_ACCESS": {
+        "name": "DATASOURCES_2_ACCESS",
+        "type": "string",
+        "source": "yaml",
+        "value": "proxy",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_ORGID": {
+        "name": "DATASOURCES_2_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_URL": {
+        "name": "DATASOURCES_2_URL",
+        "type": "string",
+        "source": "yaml",
+        "value": "172.17.0.1:5433",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_USER": {
+        "name": "DATASOURCES_2_USER",
+        "type": "string",
+        "source": "yaml",
+        "value": "postgres",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_JSONDATA_SSLMODE": {
+        "name": "DATASOURCES_2_JSONDATA_SSLMODE",
+        "type": "string",
+        "source": "yaml",
+        "value": "disable",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_JSONDATA_TIMESCALEDB": {
+        "name": "DATASOURCES_2_JSONDATA_TIMESCALEDB",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "datasources"
+        ]
+      },
+      "DATASOURCES_2_READONLY": {
+        "name": "DATASOURCES_2_READONLY",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "datasources"
         ]
       },
       "TUNNEL": {
@@ -15009,203 +15410,14 @@
           "cloudflared-rpa4all-ide"
         ]
       },
-      "GLOBAL_RESOLVE_TIMEOUT": {
-        "name": "GLOBAL_RESOLVE_TIMEOUT",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_RECEIVER": {
-        "name": "ROUTE_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "default",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_GROUP_WAIT": {
-        "name": "ROUTE_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "30s",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_GROUP_INTERVAL": {
-        "name": "ROUTE_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_REPEAT_INTERVAL": {
-        "name": "ROUTE_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "3h",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_0_RECEIVER": {
-        "name": "ROUTE_ROUTES_0_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "telegram-selfhealing",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_0_GROUP_WAIT": {
-        "name": "ROUTE_ROUTES_0_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "10s",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_0_GROUP_INTERVAL": {
-        "name": "ROUTE_ROUTES_0_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_0_REPEAT_INTERVAL": {
-        "name": "ROUTE_ROUTES_0_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "1h",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_0_CONTINUE": {
-        "name": "ROUTE_ROUTES_0_CONTINUE",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "True",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_1_RECEIVER": {
-        "name": "ROUTE_ROUTES_1_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "telegram-selfhealing",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_1_GROUP_WAIT": {
-        "name": "ROUTE_ROUTES_1_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "15s",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_1_GROUP_INTERVAL": {
-        "name": "ROUTE_ROUTES_1_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_1_REPEAT_INTERVAL": {
-        "name": "ROUTE_ROUTES_1_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "1h",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_2_RECEIVER": {
-        "name": "ROUTE_ROUTES_2_RECEIVER",
-        "type": "string",
-        "source": "yaml",
-        "value": "telegram-critical",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_2_GROUP_WAIT": {
-        "name": "ROUTE_ROUTES_2_GROUP_WAIT",
-        "type": "string",
-        "source": "yaml",
-        "value": "10s",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_2_GROUP_INTERVAL": {
-        "name": "ROUTE_ROUTES_2_GROUP_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "5m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "ROUTE_ROUTES_2_REPEAT_INTERVAL": {
-        "name": "ROUTE_ROUTES_2_REPEAT_INTERVAL",
-        "type": "string",
-        "source": "yaml",
-        "value": "30m",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_0_NAME": {
-        "name": "RECEIVERS_0_NAME",
-        "type": "string",
-        "source": "yaml",
-        "value": "default",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_NAME": {
-        "name": "RECEIVERS_1_NAME",
-        "type": "string",
-        "source": "yaml",
-        "value": "telegram-selfhealing",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_NAME": {
-        "name": "RECEIVERS_2_NAME",
-        "type": "string",
-        "source": "yaml",
-        "value": "telegram-critical",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
       "OPENAPI": {
         "name": "OPENAPI",
         "type": "string",
         "source": "yaml",
         "value": "3.0.3",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "INFO_TITLE": {
@@ -15214,8 +15426,8 @@
         "source": "yaml",
         "value": "Shared Auto Dev - Aggregated API",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "INFO_VERSION": {
@@ -15224,8 +15436,8 @@
         "source": "yaml",
         "value": "1.0.0",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "INFO_DESCRIPTION": {
@@ -15234,8 +15446,8 @@
         "source": "yaml",
         "value": "Aggregated OpenAPI specification generated from repository scans.\n",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "SERVERS_0_URL": {
@@ -15244,8 +15456,8 @@
         "source": "yaml",
         "value": "https://nearby-efficiency-customize-when.trycloudflare.com",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "SERVERS_0_DESCRIPTION": {
@@ -15254,8 +15466,8 @@
         "source": "yaml",
         "value": "Quick Cloudflare Tunnel (public)",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS_GET_SUMMARY": {
@@ -15264,8 +15476,8 @@
         "source": "yaml",
         "value": "List models",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS_GET_RESPONSES_200_DESCRIPTION": {
@@ -15274,8 +15486,8 @@
         "source": "yaml",
         "value": "Model list",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_SUMMARY": {
@@ -15284,8 +15496,8 @@
         "source": "yaml",
         "value": "Get model by id",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_PARAMETERS_0_NAME": {
@@ -15294,8 +15506,8 @@
         "source": "yaml",
         "value": "id",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_PARAMETERS_0_IN": {
@@ -15304,8 +15516,8 @@
         "source": "yaml",
         "value": "path",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_PARAMETERS_0_REQUIRED": {
@@ -15314,8 +15526,8 @@
         "source": "yaml",
         "value": "True",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_PARAMETERS_0_SCHEMA_TYPE": {
@@ -15324,8 +15536,8 @@
         "source": "yaml",
         "value": "string",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/MODELS/{ID}_GET_RESPONSES_200_DESCRIPTION": {
@@ -15334,8 +15546,8 @@
         "source": "yaml",
         "value": "Model",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/FUNCTIONS_GET_SUMMARY": {
@@ -15344,8 +15556,8 @@
         "source": "yaml",
         "value": "List functions",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/FUNCTIONS_GET_RESPONSES_200_DESCRIPTION": {
@@ -15354,8 +15566,8 @@
         "source": "yaml",
         "value": "OK",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/FUNCTIONS_POST_SUMMARY": {
@@ -15364,8 +15576,8 @@
         "source": "yaml",
         "value": "Create function",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/FUNCTIONS_POST_RESPONSES_201_DESCRIPTION": {
@@ -15374,8 +15586,8 @@
         "source": "yaml",
         "value": "Created",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/RAG/INDEX_POST_SUMMARY": {
@@ -15384,8 +15596,8 @@
         "source": "yaml",
         "value": "Index documents for RAG",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/RAG/INDEX_POST_RESPONSES_200_DESCRIPTION": {
@@ -15394,8 +15606,8 @@
         "source": "yaml",
         "value": "Indexed",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/TAGS_GET_SUMMARY": {
@@ -15404,8 +15616,8 @@
         "source": "yaml",
         "value": "Ollama tags / models",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/TAGS_GET_RESPONSES_200_DESCRIPTION": {
@@ -15414,8 +15626,8 @@
         "source": "yaml",
         "value": "OK",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/GENERATE_POST_SUMMARY": {
@@ -15424,8 +15636,8 @@
         "source": "yaml",
         "value": "Ollama generate text",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/GENERATE_POST_RESPONSES_200_DESCRIPTION": {
@@ -15434,8 +15646,8 @@
         "source": "yaml",
         "value": "Generated text",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "COMPONENTS_SCHEMAS_USERRESPONSE_TYPE": {
@@ -15444,8 +15656,8 @@
         "source": "yaml",
         "value": "object",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "COMPONENTS_SCHEMAS_USERRESPONSE_PROPERTIES_ID_TYPE": {
@@ -15454,8 +15666,8 @@
         "source": "yaml",
         "value": "string",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "COMPONENTS_SCHEMAS_USERRESPONSE_PROPERTIES_NAME_TYPE": {
@@ -15464,8 +15676,8 @@
         "source": "yaml",
         "value": "string",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "COMPONENTS_SCHEMAS_USERRESPONSE_PROPERTIES_EMAIL_TYPE": {
@@ -15474,8 +15686,8 @@
         "source": "yaml",
         "value": "string",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "SCHEDULER_POSTS_PER_DAY": {
@@ -15613,6 +15825,50 @@
           "settings"
         ]
       },
+      "TOPIC": {
+        "name": "TOPIC",
+        "type": "string",
+        "source": "yaml",
+        "value": "curiosidades",
+        "contexts": [
+          "cripto",
+          "curiosidades",
+          "viral_trends"
+        ]
+      },
+      "TITLE_TEMPLATE": {
+        "name": "TITLE_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Voc\u00ea sabia? {trend_title}",
+        "contexts": [
+          "cripto",
+          "curiosidades",
+          "viral_trends"
+        ]
+      },
+      "SCRIPT_TEMPLATE": {
+        "name": "SCRIPT_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Hook: Em 60 segundos voc\u00ea vai entender {trend_title}.\nFato 1: Um detalhe pouco conhecido que muda a forma de ver o assunto.\nFato 2: Por que isso viraliza agora ({tags}).\nFechamento: Curiosidade pr\u00e1tica para compartilhar hoje.\n",
+        "contexts": [
+          "cripto",
+          "curiosidades",
+          "viral_trends"
+        ]
+      },
+      "CTA_TEMPLATE": {
+        "name": "CTA_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Comenta qual curiosidade voc\u00ea quer no pr\u00f3ximo v\u00eddeo!",
+        "contexts": [
+          "cripto",
+          "curiosidades",
+          "viral_trends"
+        ]
+      },
       "NAME": {
         "name": "NAME",
         "type": "string",
@@ -15683,50 +15939,6 @@
           "homelab"
         ]
       },
-      "TOPIC": {
-        "name": "TOPIC",
-        "type": "string",
-        "source": "yaml",
-        "value": "viral_trends",
-        "contexts": [
-          "viral_trends",
-          "curiosidades",
-          "cripto"
-        ]
-      },
-      "TITLE_TEMPLATE": {
-        "name": "TITLE_TEMPLATE",
-        "type": "string",
-        "source": "yaml",
-        "value": "Trend alert: {trend_title}",
-        "contexts": [
-          "viral_trends",
-          "curiosidades",
-          "cripto"
-        ]
-      },
-      "SCRIPT_TEMPLATE": {
-        "name": "SCRIPT_TEMPLATE",
-        "type": "string",
-        "source": "yaml",
-        "value": "Hook: Essa trend est\u00e1 com score {score} agora.\nPasso 1: Use o gancho nos primeiros 2 segundos.\nPasso 2: Entregue valor r\u00e1pido sobre {trend_title}.\nPasso 3: CTA claro no final para aumentar reten\u00e7\u00e3o.\nTags: {tags}.\n",
-        "contexts": [
-          "viral_trends",
-          "curiosidades",
-          "cripto"
-        ]
-      },
-      "CTA_TEMPLATE": {
-        "name": "CTA_TEMPLATE",
-        "type": "string",
-        "source": "yaml",
-        "value": "Marca algu\u00e9m que precisa surfar essa trend hoje!",
-        "contexts": [
-          "viral_trends",
-          "curiosidades",
-          "cripto"
-        ]
-      },
       "DATASOURCES_0_JSONDATA_TLSSKIPVERIFY": {
         "name": "DATASOURCES_0_JSONDATA_TLSSKIPVERIFY",
         "type": "boolean",
@@ -15765,6 +15977,27 @@
       }
     },
     "authentication": {
+      "WIKI_TOKEN": {
+        "name": "WIKI_TOKEN",
+        "type": "string",
+        "source": ".env",
+        "value": "***REDACTED***",
+        "locations": [
+          {
+            "file": ".env",
+            "line": 5
+          },
+          {
+            "file": ".env.example.wiki",
+            "line": 4
+          },
+          {
+            "file": ".env",
+            "line": 5
+          }
+        ],
+        "contexts": []
+      },
       "OPENAI_COMPATIBLE_API_KEY": {
         "name": "OPENAI_COMPATIBLE_API_KEY",
         "type": "string",
@@ -15774,19 +16007,6 @@
           "config"
         ]
       },
-      "WIKI_TOKEN": {
-        "name": "WIKI_TOKEN",
-        "type": "string",
-        "source": ".env",
-        "value": "***REDACTED***",
-        "locations": [
-          {
-            "file": ".env.example.wiki",
-            "line": 4
-          }
-        ],
-        "contexts": []
-      },
       "OPENROUTER_API_KEY": {
         "name": "OPENROUTER_API_KEY",
         "type": "string",
@@ -15794,11 +16014,38 @@
         "value": "***REDACTED***",
         "locations": [
           {
+            "file": ".env",
+            "line": 17
+          },
+          {
             "file": ".env.example",
             "line": 1
+          },
+          {
+            "file": ".env",
+            "line": 17
           }
         ],
         "contexts": []
+      },
+      "DB_PASSWORD": {
+        "name": "DB_PASSWORD",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "NEXTCLOUD_ADMIN_PASSWORD": {
+        "name": "NEXTCLOUD_ADMIN_PASSWORD",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "config"
+        ]
       },
       "GOOGLE_AI_API_KEY": {
         "name": "GOOGLE_AI_API_KEY",
@@ -15854,11 +16101,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-backend",
+          "mailu-postfix",
           "mailu-roundcube",
           "mailu-frontend",
           "mailu-dovecot",
-          "mailu-postfix"
+          "mailu-backend"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -15925,16 +16172,6 @@
           }
         ],
         "contexts": []
-      },
-      "DB_PASSWORD": {
-        "name": "DB_PASSWORD",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
       },
       "SHARED_IPC_SECRET": {
         "name": "SHARED_IPC_SECRET",
@@ -16343,38 +16580,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
+          "netbox-postgres",
           "mailu-db",
-          "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
-        ]
-      },
-      "OIDC_CLIENT_SECRET": {
-        "name": "OIDC_CLIENT_SECRET",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_AUTH_ENDPOINT": {
-        "name": "OIDC_AUTH_ENDPOINT",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "OIDC_TOKEN_ENDPOINT": {
-        "name": "OIDC_TOKEN_ENDPOINT",
-        "type": "url",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "wikijs"
+          "postgres",
+          "wikijs-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_PASSWORD": {
@@ -16384,15 +16594,6 @@
         "value": "***REDACTED***",
         "contexts": [
           "roundcube"
-        ]
-      },
-      "OPENSEARCH_INITIAL_ADMIN_PASSWORD": {
-        "name": "OPENSEARCH_INITIAL_ADMIN_PASSWORD",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "opensearch-node1"
         ]
       },
       "GF_SECURITY_ADMIN_PASSWORD": {
@@ -16467,14 +16668,59 @@
           "grafana"
         ]
       },
+      "OPENSEARCH_INITIAL_ADMIN_PASSWORD": {
+        "name": "OPENSEARCH_INITIAL_ADMIN_PASSWORD",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "opensearch-node1"
+        ]
+      },
+      "OIDC_CLIENT_SECRET": {
+        "name": "OIDC_CLIENT_SECRET",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_AUTH_ENDPOINT": {
+        "name": "OIDC_AUTH_ENDPOINT",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "OIDC_TOKEN_ENDPOINT": {
+        "name": "OIDC_TOKEN_ENDPOINT",
+        "type": "url",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "ADMIN_TOKEN": {
+        "name": "ADMIN_TOKEN",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "vaultwarden"
+        ]
+      },
       "REDIS_CACHE_PASSWORD": {
         "name": "REDIS_CACHE_PASSWORD",
         "type": "string",
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_PASSWORD": {
@@ -16483,9 +16729,9 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
+          "netbox-worker",
           "netbox",
           "netbox-redis-cache",
-          "netbox-worker",
           "netbox-redis"
         ]
       },
@@ -16495,8 +16741,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_ENABLED": {
@@ -16505,8 +16751,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_HEADER": {
@@ -16515,8 +16761,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SEPARATOR": {
@@ -16525,8 +16771,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SYNC_ENABLED": {
@@ -16535,8 +16781,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_HEADER": {
@@ -16545,8 +16791,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_STAFF_GROUPS": {
@@ -16555,8 +16801,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_SUPERUSER_GROUPS": {
@@ -16565,8 +16811,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_USER_EMAIL": {
@@ -16575,8 +16821,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SECRET_KEY": {
@@ -16585,8 +16831,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_PASSWORD": {
@@ -16595,8 +16841,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_PASSWORD": {
@@ -16617,22 +16863,13 @@
           "glpi-db"
         ]
       },
-      "ADMIN_TOKEN": {
-        "name": "ADMIN_TOKEN",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "vaultwarden"
-        ]
-      },
-      "BRIDGE_RUNTIME_TOKENS": {
-        "name": "BRIDGE_RUNTIME_TOKENS",
+      "SECRETS_AGENT_DATA": {
+        "name": "SECRETS_AGENT_DATA",
         "type": "path",
         "source": "systemd",
         "value": "***REDACTED***",
         "contexts": [
-          "tuya-token-selfheal"
+          "clear-trading-agent"
         ]
       },
       "SECRETS_AGENT_URL": {
@@ -16644,13 +16881,13 @@
           "configure_authentik_nas_ldap"
         ]
       },
-      "SECRETS_AGENT_DATA": {
-        "name": "SECRETS_AGENT_DATA",
+      "BRIDGE_RUNTIME_TOKENS": {
+        "name": "BRIDGE_RUNTIME_TOKENS",
         "type": "path",
         "source": "systemd",
         "value": "***REDACTED***",
         "contexts": [
-          "clear-trading-agent"
+          "tuya-token-selfheal"
         ]
       },
       "HF_TOKEN": {
@@ -16664,15 +16901,6 @@
       },
       "HUGGINGFACEHUB_API_TOKEN": {
         "name": "HUGGINGFACEHUB_API_TOKEN",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_PASSWORD": {
-        "name": "NEXTCLOUD_ADMIN_PASSWORD",
         "type": "string",
         "source": "python-config",
         "value": "***REDACTED***",
@@ -16704,62 +16932,7 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nextcloud_oidc",
-          "configure_authentik_nas_ldap"
-        ]
-      },
-      "AUTHENTIK_TOKEN": {
-        "name": "AUTHENTIK_TOKEN",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "configure_authentik_nextcloud_oidc",
-          "configure_authentik_nas_ldap"
-        ]
-      },
-      "AUTHENTIK_NEXTCLOUD_CLIENT_ID": {
-        "name": "AUTHENTIK_NEXTCLOUD_CLIENT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "configure_authentik_nextcloud_oidc"
-        ]
-      },
-      "AUTHENTIK_NEXTCLOUD_CLIENT_SECRET": {
-        "name": "AUTHENTIK_NEXTCLOUD_CLIENT_SECRET",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "configure_authentik_nextcloud_oidc"
-        ]
-      },
-      "AUTHENTIK_NEXTCLOUD_PROVIDER_NAME": {
-        "name": "AUTHENTIK_NEXTCLOUD_PROVIDER_NAME",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "configure_authentik_nextcloud_oidc"
-        ]
-      },
-      "AUTHENTIK_NEXTCLOUD_APP_NAME": {
-        "name": "AUTHENTIK_NEXTCLOUD_APP_NAME",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "configure_authentik_nextcloud_oidc"
-        ]
-      },
-      "AUTHENTIK_NEXTCLOUD_APP_SLUG": {
-        "name": "AUTHENTIK_NEXTCLOUD_APP_SLUG",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
+          "configure_authentik_nas_ldap",
           "configure_authentik_nextcloud_oidc"
         ]
       },
@@ -16853,6 +17026,16 @@
           "configure_authentik_nas_ldap"
         ]
       },
+      "AUTHENTIK_TOKEN": {
+        "name": "AUTHENTIK_TOKEN",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nas_ldap",
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
       "NAS_API_KEY": {
         "name": "NAS_API_KEY",
         "type": "string",
@@ -16871,6 +17054,51 @@
           "configure_authentik_nas_ldap"
         ]
       },
+      "AUTHENTIK_NEXTCLOUD_CLIENT_ID": {
+        "name": "AUTHENTIK_NEXTCLOUD_CLIENT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
+      "AUTHENTIK_NEXTCLOUD_CLIENT_SECRET": {
+        "name": "AUTHENTIK_NEXTCLOUD_CLIENT_SECRET",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
+      "AUTHENTIK_NEXTCLOUD_PROVIDER_NAME": {
+        "name": "AUTHENTIK_NEXTCLOUD_PROVIDER_NAME",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
+      "AUTHENTIK_NEXTCLOUD_APP_NAME": {
+        "name": "AUTHENTIK_NEXTCLOUD_APP_NAME",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
+      "AUTHENTIK_NEXTCLOUD_APP_SLUG": {
+        "name": "AUTHENTIK_NEXTCLOUD_APP_SLUG",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "configure_authentik_nextcloud_oidc"
+        ]
+      },
       "ALL_CHILDREN_HOMELAB_HOSTS_HOMELAB_ANSIBLE_SSH_PRIVATE_KEY_FILE": {
         "name": "ALL_CHILDREN_HOMELAB_HOSTS_HOMELAB_ANSIBLE_SSH_PRIVATE_KEY_FILE",
         "type": "string",
@@ -16878,6 +17106,15 @@
         "value": "***REDACTED***",
         "contexts": [
           "inventory_homelab"
+        ]
+      },
+      "CONTACTPOINTS_0_RECEIVERS_0_SETTINGS_BOTTOKEN": {
+        "name": "CONTACTPOINTS_0_RECEIVERS_0_SETTINGS_BOTTOKEN",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "contactpoints"
         ]
       },
       "DATASOURCES_0_BASICAUTH": {
@@ -16925,23 +17162,14 @@
           "datasources"
         ]
       },
-      "CONTACTPOINTS_0_RECEIVERS_0_SETTINGS_BOTTOKEN": {
-        "name": "CONTACTPOINTS_0_RECEIVERS_0_SETTINGS_BOTTOKEN",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "contactpoints"
-        ]
-      },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_SUMMARY": {
         "name": "PATHS_/API/V1/AUTHS/SIGNIN_POST_SUMMARY",
         "type": "string",
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_REQUESTBODY_REQUIRED": {
@@ -16950,8 +17178,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_REQUESTBODY_CONTENT_APPLICATION/JSON_SCHEMA_TYPE": {
@@ -16960,8 +17188,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_REQUESTBODY_CONTENT_APPLICATION/JSON_SCHEMA_PROPERTIES_EMAIL_TYPE": {
@@ -16970,8 +17198,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_REQUESTBODY_CONTENT_APPLICATION/JSON_SCHEMA_PROPERTIES_PASSWORD_TYPE": {
@@ -16980,8 +17208,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_RESPONSES_200_DESCRIPTION": {
@@ -16990,8 +17218,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "PATHS_/API/V1/AUTHS/SIGNIN_POST_RESPONSES_200_CONTENT_APPLICATION/JSON_SCHEMA_$REF": {
@@ -17000,8 +17228,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "COMPONENTS_SCHEMAS_USERRESPONSE_PROPERTIES_TOKEN_TYPE": {
@@ -17010,8 +17238,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "openapi",
-          "openapi.generated"
+          "openapi.generated",
+          "openapi"
         ]
       },
       "MCPSERVERS_0_ENV_SECRETS_AGENT_URL": {
@@ -17025,148 +17253,58 @@
         ]
       }
     },
-    "integrations": {
-      "GOOGLE_SDM_PROJECT": {
-        "name": "GOOGLE_SDM_PROJECT",
-        "type": "string",
-        "source": ".env",
-        "value": "projects/your_project_id",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 17
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_NUMBER": {
-        "name": "GOOGLE_SDM_PROJECT_NUMBER",
-        "type": "string",
-        "source": ".env",
-        "value": "your_project_number",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 18
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_ID": {
-        "name": "GOOGLE_SDM_PROJECT_ID",
-        "type": "string",
-        "source": ".env",
-        "value": "your_project_id",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 19
-          }
-        ],
-        "contexts": []
-      },
-      "TELEGRAM_CHAT_ID": {
-        "name": "TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "WEBHOOKS_ENABLED": {
-        "name": "WEBHOOKS_ENABLED",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "AGENDA_TELEGRAM_CHAT_ID": {
-        "name": "AGENDA_TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "daily_agenda_config"
-        ]
-      },
-      "GITHUB_AGENT_URL": {
-        "name": "GITHUB_AGENT_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "GLOBAL_TELEGRAM_API_URL": {
-        "name": "GLOBAL_TELEGRAM_API_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "https://api.telegram.org/bot",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      }
-    },
     "database": {
+      "DATABASE_URL": {
+        "name": "DATABASE_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "DB_HOST": {
+        "name": "DB_HOST",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "wikijs-db",
+        "contexts": [
+          "wikijs",
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "DB_PORT": {
+        "name": "DB_PORT",
+        "type": "integer",
+        "source": "docker-compose",
+        "value": 5432,
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "DB_USER": {
+        "name": "DB_USER",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "wikijs",
+        "contexts": [
+          "wikijs",
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "DB_NAME": {
+        "name": "DB_NAME",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "wikijs",
+        "contexts": [
+          "wikijs",
+          "netbox-worker",
+          "netbox"
+        ]
+      },
       "MAILU_DATABASE_URL": {
         "name": "MAILU_DATABASE_URL",
         "type": "url",
@@ -17192,57 +17330,6 @@
           }
         ],
         "contexts": []
-      },
-      "DB_HOST": {
-        "name": "DB_HOST",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "wikijs-db",
-        "contexts": [
-          "netbox",
-          "netbox-worker",
-          "wikijs"
-        ]
-      },
-      "DB_PORT": {
-        "name": "DB_PORT",
-        "type": "integer",
-        "source": "docker-compose",
-        "value": 5432,
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "DB_USER": {
-        "name": "DB_USER",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "wikijs",
-        "contexts": [
-          "netbox",
-          "netbox-worker",
-          "wikijs"
-        ]
-      },
-      "DB_NAME": {
-        "name": "DB_NAME",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "wikijs",
-        "contexts": [
-          "netbox",
-          "netbox-worker",
-          "wikijs"
-        ]
-      },
-      "DATABASE_URL": {
-        "name": "DATABASE_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
       },
       "CMDB_TIMEZONE": {
         "name": "CMDB_TIMEZONE",
@@ -17370,44 +17457,26 @@
         "name": "POSTGRES_DB",
         "type": "string",
         "source": "docker-compose",
-        "value": "wikijs",
+        "value": "roundcube",
         "contexts": [
+          "netbox-postgres",
           "mailu-db",
-          "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
+          "postgres",
+          "wikijs-db"
         ]
       },
       "POSTGRES_USER": {
         "name": "POSTGRES_USER",
         "type": "string",
         "source": "docker-compose",
-        "value": "wikijs",
+        "value": "roundcube",
         "contexts": [
+          "netbox-postgres",
           "mailu-db",
-          "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
-        ]
-      },
-      "DB_TYPE": {
-        "name": "DB_TYPE",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "postgres",
-        "contexts": [
-          "wikijs"
-        ]
-      },
-      "DB_PASS": {
-        "name": "DB_PASS",
-        "type": "string",
-        "source": "docker-compose",
-        "value": "${WIKIJS_DB_PASSWORD:-wikijs_rpa4all_2026}",
-        "contexts": [
-          "wikijs"
+          "postgres",
+          "wikijs-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_TYPE": {
@@ -17470,8 +17539,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-backend",
-          "mailu-roundcube"
+          "mailu-roundcube",
+          "mailu-backend"
         ]
       },
       "GF_DATABASE_TYPE": {
@@ -17519,14 +17588,32 @@
           "grafana"
         ]
       },
+      "DB_TYPE": {
+        "name": "DB_TYPE",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "postgres",
+        "contexts": [
+          "wikijs"
+        ]
+      },
+      "DB_PASS": {
+        "name": "DB_PASS",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "${WIKIJS_DB_PASSWORD:-wikijs_rpa4all_2026}",
+        "contexts": [
+          "wikijs"
+        ]
+      },
       "REDIS_CACHE_DATABASE": {
         "name": "REDIS_CACHE_DATABASE",
         "type": "boolean",
         "source": "docker-compose",
         "value": "1",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_CACHE_HOST": {
@@ -17535,8 +17622,8 @@
         "source": "docker-compose",
         "value": "netbox-redis-cache",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_DATABASE": {
@@ -17545,8 +17632,8 @@
         "source": "docker-compose",
         "value": "0",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_HOST": {
@@ -17555,8 +17642,8 @@
         "source": "docker-compose",
         "value": "netbox-redis",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_DATABASE": {
@@ -17668,8 +17755,16 @@
         "value": "***REDACTED***",
         "locations": [
           {
+            "file": ".env",
+            "line": 35
+          },
+          {
             "file": ".env.consolidated",
             "line": 66
+          },
+          {
+            "file": ".env",
+            "line": 35
           }
         ],
         "contexts": []
@@ -17681,8 +17776,16 @@
         "value": "***REDACTED***",
         "locations": [
           {
+            "file": ".env",
+            "line": 36
+          },
+          {
             "file": ".env.consolidated",
             "line": 67
+          },
+          {
+            "file": ".env",
+            "line": 36
           }
         ],
         "contexts": []
@@ -17691,11 +17794,19 @@
         "name": "KUCOIN_API_PASSPHRASE",
         "type": "string",
         "source": ".env",
-        "value": "your_kucoin_api_passphrase_here",
+        "value": "PLACEHOLDER_SET_ME",
         "locations": [
+          {
+            "file": ".env",
+            "line": 37
+          },
           {
             "file": ".env.consolidated",
             "line": 68
+          },
+          {
+            "file": ".env",
+            "line": 37
           }
         ],
         "contexts": []
@@ -17765,6 +17876,15 @@
         ],
         "contexts": []
       },
+      "COIN_CONFIG_FILE": {
+        "name": "COIN_CONFIG_FILE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "validate_btc_config"
+        ]
+      },
       "OLLAMA_TRADING_MODEL": {
         "name": "OLLAMA_TRADING_MODEL",
         "type": "string",
@@ -17772,6 +17892,15 @@
         "value": "trading-analyst:latest",
         "contexts": [
           "trading-daily-report"
+        ]
+      },
+      "COMPATIBILITY_METHOD": {
+        "name": "COMPATIBILITY_METHOD",
+        "type": "string",
+        "source": "systemd",
+        "value": "semantic",
+        "contexts": [
+          "job-monitor"
         ]
       },
       "PROMETHEUS_URL": {
@@ -17789,26 +17918,8 @@
         "source": "systemd",
         "value": "/apps/crypto-trader/trading/btc_trading_agent",
         "contexts": [
-          "kucoin-usdt-rebalance",
-          "kucoin-postgres-sync"
-        ]
-      },
-      "COMPATIBILITY_METHOD": {
-        "name": "COMPATIBILITY_METHOD",
-        "type": "string",
-        "source": "systemd",
-        "value": "semantic",
-        "contexts": [
-          "job-monitor"
-        ]
-      },
-      "COIN_CONFIG_FILE": {
-        "name": "COIN_CONFIG_FILE",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "validate_btc_config"
+          "kucoin-postgres-sync",
+          "kucoin-usdt-rebalance"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_COIN": {
@@ -17924,6 +18035,24 @@
         "type": "string",
         "source": "yaml",
         "value": "DOGE-USDT",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_COIN": {
+        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_COIN",
+        "type": "string",
+        "source": "yaml",
+        "value": "USDT-BRL",
+        "contexts": [
+          "prometheus"
+        ]
+      },
+      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_COIN": {
+        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_COIN",
+        "type": "string",
+        "source": "yaml",
+        "value": "USDT-BRL",
         "contexts": [
           "prometheus"
         ]
@@ -18064,6 +18193,147 @@
         ]
       }
     },
+    "integrations": {
+      "GOOGLE_SDM_PROJECT": {
+        "name": "GOOGLE_SDM_PROJECT",
+        "type": "string",
+        "source": ".env",
+        "value": "projects/your_project_id",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 17
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_NUMBER": {
+        "name": "GOOGLE_SDM_PROJECT_NUMBER",
+        "type": "string",
+        "source": ".env",
+        "value": "your_project_number",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 18
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_ID": {
+        "name": "GOOGLE_SDM_PROJECT_ID",
+        "type": "string",
+        "source": ".env",
+        "value": "your_project_id",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 19
+          }
+        ],
+        "contexts": []
+      },
+      "TELEGRAM_CHAT_ID": {
+        "name": "TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "WEBHOOKS_ENABLED": {
+        "name": "WEBHOOKS_ENABLED",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "GITHUB_AGENT_URL": {
+        "name": "GITHUB_AGENT_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "AGENDA_TELEGRAM_CHAT_ID": {
+        "name": "AGENDA_TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "daily_agenda_config"
+        ]
+      },
+      "GLOBAL_TELEGRAM_API_URL": {
+        "name": "GLOBAL_TELEGRAM_API_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "https://api.telegram.org/bot",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      }
+    },
     "infrastructure": {
       "LTFS_MOUNT_POINT": {
         "name": "LTFS_MOUNT_POINT",
@@ -18078,15 +18348,6 @@
         ],
         "contexts": []
       },
-      "LTFS_ALLOW_UNMOUNTED_OUTSIDE_WINDOW": {
-        "name": "LTFS_ALLOW_UNMOUNTED_OUTSIDE_WINDOW",
-        "type": "boolean",
-        "source": "systemd",
-        "value": "false",
-        "contexts": [
-          "ltfs-lto6-selfheal-escalator"
-        ]
-      },
       "REQUIRE_MOUNTPOINT": {
         "name": "REQUIRE_MOUNTPOINT",
         "type": "path",
@@ -18094,6 +18355,15 @@
         "value": "/mnt/tape_sg1",
         "contexts": [
           "homelab-tape-log-drain-sg1"
+        ]
+      },
+      "LTFS_ALLOW_UNMOUNTED_OUTSIDE_WINDOW": {
+        "name": "LTFS_ALLOW_UNMOUNTED_OUTSIDE_WINDOW",
+        "type": "boolean",
+        "source": "systemd",
+        "value": "false",
+        "contexts": [
+          "ltfs-lto6-selfheal-escalator"
         ]
       },
       "AGENT_NETWORK_EXPORTER_PORT": {
@@ -18116,23 +18386,14 @@
       }
     },
     "monitoring": {
-      "ABSENT_ALERT_MIN": {
-        "name": "ABSENT_ALERT_MIN",
-        "type": "integer",
-        "source": "systemd",
-        "value": "30",
-        "contexts": [
-          "iot-presence-watchdog"
-        ]
-      },
       "GRAFANA_URL": {
         "name": "GRAFANA_URL",
         "type": "url",
         "source": "systemd",
-        "value": "http://localhost:3002/grafana",
+        "value": "http://localhost:3002",
         "contexts": [
-          "grafana-selfheal",
-          "tape-quality-ollama-narrator"
+          "tape-quality-ollama-narrator",
+          "grafana-selfheal"
         ]
       },
       "GRAFANA_CONTAINER": {
@@ -18144,16 +18405,25 @@
           "grafana-selfheal"
         ]
       },
+      "ABSENT_ALERT_MIN": {
+        "name": "ABSENT_ALERT_MIN",
+        "type": "integer",
+        "source": "systemd",
+        "value": "30",
+        "contexts": [
+          "iot-presence-watchdog"
+        ]
+      },
       "GROUPS_0_RULES_0_ALERT": {
         "name": "GROUPS_0_RULES_0_ALERT",
         "type": "string",
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -18162,10 +18432,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -18174,10 +18444,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
+          "ltfs-selfheal-rules",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -18186,9 +18456,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
+          "ltfs-selfheal-rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_4_ALERT": {
@@ -18197,8 +18467,8 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_ALERT": {
@@ -18207,8 +18477,8 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_1_RULES_0_ALERT": {
@@ -18217,8 +18487,8 @@
         "source": "yaml",
         "value": "TradingAgentDown",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ALERT": {
@@ -18227,8 +18497,8 @@
         "source": "yaml",
         "value": "TradingAgentStalled",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_ALERT": {
@@ -18237,8 +18507,8 @@
         "source": "yaml",
         "value": "TradingDecisionsGap",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ALERT": {
@@ -18247,8 +18517,8 @@
         "source": "yaml",
         "value": "TradingSelfHealExhausted",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_ALERT": {
@@ -18299,169 +18569,175 @@
     }
   },
   "metadata": {
-    "totalVariables": 1937,
+    "totalVariables": 1955,
     "sourceFiles": [
+      ".env",
       ".env.openai-compatible.example",
-      ".env.example.wiki",
       ".env.example",
       ".env.consolidated",
+      ".env.example.wiki",
       "deploy/cmdb/.env.example",
+      ".env",
+      "btc_trading_agent/BTC_USDT_shadow.env",
       "systemd/ltfs-lto6-sg1.env",
       "deploy/production_autonomous.env",
-      "btc_trading_agent/BTC_USDT_shadow.env",
       "tools/authentik_management/configs/openwebui.env",
       "tools/authentik_management/configs/grafana.env",
-      "docker/docker-compose.wikijs.yml",
+      "docker/docker-compose.gdrive.yml",
       "docker/docker-compose.simple-mail.yml",
-      "docker/docker-compose.opensearch.yml",
-      "docker/docker-compose.ntopng.yml",
       "docker/docker-compose.mailu.yml",
       "docker/docker-compose.grafana.yml",
-      "docker/docker-compose.gdrive.yml",
-      "docker/docker-compose.email-simple.yml",
+      "docker/docker-compose.opensearch.yml",
       "docker/docker-compose-exporters.yml",
-      "deploy/printshare/docker-compose.yml",
-      "deploy/cmdb/docker-compose.yml",
+      "docker/docker-compose.wikijs.yml",
+      "docker/docker-compose.email-simple.yml",
+      "docker/docker-compose.ntopng.yml",
       "tools/vaultwarden/docker-compose.yml",
       "tools/authentik_management/configs/docker-compose.override.yml",
-      "systemd/tuya-token-selfheal.service",
-      "systemd/iot-presence-watchdog.service",
-      "systemd/protonvpn-unit-selfheal.service",
-      "systemd/ethwan-selfheal.service",
-      "systemd/workstation-win11l-rdp@.service",
-      "systemd/workstation-win11l-http@.service",
-      "systemd/tuya-token-renewer.service",
-      "systemd/trading-daily-report.service",
-      "systemd/trading-analyst-weekly-retrain.service",
-      "systemd/tape-safe-eject.service",
-      "systemd/tape-quality-ollama-narrator.service",
-      "systemd/tape-component-quality-exporter.service",
-      "systemd/storj-macvlan-watchdog.service",
-      "systemd/storj-macvlan-network.service",
-      "systemd/storj-host-shim.service",
-      "systemd/specialized_agents-dashboard.service",
-      "systemd/rss-sentiment-exporter.service",
-      "systemd/rpa4all-validation.service",
-      "systemd/rag-reindex.service",
-      "systemd/python-training.service",
-      "systemd/protonvpn-boot-selfheal.service",
-      "systemd/post-boot-check.service",
-      "systemd/pihole-ipv6-dns-fix.service",
-      "systemd/pandaplus-telegram-bridge.service",
-      "systemd/ollama-warmup.service",
-      "systemd/ollama-gpu1.service",
-      "systemd/ollama-gpu-coordinator.service",
-      "systemd/ollama-finetune.service",
-      "systemd/notebook-power-agent.service",
-      "systemd/monitoring-containers-bootstrap.service",
-      "systemd/meeting-translator.service",
-      "systemd/marketing-x-posts.service",
-      "systemd/marketing-email-drip.service",
-      "systemd/marketing-daily-report.service",
-      "systemd/marketing-api.service",
-      "systemd/lto6-selfheal.service",
-      "systemd/lto6-drain-backups.service",
-      "systemd/lto6-checkpoint-recover.service",
-      "systemd/lto6-checkpoint-drain.service",
-      "systemd/ltfs-window-enforcer.service",
-      "systemd/ltfs-lto6b.service",
-      "systemd/ltfs-lto6.service",
-      "systemd/ltfs-lto6-sg1.service",
-      "systemd/ltfs-lto6-selfheal-escalator.service",
-      "systemd/ltfs-log-rotation.service",
-      "systemd/ltfs-deep-recovery.service",
-      "systemd/ltfs-button-watch.service",
-      "systemd/ltfs-boot-reconcile.service",
-      "systemd/ltfs-backup-catalog.service",
-      "systemd/llm-log-panel.service",
-      "systemd/kucoin-usdt-rebalance.service",
-      "systemd/kucoin-postgres-sync.service",
-      "systemd/journal-ingestor.service",
-      "systemd/job-monitor.service",
-      "systemd/ipv6-proxy.service",
-      "systemd/iot-vpn-bypass-watchdog.service",
+      "deploy/cmdb/docker-compose.yml",
+      "deploy/printshare/docker-compose.yml",
       "systemd/homelab-vault-close.service",
-      "systemd/homelab-vault-backup.service",
-      "systemd/homelab-tape-logrotate.service",
-      "systemd/homelab-tape-log-drain-sg1.service",
-      "systemd/homelab-tape-log-drain-nextcloud.service",
-      "systemd/homelab-dashboard.service",
-      "systemd/grafana-selfheal.service",
-      "systemd/github-agent.service",
-      "systemd/eddie_central_extended_metrics.service",
-      "systemd/eddie-whatsapp-bot.service",
-      "systemd/eddie-telegram-bot.service",
-      "systemd/eddie-expurgo.service",
-      "systemd/eddie-calendar.service",
-      "systemd/disk-clean.service",
+      "systemd/marketing-x-posts.service",
+      "systemd/tuya-local-key-selfheal.service",
+      "systemd/coordinator.service",
+      "systemd/ollama-gpu-coordinator.service",
+      "systemd/marketing-email-drip.service",
+      "systemd/rag-reindex.service",
+      "systemd/ltfs-lto6.service",
+      "systemd/candle-collector.service",
+      "systemd/workstation-win11l-rdp@.service",
+      "systemd/tape-component-quality-exporter.service",
+      "systemd/ltfs-lto6-sg1.service",
       "systemd/diretor.service",
       "systemd/dhcp-selfheal.service",
-      "systemd/daily-agenda-panel.service",
       "systemd/daily-agenda-broadcast.service",
-      "systemd/crypto-agent@.service",
-      "systemd/coordinator.service",
-      "systemd/cloudflared-tunnel-guardian.service",
-      "systemd/clear-trading-agent.service",
+      "systemd/trading-analyst-weekly-retrain.service",
       "systemd/clear-agent@.service",
-      "systemd/chromecast-ambilight.service",
-      "systemd/check_projects.service",
-      "systemd/candle-collector.service",
-      "systemd/bn-acervo-agent.service",
-      "systemd/banking-metrics-exporter.service",
-      "systemd/approval-gateway.service",
       "systemd/akash-sweep.service",
+      "systemd/ltfs-backup-catalog.service",
+      "systemd/pandaplus-telegram-bridge.service",
+      "systemd/homelab-tape-log-drain-sg1.service",
+      "systemd/clear-trading-agent.service",
+      "systemd/eddie-whatsapp-bot.service",
+      "systemd/specialized_agents-dashboard.service",
+      "systemd/decisions-track-record-rollup.service",
+      "systemd/storj-host-shim.service",
+      "systemd/github-agent.service",
+      "systemd/grafana-selfheal.service",
+      "systemd/banking-metrics-exporter.service",
+      "systemd/lto6-selfheal.service",
+      "systemd/notebook-power-agent.service",
+      "systemd/check_projects.service",
+      "systemd/ltfs-deep-recovery.service",
+      "systemd/llm-log-panel.service",
+      "systemd/crypto-agent@.service",
+      "systemd/ethwan-selfheal.service",
+      "systemd/iot-presence-watchdog.service",
+      "systemd/rpa4all-validation.service",
+      "systemd/daily-agenda-panel.service",
+      "systemd/ollama-warmup.service",
+      "systemd/bn-acervo-agent.service",
+      "systemd/trading-daily-report.service",
+      "systemd/ltfs-lto6b.service",
+      "systemd/job-monitor.service",
+      "systemd/rss-sentiment-exporter.service",
+      "systemd/homelab-vault-backup.service",
+      "systemd/journal-ingestor.service",
+      "systemd/tuya-token-renewer.service",
+      "systemd/ollama-finetune.service",
+      "systemd/homelab-tape-logrotate.service",
+      "systemd/eddie-expurgo.service",
+      "systemd/ltfs-button-watch.service",
+      "systemd/python-training.service",
+      "systemd/workstation-win11l-http@.service",
+      "systemd/approval-gateway.service",
+      "systemd/ltfs-window-enforcer.service",
+      "systemd/tape-quality-ollama-narrator.service",
+      "systemd/ipv6-proxy.service",
+      "systemd/monitoring-containers-bootstrap.service",
+      "systemd/iot-vpn-bypass-watchdog.service",
+      "systemd/homelab-dashboard.service",
+      "systemd/meeting-translator.service",
+      "systemd/eddie_central_extended_metrics.service",
+      "systemd/storj-macvlan-network.service",
+      "systemd/eddie-telegram-bot.service",
+      "systemd/protonvpn-unit-selfheal.service",
+      "systemd/disk-clean.service",
+      "systemd/chromecast-ambilight.service",
+      "systemd/ollama-gpu1.service",
+      "systemd/kucoin-usdt-rebalance.service",
+      "systemd/lto6-checkpoint-drain.service",
+      "systemd/homelab-tape-log-drain-nextcloud.service",
+      "systemd/lto6-drain-backups.service",
+      "systemd/kucoin-postgres-sync.service",
+      "systemd/cloudflared-tunnel-guardian.service",
+      "systemd/protonvpn-boot-selfheal.service",
+      "systemd/ltfs-lto6-selfheal-escalator.service",
+      "systemd/ltfs-log-rotation.service",
+      "systemd/lto6-checkpoint-recover.service",
+      "systemd/pihole-ipv6-dns-fix.service",
+      "systemd/storj-macvlan-watchdog.service",
+      "systemd/marketing-daily-report.service",
+      "systemd/tape-safe-eject.service",
+      "systemd/post-boot-check.service",
+      "systemd/marketing-api.service",
       "systemd/agent-network-exporter.service",
-      "tools/daily_agenda_config.py",
-      "tests/test_wikijs_configure.py",
-      "tests/test_validate_btc_config.py",
-      "tests/test_render_wireguard_client_config.py",
-      "tests/test_configure_authentik_nextcloud_oidc.py",
-      "tests/test_authentik_os_strict_config.py",
+      "systemd/tuya-token-selfheal.service",
+      "systemd/ltfs-boot-reconcile.service",
+      "systemd/eddie-calendar.service",
       "tests/test_authentik_openwebui_config_consistency.py",
+      "tests/test_validate_btc_config.py",
+      "tests/test_configure_authentik_nextcloud_oidc.py",
       "tests/_variables_catalog_config.py",
-      "systemd/validate_btc_config.py",
+      "tests/test_authentik_os_strict_config.py",
+      "tests/test_wikijs_configure.py",
+      "tests/test_render_wireguard_client_config.py",
       "specialized_agents/config.py",
-      "scripts/wikijs_configure.py",
-      "scripts/router_network_config.py",
-      "scripts/render_wireguard_client_config.py",
-      "scripts/generate_profile_configs.py",
-      "dev_agent/config.py",
-      "dashboard/config.py",
-      "content_automation/config.py",
       ".variables-catalog/config.py",
-      "scripts/misc/configure_diretor_model.py",
-      "tests/unit/test_trading_profile_config.py",
-      "tests/copilot_hooks/test_hook_configs.py",
+      "systemd/validate_btc_config.py",
+      "dev_agent/config.py",
+      "scripts/router_network_config.py",
+      "scripts/generate_profile_configs.py",
+      "scripts/render_wireguard_client_config.py",
+      "scripts/wikijs_configure.py",
+      "content_automation/config.py",
+      "tools/daily_agenda_config.py",
+      "dashboard/config.py",
       "tools/pandaplus_bridge/config.py",
-      "tools/authentik_management/configure_authentik_os_strict.py",
-      "tools/authentik_management/configure_authentik_nextcloud_oidc.py",
       "tools/authentik_management/configure_authentik_nas_ldap.py",
+      "tools/authentik_management/configure_authentik_nextcloud_oidc.py",
+      "tools/authentik_management/configure_authentik_os_strict.py",
+      "scripts/misc/configure_diretor_model.py",
+      "tests/copilot_hooks/test_hook_configs.py",
+      "tests/unit/test_trading_profile_config.py",
       "rpa4all-snapshot-alerts.yml",
+      "docker/deploy_selfhealing.yml",
       "monitoring/prometheus.yml",
       "monitoring/grafana_gpu_alert_rules.yml",
       "monitoring/alert_rules.yml",
-      "docker/deploy_selfhealing.yml",
       "config/prometheus-config.yml",
       "config/inventory_homelab.yml",
+      "tools/alerting/alertmanager_telegram.yml",
       "monitoring/prometheus/selfhealing_rules.yml",
       "monitoring/prometheus/ltfs-selfheal-rules.yml",
       "monitoring/grafana/provisioning/datasources.yml",
-      "monitoring/grafana/provisioning/datasources/datasources.yml",
-      "monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      "monitoring/grafana/provisioning/alerting/rules.yml",
       "monitoring/grafana/provisioning/alerting/policies.yml",
+      "monitoring/grafana/provisioning/alerting/rules.yml",
       "monitoring/grafana/provisioning/alerting/contactpoints.yml",
+      "monitoring/grafana/provisioning/dashboards/dashboards.yml",
+      "monitoring/grafana/provisioning/datasources/datasources.yml",
       "site/deploy/cloudflared-rpa4all-ide.yml",
-      "tools/alerting/alertmanager_telegram.yml",
       "docs/openapi.yaml",
       "docs/openapi.generated.yaml",
       "content_automation/settings.yaml",
-      ".continue/mcpServers/new-mcp-server.yaml",
-      ".continue/mcpServers/homelab.yaml",
-      "content_automation/data/prompts/viral_trends.yaml",
+      ".venv/lib/python3.13/site-packages/markdown_it/port.yaml",
       "content_automation/data/prompts/curiosidades.yaml",
       "content_automation/data/prompts/cripto.yaml",
-      "grafana/provisioning/datasources/authentik-http.yaml"
+      "content_automation/data/prompts/viral_trends.yaml",
+      ".continue/mcpServers/new-mcp-server.yaml",
+      ".continue/mcpServers/homelab.yaml",
+      "grafana/provisioning/datasources/authentik-http.yaml",
+      "philco10b_raspios/.venv/lib/python3.13/site-packages/markdown_it/port.yaml"
     ],
     "serviceCount": 0
   }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-23T13:55:47.335922+00:00",
+  "generated_at": "2026-07-23T19:37:11.312693+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T13:55:47.335922+00:00`
+- Generated at: `2026-07-23T19:37:11.312693+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/docs/variables-taxonomy/TUYA_TOKEN_SELFHEAL.md
+++ b/docs/variables-taxonomy/TUYA_TOKEN_SELFHEAL.md
@@ -1,21 +1,28 @@
 # Tuya Token Selfheal — Variáveis
 
-Serviço: `tuya-token-selfheal.service` (+ `.timer`, a cada 15 min) — script
+Serviço: `tuya-token-selfheal.service` (+ `.timer`, a cada **5 min**) — script
 `tools/homelab/tuya_token_selfheal.py`, instalado em
 `/usr/local/bin/tuya_token_selfheal.py` no homelab (192.168.15.2).
 
-Detecta o refresh token Tuya morto no Home Assistant (0 entidades ativas +
-token expirado) e injeta o token vivo do pandaplus-bridge, reiniciando o
-container do HA. Métricas em
+Detecta access token Tuya prestes a expirar (ou já expirado) no Home
+Assistant, **força refresh proativo** via API Tuya Sharing (o SDK do bridge
+só renova com <60s), grava o token em `tuya_tokens_runtime.json` e injeta no
+HA preferindo hot-apply (`tuya_token_inject.apply`), com fallback para
+`homeassistant.restart` e `docker restart`. Métricas em
 `/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom` (dashboard
 Grafana `tuya-token-selfheal`).
 
 | Variável | Default | Propósito |
 |---|---|---|
 | `HA_CONTAINER` | `homeassistant` | Nome do container Docker do Home Assistant (mesma semântica do `tuya_token_renewer.py`). |
+| `HA_URL` | `http://127.0.0.1:8123` | Base URL da API local do Home Assistant. |
 | `HA_CONFIG_ENTRIES` | `/home/homelab/homeassistant/config/.storage/core.config_entries` | Caminho no host do storage de config entries do HA onde o `token_info` é injetado. |
-| `BRIDGE_RUNTIME_TOKENS` | `/var/lib/pandaplus-bridge/tuya_tokens_runtime.json` | Token Tuya renovado persistido pelo pandaplus-bridge (fonte do heal). |
+| `BRIDGE_RUNTIME_TOKENS` | `/var/lib/pandaplus-bridge/tuya_tokens_runtime.json` | Token Tuya renovado (bridge ou selfheal) — fonte do heal. |
 | `STATE_FILE` | `/var/lib/tuya-selfheal/state.json` | Estado persistente do selfheal (contadores e histórico de heals p/ rate limit). |
 | `PROM_FILE` | `/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom` | Saída textfile collector das métricas Prometheus. |
-| `MAX_HEALS_24H` | `3` | Rate limit de heals por 24h — acima disso o problema é estrutural (reauth QR via `tuya_reauth_via_authentik.py`). |
-| `HA_BOOT_WAIT_S` | `300` | Tempo máximo aguardando o HA subir após o restart antes de declarar falha do heal. |
+| `MAX_HEALS_24H` | `24` | Rate limit de heals por 24h — acima disso o problema é estrutural (reauth QR via `tuya_reauth_via_authentik.py`). |
+| `HA_BOOT_WAIT_S` | `300` | Tempo máximo aguardando o HA subir após docker restart antes de declarar falha do heal. |
+| `TUYA_SELFHEAL_HOT_WAIT_S` | `90` | Tempo máximo (s) aguardando entidades após hot-apply do token (distinto de `HA_BOOT_WAIT_S`, usado no docker restart). |
+| `HEAL_SOFT_THRESHOLD_MIN` | `45` | Minutos restantes do access token do HA abaixo dos quais o selfheal renova proativamente e injeta. `0` = só com token já expirado. |
+| `TUYA_CLIENT_ID` | `HA_3y9q4ak7g4ephrvke` | Client ID público da integração Tuya do HA core (refresh Sharing API). |
+| `TUYA_SHARING_SITE` | `/home/homelab/myClaude/.venv/lib/python3.12/site-packages` | site-packages com `tuya_sharing` (venv do pandaplus-bridge). |

--- a/systemd/tuya-token-selfheal.service
+++ b/systemd/tuya-token-selfheal.service
@@ -16,8 +16,12 @@ Environment=HA_CONFIG_ENTRIES=/home/homelab/homeassistant/config/.storage/core.c
 Environment=BRIDGE_RUNTIME_TOKENS=/var/lib/pandaplus-bridge/tuya_tokens_runtime.json
 Environment=STATE_FILE=/var/lib/tuya-selfheal/state.json
 Environment=PROM_FILE=/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom
-Environment=MAX_HEALS_24H=6
+Environment=MAX_HEALS_24H=24
 Environment=HA_BOOT_WAIT_S=300
+Environment=TUYA_SELFHEAL_HOT_WAIT_S=90
+Environment=HEAL_SOFT_THRESHOLD_MIN=45
+Environment=TUYA_CLIENT_ID=HA_3y9q4ak7g4ephrvke
+Environment=TUYA_SHARING_SITE=/home/homelab/myClaude/.venv/lib/python3.12/site-packages
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=tuya-token-selfheal

--- a/systemd/tuya-token-selfheal.timer
+++ b/systemd/tuya-token-selfheal.timer
@@ -1,10 +1,10 @@
 [Unit]
-Description=Roda o self-heal do token Tuya a cada 15 minutos
+Description=Roda o self-heal do token Tuya a cada 5 minutos
 After=network-online.target
 
 [Timer]
-OnBootSec=10min
-OnUnitActiveSec=15min
+OnBootSec=2min
+OnUnitActiveSec=5min
 Persistent=true
 Unit=tuya-token-selfheal.service
 

--- a/tests/test_tuya_token_selfheal.py
+++ b/tests/test_tuya_token_selfheal.py
@@ -20,6 +20,22 @@ FRESH_TOKEN = {
     "t": NOW_MS - 60_000,
     "uid": "az1",
 }
+# ~30 min remaining with default soft=45 → inside soft window
+NEAR_EXPIRY_TOKEN = {
+    "access_token": "a-old",
+    "refresh_token": "r-old",
+    "expire_time": 7200,
+    "t": NOW_MS - 90 * 60 * 1000,
+    "uid": "az1",
+}
+# Newer than NEAR_EXPIRY (~100 min remaining)
+NEWER_RUNTIME = {
+    "access_token": "a-new",
+    "refresh_token": "r-new",
+    "expire_time": 7200,
+    "t": NOW_MS - 20 * 60 * 1000,
+    "uid": "az1",
+}
 EXPIRED_TOKEN = {
     "access_token": "a",
     "refresh_token": "r",
@@ -39,6 +55,8 @@ def test_token_remaining_minutes() -> None:
     remaining = selfheal.token_remaining_minutes(FRESH_TOKEN, now_ms=NOW_MS)
     assert remaining == pytest.approx(119, abs=1)
     assert selfheal.token_remaining_minutes(EXPIRED_TOKEN, now_ms=NOW_MS) < 0
+    near = selfheal.token_remaining_minutes(NEAR_EXPIRY_TOKEN, now_ms=NOW_MS)
+    assert 25 < near < 35
 
 
 def test_valid_runtime_token() -> None:
@@ -48,26 +66,76 @@ def test_valid_runtime_token() -> None:
     assert not selfheal.valid_runtime_token([1, 2])
 
 
-def test_should_heal_happy_path() -> None:
+def test_should_heal_expired_with_active_entities() -> None:
+    """Estado zumbi: token expirado mas entidades ainda 'ativas' no cache."""
     heal, reason = selfheal.should_heal(
-        EXPIRED_TOKEN, FRESH_TOKEN, entities_active=0, heals_last_24h=0, now_ms=NOW_MS
+        EXPIRED_TOKEN,
+        FRESH_TOKEN,
+        entities_active=75,
+        heals_last_24h=0,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
     )
     assert heal, reason
+    assert "expirado" in reason
+
+
+def test_should_heal_soft_threshold_with_newer_bridge() -> None:
+    heal, reason = selfheal.should_heal(
+        NEAR_EXPIRY_TOKEN,
+        NEWER_RUNTIME,
+        entities_active=75,
+        heals_last_24h=0,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
+    )
+    assert heal, reason
+    assert "expira em" in reason
+
+
+def test_should_heal_soft_skips_when_bridge_not_newer() -> None:
+    heal, reason = selfheal.should_heal(
+        NEAR_EXPIRY_TOKEN,
+        NEAR_EXPIRY_TOKEN,
+        entities_active=75,
+        heals_last_24h=0,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
+    )
+    assert not heal
+    assert "não é mais novo" in reason
+
+
+def test_should_heal_still_valid_above_soft() -> None:
+    heal, reason = selfheal.should_heal(
+        FRESH_TOKEN,
+        NEWER_RUNTIME,
+        entities_active=0,
+        heals_last_24h=0,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
+    )
+    assert not heal
+    assert "ainda válido" in reason
 
 
 @pytest.mark.parametrize(
     ("ha_token", "runtime", "active", "heals", "expected_reason"),
     [
-        (EXPIRED_TOKEN, FRESH_TOKEN, 5, 0, "entidades ativas"),
         (FRESH_TOKEN, FRESH_TOKEN, 0, 0, "ainda válido"),
         (EXPIRED_TOKEN, None, 0, 0, "ausente/inválido"),
         (EXPIRED_TOKEN, EXPIRED_TOKEN, 0, 0, "não é mais novo"),
-        (EXPIRED_TOKEN, FRESH_TOKEN, 0, 3, "rate limit"),
+        (EXPIRED_TOKEN, FRESH_TOKEN, 0, 24, "rate limit"),
     ],
 )
 def test_should_heal_guards(ha_token, runtime, active, heals, expected_reason) -> None:
     heal, reason = selfheal.should_heal(
-        ha_token, runtime, entities_active=active, heals_last_24h=heals, now_ms=NOW_MS
+        ha_token,
+        runtime,
+        entities_active=active,
+        heals_last_24h=heals,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
     )
     assert not heal
     assert expected_reason in reason
@@ -134,3 +202,79 @@ def test_prune_heal_history() -> None:
     now = 1_784_000_000.0
     history = [now - 90_000, now - 3_600, now - 10]
     assert selfheal.prune_heal_history(history, now=now) == [now - 3_600, now - 10]
+
+
+def test_ensure_fresh_runtime_skips_when_ha_has_margin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"n": 0}
+
+    def boom(*_a, **_k):  # noqa: ANN001
+        called["n"] += 1
+        raise AssertionError("não deve refreshar")
+
+    monkeypatch.setattr(selfheal, "force_refresh_token", boom)
+    out = selfheal.ensure_fresh_runtime_token(
+        FRESH_TOKEN, NEWER_RUNTIME, soft_threshold_min=45, now_ms=NOW_MS
+    )
+    assert out == NEWER_RUNTIME
+    assert called["n"] == 0
+
+
+def test_ensure_fresh_runtime_refreshes_when_soft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refreshed = {
+        "access_token": "a-ref",
+        "refresh_token": "r-ref",
+        "expire_time": 7200,
+        "t": NOW_MS + 1_000,
+        "uid": "az1",
+    }
+    persisted: list[dict] = []
+
+    monkeypatch.setattr(
+        selfheal,
+        "load_tuya_entry_meta",
+        lambda: {"user_code": "Ba0osdh", "endpoint": "https://apigw.tuyaus.com"},
+    )
+    monkeypatch.setattr(selfheal, "force_refresh_token", lambda *a, **k: refreshed)
+    monkeypatch.setattr(selfheal, "persist_runtime_token", lambda t: persisted.append(t))
+
+    out = selfheal.ensure_fresh_runtime_token(
+        NEAR_EXPIRY_TOKEN,
+        NEAR_EXPIRY_TOKEN,
+        soft_threshold_min=45,
+        now_ms=NOW_MS,
+    )
+    assert out == refreshed
+    assert persisted == [refreshed]
+
+
+def test_ensure_fresh_uses_existing_newer_runtime_without_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Runtime mais novo com folga > soft — não chama force_refresh.
+    rich_runtime = {
+        "access_token": "a-rich",
+        "refresh_token": "r-rich",
+        "expire_time": 7200,
+        "t": NOW_MS - 5 * 60 * 1000,  # ~115 min remaining
+        "uid": "az1",
+    }
+    monkeypatch.setattr(
+        selfheal,
+        "force_refresh_token",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no refresh")),
+    )
+    out = selfheal.ensure_fresh_runtime_token(
+        NEAR_EXPIRY_TOKEN,
+        rich_runtime,
+        soft_threshold_min=45,
+        now_ms=NOW_MS,
+    )
+    assert out == rich_runtime
+
+
+def test_default_soft_threshold_is_45() -> None:
+    assert selfheal.HEAL_SOFT_THRESHOLD_MIN == 45

--- a/tools/homelab/tuya_token_selfheal.py
+++ b/tools/homelab/tuya_token_selfheal.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
 """Self-heal do token Tuya no Home Assistant.
 
-Quando o refresh token da config entry `tuya` morre, o HA loga
-"could not authenticate" e todas as entidades ficam indisponíveis
-(0/N ativas). O pandaplus-bridge mantém sessão Tuya própria e persiste
-token renovado em /var/lib/pandaplus-bridge/tuya_tokens_runtime.json.
+Quando o access token da config entry `tuya` expira (~2h), o HA entra em
+estado degradado — comandos cloud falham com `sign invalid` / `2001` e o
+MQTT tuya_sharing cai. O pandaplus-bridge mantém sessão própria, mas o SDK
+só renova o token quando faltam <60s; sem intervenção proativa restam
+janelas de 5–15 min com HA sem token válido.
 
-Este script detecta o cenário e aplica a recuperação validada em
-2026-07-06/13/16: backup de core.config_entries, injeção do token_info
-do bridge na entry `tuya` e restart do container do HA. Exporta métricas
-via textfile collector para o painel Grafana "Tuya Token Selfheal".
+Fluxo:
+1. Se o access token (HA ou bridge) está abaixo do limiar soft, **força
+   refresh** via API Tuya Sharing e grava em tuya_tokens_runtime.json.
+2. Se o bridge/runtime ficou mais novo que o HA, injeta no HA:
+   a. **hot** — serviço `tuya_token_inject.apply` (preferido)
+   b. **core_restart** — storage + `homeassistant.restart`
+   c. **docker_restart** — storage + `docker restart` (último recurso)
+
+Exporta métricas via textfile collector.
 """
 
 from __future__ import annotations
@@ -19,13 +25,17 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger("tuya-token-selfheal")
 
 CONTAINER = os.environ.get("HA_CONTAINER", "homeassistant")
+HA_URL = os.environ.get("HA_URL", "http://127.0.0.1:8123").rstrip("/")
 CONFIG_ENTRIES = Path(
     os.environ.get(
         "HA_CONFIG_ENTRIES",
@@ -43,11 +53,31 @@ PROM_FILE = Path(
         "PROM_FILE", "/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom"
     )
 )
-MAX_HEALS_24H = int(os.environ.get("MAX_HEALS_24H", "3"))
+MAX_HEALS_24H = int(os.environ.get("MAX_HEALS_24H", "24"))
 HA_BOOT_WAIT_S = int(os.environ.get("HA_BOOT_WAIT_S", "300"))
+# Tempo de recovery do hot-apply (nome distinto de HA_BOOT_WAIT_S de propósito).
+TUYA_SELFHEAL_HOT_WAIT_S = int(os.environ.get("TUYA_SELFHEAL_HOT_WAIT_S", "90"))
+# Heal proativo quando o access token do HA está prestes a expirar (minutos).
+# 0 = só com token já expirado (remaining <= 0).
+HEAL_SOFT_THRESHOLD_MIN = float(os.environ.get("HEAL_SOFT_THRESHOLD_MIN", "45"))
+# Client ID público da integração Tuya do Home Assistant core.
+TUYA_CLIENT_ID = os.environ.get("TUYA_CLIENT_ID", "HA_3y9q4ak7g4ephrvke")
+# site-packages do venv que tem tuya_sharing (bridge).
+TUYA_SHARING_SITE = Path(
+    os.environ.get(
+        "TUYA_SHARING_SITE",
+        "/home/homelab/myClaude/.venv/lib/python3.12/site-packages",
+    )
+)
 IGNORED_DOMAINS = {"scene"}
 
 REQUIRED_TOKEN_FIELDS = {"access_token", "refresh_token", "expire_time", "t", "uid"}
+
+# Modos exportados em métrica tuya_selfheal_last_mode
+MODE_NONE = 0
+MODE_HOT = 1
+MODE_CORE_RESTART = 2
+MODE_DOCKER_RESTART = 3
 
 
 # ---------------------------------------------------------------- helpers puros
@@ -76,24 +106,242 @@ def should_heal(
     entities_active: int,
     heals_last_24h: int,
     now_ms: float | None = None,
+    soft_threshold_min: float | None = None,
 ) -> tuple[bool, str]:
     """Decide se a injeção do token do bridge deve ser aplicada.
 
-    Conservador de propósito: só age com token do HA expirado, zero
-    entidades ativas e token do bridge estritamente mais novo.
+    Regras (2026-07-23):
+    - Token do HA **expirado** (remaining <= 0): heal **mesmo com entidades
+      ainda "ativas"** — estado zumbi típico (cloud morta, HA cacheia on/off).
+    - Soft threshold (HEAL_SOFT_THRESHOLD_MIN, default 45): heal proativo se
+      remaining estiver abaixo do limiar e o runtime/bridge for mais novo.
+    - Bridge/runtime precisa de token válido e estritamente mais novo (t maior).
+    - Rate limit por 24h.
     """
     now_ms = time.time() * 1000 if now_ms is None else now_ms
-    if entities_active > 0:
-        return False, "entidades ativas > 0"
-    if token_remaining_minutes(ha_token, now_ms) > 0:
+    if soft_threshold_min is None:
+        soft_threshold_min = HEAL_SOFT_THRESHOLD_MIN
+
+    remaining = token_remaining_minutes(ha_token, now_ms)
+
+    # Token saudável: não injeta (hot path é barato, mas refresh desnecessário).
+    if remaining > soft_threshold_min:
         return False, "token do HA ainda válido"
+
     if not valid_runtime_token(runtime_token):
         return False, "token runtime do bridge ausente/inválido"
-    if int(runtime_token["t"]) <= int(ha_token.get("t", 0)):
+    try:
+        bridge_t = int(runtime_token["t"])
+        ha_t = int(ha_token.get("t", 0) or 0)
+    except (TypeError, ValueError):
+        return False, "token runtime do bridge ausente/inválido"
+    if bridge_t <= ha_t:
         return False, "token do bridge não é mais novo que o do HA"
     if heals_last_24h >= MAX_HEALS_24H:
         return False, f"rate limit: {heals_last_24h} heals nas últimas 24h"
-    return True, "token HA expirado + 0 entidades + bridge com token mais novo"
+
+    if remaining <= 0:
+        return (
+            True,
+            f"token HA expirado ({remaining:.0f} min) + bridge mais novo"
+            + (f" | {entities_active} entidades ainda ativas" if entities_active > 0 else ""),
+        )
+
+    # Soft threshold: token ainda válido por poucos minutos.
+    return (
+        True,
+        f"token HA expira em {remaining:.0f} min (<= {soft_threshold_min:.0f}) + bridge mais novo",
+    )
+
+
+def load_tuya_entry_meta() -> dict[str, str]:
+    """Lê user_code e endpoint da entry tuya em core.config_entries (host)."""
+    try:
+        config = json.loads(CONFIG_ENTRIES.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    for entry in config.get("data", {}).get("entries", []):
+        if entry.get("domain") != "tuya":
+            continue
+        data = entry.get("data") or {}
+        return {
+            "user_code": str(data.get("user_code") or ""),
+            "endpoint": str(data.get("endpoint") or "https://apigw.tuyaus.com"),
+        }
+    return {}
+
+
+def _import_tuya_sharing() -> tuple[object, object]:
+    """Importa CustomerApi/CustomerTokenInfo (system ou venv do bridge)."""
+    try:
+        from tuya_sharing.customerapi import CustomerApi, CustomerTokenInfo  # type: ignore
+        return CustomerApi, CustomerTokenInfo
+    except ImportError:
+        site = str(TUYA_SHARING_SITE)
+        if site not in sys.path and TUYA_SHARING_SITE.is_dir():
+            sys.path.insert(0, site)
+        from tuya_sharing.customerapi import CustomerApi, CustomerTokenInfo  # type: ignore
+        return CustomerApi, CustomerTokenInfo
+
+
+def force_refresh_token(
+    token_info: dict,
+    *,
+    user_code: str,
+    endpoint: str,
+    client_id: str = TUYA_CLIENT_ID,
+) -> dict | None:
+    """Força refresh do access token via API Tuya Sharing.
+
+    O SDK só renova com <60s restantes; aqui forçamos expire_time no passado
+    para obter um token novo antes da janela de blackout do HA.
+    """
+    if not valid_runtime_token(token_info) or not user_code:
+        return None
+    try:
+        CustomerApi, CustomerTokenInfo = _import_tuya_sharing()
+    except ImportError as exc:
+        log.warning("tuya_sharing indisponível para refresh proativo: %s", exc)
+        return None
+
+    class _Listener:
+        def __init__(self) -> None:
+            self.updated: dict | None = None
+
+        def update_token(self, new_token: dict) -> None:  # noqa: ANN001
+            self.updated = new_token
+
+    listener = _Listener()
+    try:
+        api = CustomerApi(
+            CustomerTokenInfo(dict(token_info)),
+            client_id,
+            user_code,
+            endpoint.rstrip("/"),
+            listener,
+        )
+        # Força o ramo de refresh em refresh_access_token_if_need().
+        api.token_info.expire_time = int(time.time() * 1000) - 1
+        api.refresh_access_token_if_need()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("force_refresh_token falhou: %s", exc)
+        return None
+
+    if listener.updated and valid_runtime_token(listener.updated):
+        return listener.updated
+
+    # Fallback: montar dict a partir do CustomerTokenInfo interno.
+    try:
+        ti = api.token_info
+        # expire_time no objeto é absoluto (ms); reconverter para o formato storage.
+        now_ms = int(time.time() * 1000)
+        absolute = int(getattr(ti, "expire_time", 0) or 0)
+        # Preferir o payload do listener; se só temos objeto, estimar t.
+        built = {
+            "access_token": getattr(ti, "access_token", ""),
+            "refresh_token": getattr(ti, "refresh_token", ""),
+            "uid": getattr(ti, "uid", token_info.get("uid", "")),
+            "t": now_ms,
+            "expire_time": max(0, (absolute - now_ms) // 1000) or int(token_info.get("expire_time") or 7200),
+        }
+        if valid_runtime_token(built) and built["access_token"] != token_info.get("access_token"):
+            return built
+    except Exception as exc:  # noqa: BLE001
+        log.warning("force_refresh_token parse fallback falhou: %s", exc)
+    return None
+
+
+def persist_runtime_token(token_info: dict) -> None:
+    """Grava token renovado no path do bridge (fonte do heal)."""
+    RUNTIME_TOKENS.parent.mkdir(parents=True, exist_ok=True)
+    tmp = RUNTIME_TOKENS.with_suffix(".tmp")
+    tmp.write_text(json.dumps(token_info, ensure_ascii=True), encoding="utf-8")
+    tmp.replace(RUNTIME_TOKENS)
+    log.info(
+        "runtime token atualizado (t=%s remaining=%.0f min)",
+        token_info.get("t"),
+        token_remaining_minutes(token_info),
+    )
+
+
+def ensure_fresh_runtime_token(
+    ha_token: dict,
+    runtime_token: dict | None,
+    *,
+    soft_threshold_min: float | None = None,
+    now_ms: float | None = None,
+) -> dict | None:
+    """Garante runtime token mais novo que o HA quando restam poucos minutos.
+
+    Retorna o runtime token a usar (pode ser o mesmo de entrada se não
+    precisou/conseguiu renovar).
+    """
+    now_ms = time.time() * 1000 if now_ms is None else now_ms
+    if soft_threshold_min is None:
+        soft_threshold_min = HEAL_SOFT_THRESHOLD_MIN
+
+    ha_remaining = token_remaining_minutes(ha_token, now_ms) if ha_token else -1
+    runtime_remaining = (
+        token_remaining_minutes(runtime_token, now_ms)
+        if valid_runtime_token(runtime_token)
+        else -1
+    )
+
+    # Nada a fazer se o HA ainda tem folga confortável.
+    if ha_remaining > soft_threshold_min:
+        return runtime_token if valid_runtime_token(runtime_token) else None
+
+    # Já temos runtime estritamente mais novo e ainda com vida: usa direto.
+    try:
+        ha_t = int(ha_token.get("t", 0) or 0) if ha_token else 0
+        rt_t = int(runtime_token["t"]) if valid_runtime_token(runtime_token) else 0
+    except (TypeError, ValueError, KeyError):
+        ha_t, rt_t = 0, 0
+    if (
+        valid_runtime_token(runtime_token)
+        and rt_t > ha_t
+        and runtime_remaining > soft_threshold_min
+    ):
+        return runtime_token
+
+    # Escolhe a melhor base para refresh (runtime se existir, senão HA).
+    source: dict | None = None
+    if valid_runtime_token(runtime_token) and runtime_remaining >= ha_remaining:
+        source = runtime_token  # type: ignore[assignment]
+    elif valid_runtime_token(ha_token):
+        source = ha_token
+    elif valid_runtime_token(runtime_token):
+        source = runtime_token  # type: ignore[assignment]
+    else:
+        log.warning("Sem token base válido para refresh proativo")
+        return runtime_token if valid_runtime_token(runtime_token) else None
+
+    meta = load_tuya_entry_meta()
+    user_code = meta.get("user_code") or ""
+    endpoint = meta.get("endpoint") or "https://apigw.tuyaus.com"
+    if not user_code:
+        log.warning("user_code tuya ausente em config_entries — skip refresh proativo")
+        return runtime_token if valid_runtime_token(runtime_token) else None
+
+    log.info(
+        "Refresh proativo Tuya (HA resta %.0f min, runtime resta %.0f min, soft=%.0f)",
+        ha_remaining,
+        runtime_remaining,
+        soft_threshold_min,
+    )
+    refreshed = force_refresh_token(source, user_code=user_code, endpoint=endpoint)
+    if not refreshed:
+        return runtime_token if valid_runtime_token(runtime_token) else None
+
+    try:
+        if int(refreshed["t"]) <= int(source.get("t", 0) or 0):
+            log.warning("Refresh proativo não gerou t mais novo; mantendo runtime atual")
+            return runtime_token if valid_runtime_token(runtime_token) else None
+    except (TypeError, ValueError):
+        pass
+
+    persist_runtime_token(refreshed)
+    return refreshed
 
 
 def inject_token(config: dict, token_info: dict) -> dict:
@@ -114,6 +362,10 @@ def render_prom(metrics: dict[str, float | int]) -> str:
         "tuya_selfheal_last_run_timestamp": ("gauge", "Unix time da última execução"),
         "tuya_selfheal_last_heal_timestamp": ("gauge", "Unix time do último heal"),
         "tuya_selfheal_healthy": ("gauge", "1=integração Tuya saudável no HA"),
+        "tuya_selfheal_last_mode": (
+            "gauge",
+            "Último modo de heal: 0=none 1=hot 2=core_restart 3=docker_restart",
+        ),
         "tuya_token_remaining_minutes": ("gauge", "Minutos até expirar o token da entry tuya no HA"),
         "tuya_bridge_token_remaining_minutes": ("gauge", "Minutos até expirar o token runtime do bridge"),
         "tuya_entities_active": ("gauge", "Entidades Tuya disponíveis no HA"),
@@ -225,30 +477,160 @@ def load_runtime_token() -> dict | None:
     return token if valid_runtime_token(token) else None
 
 
-def apply_heal(runtime_token: dict) -> None:
+def backup_config_entries() -> Path:
     backup = CONFIG_ENTRIES.with_name(
         CONFIG_ENTRIES.name + f".tuya-selfheal-{int(time.time())}.bak"
     )
     shutil.copy2(CONFIG_ENTRIES, backup)
     log.info("Backup criado: %s", backup)
+    return backup
 
+
+def inject_token_to_disk(runtime_token: dict) -> dict:
+    """Persiste token_info em core.config_entries (host mount). Retorna a entry."""
     config = json.loads(CONFIG_ENTRIES.read_text(encoding="utf-8"))
-    inject_token(config, runtime_token)
+    entry = inject_token(config, runtime_token)
     tmp = CONFIG_ENTRIES.with_suffix(".tmp")
     tmp.write_text(json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8")
     shutil.move(tmp, CONFIG_ENTRIES)
-    log.info("token_info injetado (t=%s)", runtime_token["t"])
+    log.info("token_info injetado em disco (t=%s)", runtime_token["t"])
+    return entry
 
+
+def ha_long_lived_jwt() -> str:
+    """JWT de short-lived a partir do long-lived access token do HA (no container)."""
+    script = (
+        "import json,jwt,time\n"
+        "a=json.load(open('/config/.storage/auth'))\n"
+        "tok=next(t for t in a['data']['refresh_tokens']\n"
+        "         if t.get('token_type')=='long_lived_access_token')\n"
+        "print(jwt.encode({'iss':tok['id'],'iat':int(time.time()),\n"
+        "                  'exp':int(time.time())+300},tok['jwt_key'],algorithm='HS256'))\n"
+    )
+    return docker_py(script)
+
+
+def ha_api_request(
+    path: str,
+    *,
+    method: str = "GET",
+    body: dict | None = None,
+    timeout: int = 60,
+) -> tuple[int, str]:
+    """Chama API local do HA; retorna (status_http, body_text)."""
+    jwt_str = ha_long_lived_jwt()
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{HA_URL}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {jwt_str}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace") if exc.fp else ""
+        return exc.code, detail
+    except urllib.error.URLError as exc:
+        # HA fechou a conexão no restart — esperado.
+        return 0, str(exc.reason if hasattr(exc, "reason") else exc)
+
+
+def ha_service_available(domain: str, service: str) -> bool:
+    code, body = ha_api_request("/api/services")
+    if code != 200:
+        return False
+    try:
+        services = json.loads(body)
+    except ValueError:
+        return False
+    for block in services:
+        if block.get("domain") == domain and service in (block.get("services") or {}):
+            return True
+    return False
+
+
+def apply_heal_hot(runtime_token: dict) -> bool:
+    """Atualiza entry em memória via custom component (sem restart)."""
+    if not ha_service_available("tuya_token_inject", "apply"):
+        log.info("Serviço tuya_token_inject.apply indisponível — hot path skip")
+        return False
+    code, body = ha_api_request(
+        "/api/services/tuya_token_inject/apply",
+        method="POST",
+        body={"token_info": runtime_token},
+        timeout=120,
+    )
+    if code not in (200, 201):
+        log.warning("hot apply HTTP %s: %s", code, body[:300])
+        return False
+    log.info("hot apply OK (tuya_token_inject.apply, t=%s)", runtime_token["t"])
+    return True
+
+
+def apply_heal_core_restart(runtime_token: dict) -> bool:
+    """Grava storage e reinicia só o core do HA (container permanece)."""
+    inject_token_to_disk(runtime_token)
+    code, body = ha_api_request(
+        "/api/services/homeassistant/restart",
+        method="POST",
+        body={},
+        timeout=30,
+    )
+    # HA pode fechar a conexão ao reiniciar (HTTPError / URLError)
+    if code in (200, 201, 500, 502, 503, 504) or code == 0:
+        log.info("homeassistant.restart solicitado (http=%s)", code)
+        return True
+    log.warning("core restart HTTP %s: %s", code, body[:200])
+    return False
+
+
+def apply_heal_docker_restart(runtime_token: dict) -> None:
+    """Último recurso: grava storage + docker restart."""
+    inject_token_to_disk(runtime_token)
     subprocess.run(["docker", "restart", CONTAINER], check=True, timeout=180)
-    log.info("Container %s reiniciado; aguardando boot", CONTAINER)
+    log.info("Container %s reiniciado (docker restart)", CONTAINER)
 
 
-def wait_recovery(deadline_s: int = HA_BOOT_WAIT_S) -> int:
-    """Aguarda o HA subir e retorna a contagem de entidades ativas."""
+def apply_heal(runtime_token: dict) -> int:
+    """Aplica heal e retorna MODE_* usado (antes de validar recovery)."""
+    backup_config_entries()
+
+    # 1) Hot — preferido
+    try:
+        if apply_heal_hot(runtime_token):
+            # Também espelha em disco para consistência (update_entry já grava;
+            # disco host pode estar um tick atrás se o serviço falhar no meio).
+            try:
+                inject_token_to_disk(runtime_token)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("Espelho em disco após hot falhou (não-fatal): %s", exc)
+            return MODE_HOT
+    except Exception as exc:  # noqa: BLE001
+        log.warning("hot path falhou: %s", exc)
+
+    # 2) Core restart
+    try:
+        if apply_heal_core_restart(runtime_token):
+            return MODE_CORE_RESTART
+    except Exception as exc:  # noqa: BLE001
+        log.warning("core_restart path falhou: %s", exc)
+
+    # 3) Docker restart
+    apply_heal_docker_restart(runtime_token)
+    return MODE_DOCKER_RESTART
+
+
+def wait_recovery(deadline_s: int = HA_BOOT_WAIT_S, poll_s: int = 5) -> int:
+    """Aguarda entidades Tuya voltarem; retorna contagem de ativas."""
     start = time.time()
     active = 0
     while time.time() - start < deadline_s:
-        time.sleep(20)
+        time.sleep(poll_s)
         try:
             active = ha_tuya_status()["entities_active"]
         except Exception:  # noqa: BLE001 - HA ainda subindo
@@ -256,6 +638,14 @@ def wait_recovery(deadline_s: int = HA_BOOT_WAIT_S) -> int:
         if active > 0:
             break
     return active
+
+
+def wait_recovery_for_mode(mode: int) -> int:
+    if mode == MODE_HOT:
+        return wait_recovery(deadline_s=TUYA_SELFHEAL_HOT_WAIT_S, poll_s=3)
+    if mode == MODE_CORE_RESTART:
+        return wait_recovery(deadline_s=min(HA_BOOT_WAIT_S, 180), poll_s=5)
+    return wait_recovery(deadline_s=HA_BOOT_WAIT_S, poll_s=10)
 
 
 # ------------------------------------------------------------------------ main
@@ -312,6 +702,13 @@ def main() -> int:
 
     ha_token = status.get("token_info") or {}
 
+    # Antes de decidir heal: renova o runtime token se o HA está na janela soft.
+    # Isso elimina a dependência de o SDK do bridge renovar só com <60s.
+    try:
+        runtime_token = ensure_fresh_runtime_token(ha_token, runtime_token) or runtime_token
+    except Exception as exc:  # noqa: BLE001
+        log.warning("ensure_fresh_runtime_token falhou (não-fatal): %s", exc)
+
     heal, reason = should_heal(
         ha_token, runtime_token, status["entities_active"], len(state["heal_history"])
     )
@@ -321,26 +718,43 @@ def main() -> int:
         token_remaining_minutes(ha_token), heal, reason,
     )
 
+    last_mode = int(state.get("last_mode", MODE_NONE))
     if heal:
         try:
-            apply_heal(runtime_token)
-            active = wait_recovery()
+            last_mode = apply_heal(runtime_token)
+            state["last_mode"] = last_mode
+            active = wait_recovery_for_mode(last_mode)
             if active > 0:
                 state["heals_total"] += 1
                 state["last_heal_timestamp"] = int(time.time())
                 state["heal_history"].append(time.time())
                 status = ha_tuya_status_with_retry() or status
                 ha_token = status.get("token_info") or {}
-                log.info("Heal OK: %s entidades ativas", active)
+                mode_name = {
+                    MODE_HOT: "hot",
+                    MODE_CORE_RESTART: "core_restart",
+                    MODE_DOCKER_RESTART: "docker_restart",
+                }.get(last_mode, str(last_mode))
+                log.info(
+                    "Heal OK (%s): %s entidades ativas | token resta %.0f min",
+                    mode_name,
+                    active,
+                    token_remaining_minutes(ha_token),
+                )
             else:
                 state["heal_failures_total"] += 1
-                log.error("Heal aplicado mas entidades não voltaram — reauth QR necessária")
+                log.error(
+                    "Heal aplicado (mode=%s) mas entidades não voltaram — reauth QR necessária",
+                    last_mode,
+                )
         except Exception:  # noqa: BLE001
             state["heal_failures_total"] += 1
             log.exception("Heal falhou")
 
     save_state(state)
-    healthy = int(status["entities_active"] > 0)
+    ha_remaining = token_remaining_minutes(ha_token)
+    # Saudável = entidades respondendo E access token ainda válido.
+    healthy = int(status["entities_active"] > 0 and ha_remaining > 0)
     write_prom({
         "tuya_selfheal_runs_total": state["runs_total"],
         "tuya_selfheal_heals_total": state["heals_total"],
@@ -349,13 +763,21 @@ def main() -> int:
         "tuya_selfheal_last_run_timestamp": int(time.time()),
         "tuya_selfheal_last_heal_timestamp": state["last_heal_timestamp"],
         "tuya_selfheal_healthy": healthy,
-        "tuya_token_remaining_minutes": round(token_remaining_minutes(ha_token), 1),
+        "tuya_selfheal_last_mode": int(state.get("last_mode", MODE_NONE)),
+        "tuya_token_remaining_minutes": round(ha_remaining, 1),
         "tuya_bridge_token_remaining_minutes": round(
             token_remaining_minutes(runtime_token) if runtime_token else -1, 1
         ),
         "tuya_entities_active": status["entities_active"],
         "tuya_entities_total": status["entities_total"],
     })
+    if not healthy and not heal:
+        log.warning(
+            "Tuya degradado sem heal: ativas=%s remaining=%.0f min reason_last=%s",
+            status["entities_active"],
+            ha_remaining,
+            reason,
+        )
     return 0 if healthy else 1
 
 


### PR DESCRIPTION
## Summary
- Força refresh do access token Tuya via Sharing API quando restam ≤45 min (o SDK do bridge só renova com <60s).
- Injeta no HA via hot-apply (`tuya_token_inject`), com fallback core/docker restart.
- Timer do selfheal: 15 min → **5 min**; `MAX_HEALS_24H=24`.
- Sincroniza o script do repo com a versão avançada já em produção (hot path + entidades zumbi).

## Context
Investigação de latência/falhas intermitentes no HA: API local OK (~1–14 ms); falhas cloud com `sign invalid` / `2001` em janelas recorrentes a cada ~2h enquanto o token ficava expirado e o selfheal só agia reativamente.

## Test plan
- [x] `pytest tests/test_tuya_token_selfheal.py` (21 passed)
- [ ] Deploy workflow `deploy-tuya-token-selfheal` no self-hosted
- [ ] Smoke: `systemctl start tuya-token-selfheal.service` + métricas prom
- [ ] Confirmar timer `OnUnitActiveSec=5min` e log sem janela de token negativo