### PR TITLE
fix(pandaplus-bridge): watchdog reinicia processo se sessão Tuya travar em erro

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,6 +1,6 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-23T16:36:25.115514",
+  "generatedAt": "2026-07-23T21:40:18.258191",
   "environment": "production",
   "categories": {
     "services": {
@@ -327,10 +327,10 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-postfix",
-          "mailu-roundcube",
           "mailu-frontend",
           "mailu-dovecot",
+          "mailu-roundcube",
+          "mailu-postfix",
           "mailu-backend"
         ]
       },
@@ -748,8 +748,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_BASE_PATH:-}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "NETBOX_LOGIN_REQUIRED": {
@@ -1432,10 +1432,10 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
-          "glpi",
-          "glpi-db",
           "grafana",
-          "netbox-postgres"
+          "glpi",
+          "netbox-postgres",
+          "glpi-db"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -1579,8 +1579,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_ALLOWED_HOSTS:-*}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "CORS_ORIGIN_ALLOW_ALL": {
@@ -1589,8 +1589,8 @@
         "source": "docker-compose",
         "value": "True",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "CSRF_TRUSTED_ORIGINS": {
@@ -1599,8 +1599,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_FROM": {
@@ -1609,8 +1609,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_PORT": {
@@ -1619,8 +1619,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_PORT:-25}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_SERVER": {
@@ -1629,8 +1629,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_SERVER:-localhost}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_TIMEOUT": {
@@ -1639,8 +1639,8 @@
         "source": "docker-compose",
         "value": "5",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_USE_SSL": {
@@ -1649,8 +1649,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_SSL:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_USE_TLS": {
@@ -1659,8 +1659,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_TLS:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "GRAPHQL_ENABLED": {
@@ -1669,8 +1669,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "LOGIN_REQUIRED": {
@@ -1679,8 +1679,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGIN_REQUIRED:-true}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "LOGOUT_REDIRECT_URL": {
@@ -1689,8 +1689,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "METRICS_ENABLED": {
@@ -1699,8 +1699,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_EMAIL": {
@@ -1709,8 +1709,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_NAME": {
@@ -1719,8 +1719,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SKIP_SUPERUSER": {
@@ -1729,8 +1729,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SKIP_SUPERUSER:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "TIME_ZONE": {
@@ -1739,8 +1739,8 @@
         "source": "docker-compose",
         "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "BAUDRATE": {
@@ -1794,34 +1794,34 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "ollama-gpu-coordinator",
-          "candle-collector",
-          "daily-agenda-broadcast",
-          "eddie-calendar",
-          "daily-agenda-panel",
-          "kucoin-usdt-rebalance",
+          "diretor",
           "marketing-api",
           "notebook-power-agent",
+          "ollama-gpu-coordinator",
           "trading-analyst-weekly-retrain",
-          "diretor",
-          "bn-acervo-agent",
-          "marketing-daily-report",
-          "meeting-translator",
-          "kucoin-postgres-sync",
-          "rss-sentiment-exporter",
-          "banking-metrics-exporter",
-          "trading-daily-report",
-          "crypto-agent@",
-          "eddie-telegram-bot",
-          "decisions-track-record-rollup",
-          "marketing-x-posts",
-          "clear-trading-agent",
-          "coordinator",
-          "tape-component-quality-exporter",
           "agent-network-exporter",
+          "eddie-calendar",
+          "rss-sentiment-exporter",
           "marketing-email-drip",
           "approval-gateway",
-          "eddie-expurgo"
+          "eddie-telegram-bot",
+          "marketing-daily-report",
+          "coordinator",
+          "crypto-agent@",
+          "decisions-track-record-rollup",
+          "marketing-x-posts",
+          "trading-daily-report",
+          "eddie-expurgo",
+          "candle-collector",
+          "daily-agenda-broadcast",
+          "meeting-translator",
+          "tape-component-quality-exporter",
+          "kucoin-postgres-sync",
+          "banking-metrics-exporter",
+          "daily-agenda-panel",
+          "kucoin-usdt-rebalance",
+          "clear-trading-agent",
+          "bn-acervo-agent"
         ]
       },
       "PYTHONPATH": {
@@ -1830,17 +1830,17 @@
         "source": "systemd",
         "value": "/home/homelab/eddie-auto-dev",
         "contexts": [
-          "tape-component-quality-exporter",
           "ollama-finetune",
-          "candle-collector",
-          "marketing-daily-report",
+          "marketing-api",
           "rss-sentiment-exporter",
-          "decisions-track-record-rollup",
-          "marketing-email-drip",
-          "marketing-x-posts",
-          "clear-trading-agent",
           "llm-log-panel",
-          "marketing-api"
+          "marketing-email-drip",
+          "marketing-daily-report",
+          "candle-collector",
+          "decisions-track-record-rollup",
+          "clear-trading-agent",
+          "marketing-x-posts",
+          "tape-component-quality-exporter"
         ]
       },
       "X_AGENT_URL": {
@@ -1904,10 +1904,10 @@
         "value": "1",
         "contexts": [
           "ollama-finetune",
-          "candle-collector",
-          "decisions-track-record-rollup",
           "rss-sentiment-exporter",
-          "llm-log-panel"
+          "llm-log-panel",
+          "candle-collector",
+          "decisions-track-record-rollup"
         ]
       },
       "HOME": {
@@ -1916,12 +1916,12 @@
         "source": "systemd",
         "value": "/apps/crypto-trader",
         "contexts": [
-          "crypto-agent@",
           "ollama-finetune",
-          "candle-collector",
-          "decisions-track-record-rollup",
           "rss-sentiment-exporter",
-          "llm-log-panel"
+          "llm-log-panel",
+          "candle-collector",
+          "crypto-agent@",
+          "decisions-track-record-rollup"
         ]
       },
       "PATH": {
@@ -1930,16 +1930,16 @@
         "source": "systemd",
         "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "contexts": [
-          "specialized_agents-dashboard",
           "homelab-dashboard",
-          "crypto-agent@",
-          "tape-component-quality-exporter",
-          "github-agent",
-          "eddie-whatsapp-bot",
-          "kucoin-usdt-rebalance",
           "kucoin-postgres-sync",
-          "rpa4all-validation",
-          "job-monitor"
+          "specialized_agents-dashboard",
+          "eddie-whatsapp-bot",
+          "github-agent",
+          "crypto-agent@",
+          "kucoin-usdt-rebalance",
+          "job-monitor",
+          "tape-component-quality-exporter",
+          "rpa4all-validation"
         ]
       },
       "CHECK_INTERVAL": {
@@ -2034,8 +2034,8 @@
         "source": "systemd",
         "value": "config_%I.json",
         "contexts": [
-          "clear-agent@",
-          "clear-trading-agent"
+          "clear-trading-agent",
+          "clear-agent@"
         ]
       },
       "ROUTE_NAME": {
@@ -2073,8 +2073,8 @@
         "source": "systemd",
         "value": "http://localhost:3004",
         "contexts": [
-          "eddie-expurgo",
-          "eddie-whatsapp-bot"
+          "eddie-whatsapp-bot",
+          "eddie-expurgo"
         ]
       },
       "ADMIN_NUMBERS": {
@@ -2344,8 +2344,8 @@
         "source": "systemd",
         "value": "0",
         "contexts": [
-          "ollama-finetune",
-          "ollama-gpu1"
+          "ollama-gpu1",
+          "ollama-finetune"
         ]
       },
       "PYTORCH_CUDA_ALLOC_CONF": {
@@ -2372,8 +2372,8 @@
         "source": "systemd",
         "value": "948686300",
         "contexts": [
-          "eddie-expurgo",
-          "eddie-calendar"
+          "eddie-calendar",
+          "eddie-expurgo"
         ]
       },
       "ADMIN_PHONE": {
@@ -2823,8 +2823,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "configure_diretor_model",
-          "config"
+          "config",
+          "configure_diretor_model"
         ]
       },
       "HOMELAB_USER": {
@@ -2977,11 +2977,12 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_INTERVAL": {
@@ -2990,11 +2991,12 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_EXPR": {
@@ -3003,10 +3005,11 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -3015,11 +3018,12 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SEVERITY": {
@@ -3028,11 +3032,12 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_COMPONENT": {
@@ -3050,11 +3055,12 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -3063,11 +3069,12 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -3094,10 +3101,11 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -3106,11 +3114,12 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_SEVERITY": {
@@ -3119,11 +3128,12 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_COMPONENT": {
@@ -3141,11 +3151,12 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -3154,11 +3165,12 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_ACTION": {
@@ -3185,10 +3197,10 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -3197,11 +3209,11 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_SEVERITY": {
@@ -3210,11 +3222,11 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_COMPONENT": {
@@ -3232,11 +3244,11 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -3245,11 +3257,11 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "selfhealing_rules",
-          "rules",
           "alert_rules",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DASHBOARD": {
@@ -3267,10 +3279,10 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -3279,10 +3291,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -3291,10 +3303,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -3312,10 +3324,10 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -3324,10 +3336,10 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -3345,9 +3357,9 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_FOR": {
@@ -3356,9 +3368,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -3367,9 +3379,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -3387,9 +3399,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -3398,9 +3410,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -3418,8 +3430,8 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_FOR": {
@@ -3428,9 +3440,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -3439,9 +3451,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -3459,9 +3471,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -3470,9 +3482,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -3490,8 +3502,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "GLOBAL_EVALUATION_INTERVAL": {
@@ -3500,8 +3512,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_0_JOB_NAME": {
@@ -3510,8 +3522,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_JOB_NAME": {
@@ -3520,8 +3532,8 @@
         "source": "yaml",
         "value": "node-exporter",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_STATIC_CONFIGS_0_LABELS_INSTANCE": {
@@ -3539,8 +3551,8 @@
         "source": "yaml",
         "value": "cadvisor",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_2_SCRAPE_INTERVAL": {
@@ -3567,8 +3579,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_INTERVAL": {
@@ -3577,8 +3589,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_TIMEOUT": {
@@ -3596,8 +3608,8 @@
         "source": "yaml",
         "value": "btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -3624,8 +3636,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_INTERVAL": {
@@ -3634,8 +3646,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_TIMEOUT": {
@@ -3653,8 +3665,8 @@
         "source": "yaml",
         "value": "btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -4627,8 +4639,8 @@
         "value": "trading_agent_alerts",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -4638,8 +4650,8 @@
         "value": "15s",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -4659,8 +4671,8 @@
         "value": "3m",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -4670,8 +4682,8 @@
         "value": "critical",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -4690,8 +4702,8 @@
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -4701,8 +4713,8 @@
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -4731,8 +4743,8 @@
         "value": "5m",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -4742,8 +4754,8 @@
         "value": "warning",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -4762,8 +4774,8 @@
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -4773,8 +4785,8 @@
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -4803,8 +4815,8 @@
         "value": "3m",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -4814,8 +4826,8 @@
         "value": "warning",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -4834,8 +4846,8 @@
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -4845,8 +4857,8 @@
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
           "selfhealing_rules",
-          "alert_rules",
-          "rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -5457,6 +5469,7 @@
         "source": "yaml",
         "value": "selfheal",
         "contexts": [
+          "pandaplus_bridge_rules",
           "selfhealing_rules"
         ]
       },
@@ -5475,6 +5488,7 @@
         "source": "yaml",
         "value": "notify",
         "contexts": [
+          "pandaplus_bridge_rules",
           "selfhealing_rules"
         ]
       },
@@ -5601,8 +5615,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -5611,8 +5625,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -5621,8 +5635,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -5631,8 +5645,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -5641,8 +5655,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -5651,8 +5665,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -5670,8 +5684,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -5680,8 +5694,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -5690,8 +5704,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -5700,8 +5714,8 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -5710,8 +5724,26 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
+        ]
+      },
+      "GROUPS_0_RULES_0_LABELS_SERVICE": {
+        "name": "GROUPS_0_RULES_0_LABELS_SERVICE",
+        "type": "string",
+        "source": "yaml",
+        "value": "pandaplus-bridge",
+        "contexts": [
+          "pandaplus_bridge_rules"
+        ]
+      },
+      "GROUPS_0_RULES_1_LABELS_SERVICE": {
+        "name": "GROUPS_0_RULES_1_LABELS_SERVICE",
+        "type": "string",
+        "source": "yaml",
+        "value": "pandaplus-bridge",
+        "contexts": [
+          "pandaplus_bridge_rules"
         ]
       },
       "APIVERSION": {
@@ -5720,12 +5752,12 @@
         "source": "yaml",
         "value": "1",
         "contexts": [
-          "authentik-http",
-          "datasources",
+          "contactpoints",
           "dashboards",
-          "rules",
           "policies",
-          "contactpoints"
+          "rules",
+          "authentik-http",
+          "datasources"
         ]
       },
       "POLICIES_0_ORGID": {
@@ -14905,8 +14937,8 @@
         "source": "yaml",
         "value": "Prometheus",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_UID": {
@@ -14915,8 +14947,8 @@
         "source": "yaml",
         "value": "dfc0w4yioe4u8e",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_TYPE": {
@@ -14925,8 +14957,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ACCESS": {
@@ -14935,8 +14967,8 @@
         "source": "yaml",
         "value": "proxy",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ORGID": {
@@ -14954,8 +14986,8 @@
         "source": "yaml",
         "value": "http://prometheus:9090",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ISDEFAULT": {
@@ -14964,8 +14996,8 @@
         "source": "yaml",
         "value": "True",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_JSONDATA_TIMEINTERVAL": {
@@ -14983,8 +15015,8 @@
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_1_NAME": {
@@ -15832,8 +15864,8 @@
         "value": "curiosidades",
         "contexts": [
           "cripto",
-          "curiosidades",
-          "viral_trends"
+          "viral_trends",
+          "curiosidades"
         ]
       },
       "TITLE_TEMPLATE": {
@@ -15843,8 +15875,8 @@
         "value": "Voc\u00ea sabia? {trend_title}",
         "contexts": [
           "cripto",
-          "curiosidades",
-          "viral_trends"
+          "viral_trends",
+          "curiosidades"
         ]
       },
       "SCRIPT_TEMPLATE": {
@@ -15854,8 +15886,8 @@
         "value": "Hook: Em 60 segundos voc\u00ea vai entender {trend_title}.\nFato 1: Um detalhe pouco conhecido que muda a forma de ver o assunto.\nFato 2: Por que isso viraliza agora ({tags}).\nFechamento: Curiosidade pr\u00e1tica para compartilhar hoje.\n",
         "contexts": [
           "cripto",
-          "curiosidades",
-          "viral_trends"
+          "viral_trends",
+          "curiosidades"
         ]
       },
       "CTA_TEMPLATE": {
@@ -15865,8 +15897,8 @@
         "value": "Comenta qual curiosidade voc\u00ea quer no pr\u00f3ximo v\u00eddeo!",
         "contexts": [
           "cripto",
-          "curiosidades",
-          "viral_trends"
+          "viral_trends",
+          "curiosidades"
         ]
       },
       "NAME": {
@@ -16034,8 +16066,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "NEXTCLOUD_ADMIN_PASSWORD": {
@@ -16101,10 +16133,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-postfix",
-          "mailu-roundcube",
           "mailu-frontend",
           "mailu-dovecot",
+          "mailu-roundcube",
+          "mailu-postfix",
           "mailu-backend"
         ]
       },
@@ -16580,11 +16612,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-postgres",
+          "wikijs-db",
           "mailu-db",
+          "netbox-postgres",
           "mail-db",
-          "postgres",
-          "wikijs-db"
+          "postgres"
         ]
       },
       "ROUNDCUBEMAIL_DB_PASSWORD": {
@@ -16719,8 +16751,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_PASSWORD": {
@@ -16729,8 +16761,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
           "netbox",
+          "netbox-worker",
           "netbox-redis-cache",
           "netbox-redis"
         ]
@@ -16741,8 +16773,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_ENABLED": {
@@ -16751,8 +16783,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_HEADER": {
@@ -16761,8 +16793,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_SEPARATOR": {
@@ -16771,8 +16803,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_SYNC_ENABLED": {
@@ -16781,8 +16813,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_HEADER": {
@@ -16791,8 +16823,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_STAFF_GROUPS": {
@@ -16801,8 +16833,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_SUPERUSER_GROUPS": {
@@ -16811,8 +16843,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_USER_EMAIL": {
@@ -16821,8 +16853,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SECRET_KEY": {
@@ -16831,8 +16863,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_PASSWORD": {
@@ -16841,8 +16873,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "MARIADB_PASSWORD": {
@@ -17269,9 +17301,9 @@
         "source": "docker-compose",
         "value": "wikijs-db",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "DB_PORT": {
@@ -17289,9 +17321,9 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "DB_NAME": {
@@ -17300,9 +17332,9 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "MAILU_DATABASE_URL": {
@@ -17459,11 +17491,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "netbox-postgres",
+          "wikijs-db",
           "mailu-db",
+          "netbox-postgres",
           "mail-db",
-          "postgres",
-          "wikijs-db"
+          "postgres"
         ]
       },
       "POSTGRES_USER": {
@@ -17472,11 +17504,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "netbox-postgres",
+          "wikijs-db",
           "mailu-db",
+          "netbox-postgres",
           "mail-db",
-          "postgres",
-          "wikijs-db"
+          "postgres"
         ]
       },
       "ROUNDCUBEMAIL_DB_TYPE": {
@@ -17612,8 +17644,8 @@
         "source": "docker-compose",
         "value": "1",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_CACHE_HOST": {
@@ -17622,8 +17654,8 @@
         "source": "docker-compose",
         "value": "netbox-redis-cache",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_DATABASE": {
@@ -17632,8 +17664,8 @@
         "source": "docker-compose",
         "value": "0",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_HOST": {
@@ -17642,8 +17674,8 @@
         "source": "docker-compose",
         "value": "netbox-redis",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "MARIADB_DATABASE": {
@@ -17918,8 +17950,8 @@
         "source": "systemd",
         "value": "/apps/crypto-trader/trading/btc_trading_agent",
         "contexts": [
-          "kucoin-postgres-sync",
-          "kucoin-usdt-rebalance"
+          "kucoin-usdt-rebalance",
+          "kucoin-postgres-sync"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_COIN": {
@@ -18248,8 +18280,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "GITHUB_AGENT_URL": {
@@ -18420,10 +18452,11 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -18432,10 +18465,11 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "pandaplus_bridge_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -18444,10 +18478,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -18456,9 +18490,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "alert_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ALERT": {
@@ -18467,8 +18501,8 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ALERT": {
@@ -18477,8 +18511,8 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_1_RULES_0_ALERT": {
@@ -18569,7 +18603,7 @@
     }
   },
   "metadata": {
-    "totalVariables": 1955,
+    "totalVariables": 1957,
     "sourceFiles": [
       ".env",
       ".env.openai-compatible.example",
@@ -18720,6 +18754,7 @@
       "tools/alerting/alertmanager_telegram.yml",
       "monitoring/prometheus/selfhealing_rules.yml",
       "monitoring/prometheus/ltfs-selfheal-rules.yml",
+      "monitoring/prometheus/pandaplus_bridge_rules.yml",
       "monitoring/grafana/provisioning/datasources.yml",
       "monitoring/grafana/provisioning/alerting/policies.yml",
       "monitoring/grafana/provisioning/alerting/rules.yml",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-23T19:37:11.312693+00:00",
+  "generated_at": "2026-07-24T00:40:48.674610+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-23T19:37:11.312693+00:00`
+- Generated at: `2026-07-24T00:40:48.674610+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/docs/variables-taxonomy/PANDAPLUS_BRIDGE_WATCHDOG.md
+++ b/docs/variables-taxonomy/PANDAPLUS_BRIDGE_WATCHDOG.md
@@ -1,0 +1,23 @@
+# PandaPlus Bridge — Watchdog da sessão Tuya
+
+Serviço: `pandaplus-telegram-bridge.service` — módulo
+`tools/pandaplus_bridge/bridge.py`, instalado no homelab (192.168.15.2).
+
+O `_tuya_supervisor_loop` faz retry interno infinito quando a sessão Tuya
+falha (ex.: `sign invalid`), o que nunca deixa o processo terminar — logo
+`Restart=on-failure` do systemd nunca dispara e o bridge pode ficar preso em
+loop por horas sem alertar ninguém (incidentes 2026-07-22 e 2026-07-23,
+ver `feedback_tuya_signinvalid_manual_selfheal` e
+`project_ha_quarto_scene_tuya_chain_20260722` na memória do agente).
+
+O watchdog abaixo faz o processo encerrar com falha (exit != 0) quando a
+sessão Tuya passa tempo demais indisponível, para o systemd reiniciar de
+verdade (o que também reexecuta o `ExecStartPre` que recopia
+`core.config_entries` fresco do container do HA). Métricas de saúde são
+exportadas via textfile collector para permitir alerta no Grafana antes que
+o watchdog precise agir.
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `PANDAPLUS_BRIDGE_TUYA_MAX_UNHEALTHY_SECONDS` | `600` | Tempo máximo (s) que a sessão Tuya pode ficar sem sucesso (connect/session_check) antes do processo encerrar com falha para o systemd reiniciar. |
+| `PANDAPLUS_BRIDGE_PROM_FILE` | `/var/lib/prometheus/node-exporter/pandaplus_bridge.prom` | Saída textfile collector com `pandaplus_bridge_tuya_session_healthy`, `pandaplus_bridge_tuya_last_success_timestamp` e `pandaplus_bridge_tuya_consecutive_failures`. |

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,6 +4,8 @@ global:
 
 rule_files:
   - 'prometheus/ltfs-selfheal-rules.yml'
+  - 'prometheus/gpu_coord_failover_rules.yml'
+  - 'prometheus/pandaplus_bridge_rules.yml'
 # selfhealing_rules.yml e alerts.yml desabilitados: contêm PromQL inválido (for: dentro de expr)
 
 alerting:

--- a/monitoring/prometheus/pandaplus_bridge_rules.yml
+++ b/monitoring/prometheus/pandaplus_bridge_rules.yml
@@ -1,0 +1,31 @@
+groups:
+  - name: pandaplus_bridge_tuya
+    interval: 30s
+    rules:
+      # Sessão Tuya do bridge presa em erro (ex.: "sign invalid") há muito
+      # tempo. O watchdog interno do bridge.py derruba o processo em 600s
+      # (default) para o systemd reiniciar sozinho — este alerta serve para
+      # avisar bem antes disso, e para detectar se o watchdog também travou
+      # (métrica parada de atualizar).
+      - alert: PandaplusBridgeTuyaSessionUnhealthy
+        expr: pandaplus_bridge_tuya_session_healthy == 0
+        for: 5m
+        labels:
+          severity: warning
+          action: notify
+          service: pandaplus-bridge
+        annotations:
+          summary: "Sessão Tuya do pandaplus-bridge indisponível há > 5min"
+          description: "Sessão Tuya do bridge sem sucesso há mais de 5min. Watchdog interno reinicia o processo automaticamente em até 10min; se persistir, checar journalctl -u pandaplus-telegram-bridge.service."
+
+      # Métrica parou de atualizar — processo morreu e não voltou.
+      - alert: PandaplusBridgeMetricsStale
+        expr: (time() - pandaplus_bridge_last_check_timestamp) > 300
+        for: 2m
+        labels:
+          severity: critical
+          action: escalate
+          service: pandaplus-bridge
+        annotations:
+          summary: "pandaplus-bridge sem heartbeat há > 5min"
+          description: "Métricas do bridge pararam de atualizar — processo pode estar morto sem o systemd ter reiniciado. Verificar systemctl status pandaplus-telegram-bridge.service."

--- a/tests/unit/test_pandaplus_bridge.py
+++ b/tests/unit/test_pandaplus_bridge.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tools.pandaplus_bridge import bridge as bridge_module
 from tools.pandaplus_bridge.bridge import (
     DOOR_ALARM_VALUES,
     RELEVANT_CODES,
@@ -687,3 +688,62 @@ def test_coerce_int() -> None:
     assert PandaplusBridge._coerce_int("17") == 17
     assert PandaplusBridge._coerce_int("nope") == 0
     assert PandaplusBridge._coerce_int(None) == 0
+
+
+def test_record_tuya_success_resets_failure_state(
+    mock_bridge: PandaplusBridge, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bridge_module, "PROM_FILE", tmp_path / "bridge.prom")
+    mock_bridge._tuya_consecutive_failures = 3
+    mock_bridge._tuya_last_healthy_ts = 0.0
+
+    mock_bridge._record_tuya_success()
+
+    assert mock_bridge._tuya_consecutive_failures == 0
+    assert mock_bridge._tuya_last_healthy_ts > 0
+    prom_content = (tmp_path / "bridge.prom").read_text(encoding="utf-8")
+    assert "pandaplus_bridge_tuya_session_healthy 1" in prom_content
+
+
+def test_record_tuya_failure_below_threshold_does_not_raise(
+    mock_bridge: PandaplusBridge, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bridge_module, "PROM_FILE", tmp_path / "bridge.prom")
+    mock_bridge._tuya_last_healthy_ts = time.time()
+
+    mock_bridge._record_tuya_failure()  # não deve levantar
+
+    assert mock_bridge._tuya_consecutive_failures == 1
+    prom_content = (tmp_path / "bridge.prom").read_text(encoding="utf-8")
+    assert "pandaplus_bridge_tuya_session_healthy 0" in prom_content
+
+
+def test_record_tuya_failure_above_threshold_raises_stuck_error(
+    mock_bridge: PandaplusBridge, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(bridge_module, "PROM_FILE", tmp_path / "bridge.prom")
+    # sessão saudável pela última vez bem além do limite configurado
+    mock_bridge._tuya_last_healthy_ts = (
+        time.time() - bridge_module.TUYA_UNHEALTHY_RESTART_SECONDS - 1
+    )
+
+    with pytest.raises(bridge_module.TuyaSessionStuckError):
+        mock_bridge._record_tuya_failure()
+
+
+@pytest.mark.asyncio
+async def test_tuya_supervisor_loop_propagates_stuck_error(
+    mock_bridge: PandaplusBridge, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """O loop supervisor deve deixar TuyaSessionStuckError escapar (não engolir)."""
+    monkeypatch.setattr(bridge_module, "PROM_FILE", tmp_path / "bridge.prom")
+    mock_bridge._tuya = MagicMock()
+    mock_bridge._tuya.session_check = MagicMock(
+        side_effect=Exception("network error:(-9999999) sign invalid")
+    )
+    mock_bridge._tuya_last_healthy_ts = (
+        time.time() - bridge_module.TUYA_UNHEALTHY_RESTART_SECONDS - 1
+    )
+
+    with pytest.raises(bridge_module.TuyaSessionStuckError):
+        await mock_bridge._tuya_supervisor_loop()

--- a/tools/pandaplus_bridge/bridge.py
+++ b/tools/pandaplus_bridge/bridge.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import secrets
 import signal
 import time
@@ -31,6 +32,26 @@ logger = logging.getLogger(__name__)
 TUYA_RETRY_SECONDS = 30
 TUYA_HEALTHCHECK_SECONDS = 120
 TUYA_POLL_SECONDS = 5
+
+# Watchdog: se a sessão Tuya ficar travada em erro (ex.: "sign invalid") além
+# deste limite, o processo encerra com falha para o systemd (Restart=on-failure)
+# reiniciar de verdade — o _tuya_supervisor_loop sozinho só faz retry interno
+# infinito e nunca deixa o processo morrer (ver incidente 2026-07-22/23).
+TUYA_UNHEALTHY_RESTART_SECONDS = int(
+    os.environ.get("PANDAPLUS_BRIDGE_TUYA_MAX_UNHEALTHY_SECONDS", "600")
+)
+
+PROM_FILE = Path(
+    os.environ.get(
+        "PANDAPLUS_BRIDGE_PROM_FILE",
+        "/var/lib/prometheus/node-exporter/pandaplus_bridge.prom",
+    )
+)
+
+
+class TuyaSessionStuckError(RuntimeError):
+    """Sessão Tuya ficou indisponível por mais que TUYA_UNHEALTHY_RESTART_SECONDS."""
+
 
 # DPs que disparam notificação. unlock_request > 0 indica pedido ativo.
 RELEVANT_CODES = frozenset({"unlock_request", "alarm_lock"})
@@ -103,6 +124,9 @@ class PandaplusBridge:
         )
         # deduplicação: (code, str(value)) → timestamp do último disparo
         self._last_event_seen: dict[tuple[str, str], float] = {}
+        # watchdog da sessão Tuya
+        self._tuya_last_healthy_ts: float = time.time()
+        self._tuya_consecutive_failures: int = 0
 
     async def start(self) -> None:
         """Inicia bridge: Tuya MQ, HTTP server, Telegram sender e consumer."""
@@ -135,8 +159,21 @@ class PandaplusBridge:
         except Exception:  # noqa: BLE001
             logger.exception("falha ao enviar mensagem inicial Telegram")
 
-        # Consumer loop
-        await self._consumer_loop()
+        # Consumer loop — roda concorrente ao supervisor. Se o supervisor
+        # levantar TuyaSessionStuckError (watchdog), propaga para encerrar
+        # o processo com falha e o systemd reiniciar (Restart=on-failure).
+        consumer_task = asyncio.create_task(self._consumer_loop())
+        done, pending = await asyncio.wait(
+            {self._tuya_supervisor_task, consumer_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        for task in done:
+            exc = task.exception()
+            if exc is not None:
+                raise exc
 
     async def stop(self) -> None:
         """Encerra bridge limpando recursos."""
@@ -155,7 +192,13 @@ class PandaplusBridge:
         logger.info("Bridge encerrado")
 
     async def _tuya_supervisor_loop(self) -> None:
-        """Mantém conexão Tuya ativa com retry automático quando houver falhas."""
+        """Mantém conexão Tuya ativa com retry automático quando houver falhas.
+
+        Levanta ``TuyaSessionStuckError`` se a sessão ficar indisponível por
+        mais que ``TUYA_UNHEALTHY_RESTART_SECONDS`` — o retry interno sozinho
+        nunca deixa o processo morrer, então sem esse watchdog o bridge pode
+        ficar preso em loop de erro (ex.: `sign invalid`) indefinidamente.
+        """
         while not self._stop_event.is_set():
             if self._tuya is None:
                 try:
@@ -167,6 +210,7 @@ class PandaplusBridge:
                         exc,
                         TUYA_RETRY_SECONDS,
                     )
+                    self._record_tuya_failure()
                     await self._sleep_or_stop(TUYA_RETRY_SECONDS)
                     continue
 
@@ -176,10 +220,62 @@ class PandaplusBridge:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Sessão Tuya inválida: %s", exc)
                 await self._disconnect_tuya()
+                self._record_tuya_failure()
                 await self._sleep_or_stop(TUYA_RETRY_SECONDS)
                 continue
 
+            self._record_tuya_success()
             await self._sleep_or_stop(TUYA_HEALTHCHECK_SECONDS)
+
+    def _record_tuya_success(self) -> None:
+        """Marca a sessão Tuya como saudável agora e exporta métricas."""
+        self._tuya_last_healthy_ts = time.time()
+        self._tuya_consecutive_failures = 0
+        self._write_prom_metrics(healthy=True)
+
+    def _record_tuya_failure(self) -> None:
+        """Registra falha da sessão Tuya; levanta watchdog se preso há tempo demais."""
+        self._tuya_consecutive_failures += 1
+        self._write_prom_metrics(healthy=False)
+        unhealthy_for = time.time() - self._tuya_last_healthy_ts
+        if unhealthy_for > TUYA_UNHEALTHY_RESTART_SECONDS:
+            raise TuyaSessionStuckError(
+                f"Sessão Tuya presa há {unhealthy_for:.0f}s "
+                f"(> {TUYA_UNHEALTHY_RESTART_SECONDS}s) — "
+                f"{self._tuya_consecutive_failures} falhas consecutivas. "
+                "Encerrando processo para systemd reiniciar."
+            )
+
+    def _write_prom_metrics(self, *, healthy: bool) -> None:
+        """Exporta métricas de saúde da sessão Tuya via textfile collector."""
+        now = int(time.time())
+        lines = [
+            "# HELP pandaplus_bridge_tuya_session_healthy "
+            "1=sessão Tuya saudável no último check, 0=falha",
+            "# TYPE pandaplus_bridge_tuya_session_healthy gauge",
+            f"pandaplus_bridge_tuya_session_healthy {1 if healthy else 0}",
+            "# HELP pandaplus_bridge_tuya_last_success_timestamp "
+            "Unix time do último connect/session_check bem-sucedido",
+            "# TYPE pandaplus_bridge_tuya_last_success_timestamp gauge",
+            "pandaplus_bridge_tuya_last_success_timestamp "
+            f"{int(self._tuya_last_healthy_ts)}",
+            "# HELP pandaplus_bridge_tuya_consecutive_failures "
+            "Falhas consecutivas desde o último sucesso",
+            "# TYPE pandaplus_bridge_tuya_consecutive_failures gauge",
+            "pandaplus_bridge_tuya_consecutive_failures "
+            f"{self._tuya_consecutive_failures}",
+            "# HELP pandaplus_bridge_last_check_timestamp "
+            "Unix time da última avaliação do supervisor (detecta processo morto)",
+            "# TYPE pandaplus_bridge_last_check_timestamp gauge",
+            f"pandaplus_bridge_last_check_timestamp {now}",
+        ]
+        try:
+            PROM_FILE.parent.mkdir(parents=True, exist_ok=True)
+            tmp = PROM_FILE.with_suffix(".prom.tmp")
+            tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            tmp.replace(PROM_FILE)
+        except OSError:
+            logger.exception("falha ao escrever métricas do bridge")
 
     async def _connect_tuya(self) -> None:
         """Cria cliente Tuya e inicia subscrição MQ."""


### PR DESCRIPTION
## Summary
- O `_tuya_supervisor_loop` fazia retry interno infinito em falhas Tuya (ex.: `sign invalid`), então `Restart=on-failure` do systemd nunca disparava — o bridge podia ficar preso horas sem alertar ninguém (recorrência 2026-07-22 e 2026-07-23, a cena do quarto parava de responder).
- Adiciona watchdog: após `PANDAPLUS_BRIDGE_TUYA_MAX_UNHEALTHY_SECONDS` (default 600s) sem sucesso, o supervisor levanta `TuyaSessionStuckError`, que propaga e derruba o processo com falha — systemd reinicia de verdade (o que também reexecuta o `ExecStartPre` que recopia `core.config_entries` fresco do HA).
- Exporta métricas via textfile collector (`pandaplus_bridge_tuya_session_healthy`, `..._last_success_timestamp`, `..._consecutive_failures`, `pandaplus_bridge_last_check_timestamp`).
- Adiciona `monitoring/prometheus/pandaplus_bridge_rules.yml` com 2 alertas (sessão indisponível > 5min, heartbeat parado > 5min) — já validado com `promtool` e recarregado no Prometheus do homelab.
- Corrige drift: `gpu_coord_failover_rules.yml` estava no `rule_files` do homelab mas não no repo.

## Test plan
- [x] `pytest tests/unit/test_pandaplus_bridge.py` — 47/47 (5 testes novos cobrindo sucesso/falha/threshold do watchdog e propagação no supervisor loop)
- [x] `promtool check rules` no novo arquivo de regras — OK
- [x] Regras já carregadas no Prometheus do homelab (restart do container, confirmado via `/api/v1/rules`)
- [ ] Deploy do `bridge.py` em produção pendente — aplicar via `git pull` + `systemctl restart pandaplus-telegram-bridge.service` no homelab após merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)