### PR TITLE
fix(pandaplus-bridge): stop() idempotente, evita crash em restart

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T00:47:05.281016+00:00",
+  "generated_at": "2026-07-24T00:53:19.589611+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T00:47:05.281016+00:00`
+- Generated at: `2026-07-24T00:53:19.589611+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/tests/unit/test_pandaplus_bridge.py
+++ b/tests/unit/test_pandaplus_bridge.py
@@ -747,3 +747,46 @@ async def test_tuya_supervisor_loop_propagates_stuck_error(
 
     with pytest.raises(bridge_module.TuyaSessionStuckError):
         await mock_bridge._tuya_supervisor_loop()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(mock_bridge: PandaplusBridge) -> None:
+    """stop() pode ser chamado 2x (signal handler + finally do main()) sem
+    re-executar cleanup — regressão do AttributeError em _http_runner.cleanup()
+    quando chamado 2x (o runner já limpo tem _server=None)."""
+    mock_bridge._tuya_supervisor_task = None
+    runner = MagicMock()
+    runner.cleanup = AsyncMock()
+    mock_bridge._http_runner = runner
+
+    await mock_bridge.stop()
+    await mock_bridge.stop()
+
+    runner.cleanup.assert_awaited_once()
+    assert mock_bridge._http_runner is None
+    assert mock_bridge._telegram is None
+
+
+@pytest.mark.asyncio
+async def test_start_ignores_cancelled_supervisor_task(
+    mock_bridge: PandaplusBridge, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancelamento do supervisor (stop() externo, ex. SIGTERM) durante
+    start() não deve virar exceção fatal propagada para main()."""
+
+    async def fake_supervisor() -> None:
+        await asyncio.Event().wait()  # nunca completa sozinho
+
+    async def fake_consumer() -> None:
+        await asyncio.sleep(0.01)
+        assert mock_bridge._tuya_supervisor_task is not None
+        mock_bridge._tuya_supervisor_task.cancel()
+        await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(mock_bridge, "_tuya_supervisor_loop", fake_supervisor)
+    monkeypatch.setattr(mock_bridge, "_consumer_loop", fake_consumer)
+    monkeypatch.setattr(
+        bridge_module.TelegramSender, "__aenter__", AsyncMock(return_value=mock_bridge._telegram)
+    )
+
+    await mock_bridge.start()  # não deve levantar CancelledError

--- a/tools/pandaplus_bridge/bridge.py
+++ b/tools/pandaplus_bridge/bridge.py
@@ -162,6 +162,8 @@ class PandaplusBridge:
         # Consumer loop — roda concorrente ao supervisor. Se o supervisor
         # levantar TuyaSessionStuckError (watchdog), propaga para encerrar
         # o processo com falha e o systemd reiniciar (Restart=on-failure).
+        # Cancelamento (SIGTERM/stop() externo) não é propagado como erro:
+        # é o desligamento normal, não um watchdog disparando.
         consumer_task = asyncio.create_task(self._consumer_loop())
         done, pending = await asyncio.wait(
             {self._tuya_supervisor_task, consumer_task},
@@ -171,12 +173,18 @@ class PandaplusBridge:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
         for task in done:
+            if task.cancelled():
+                continue
             exc = task.exception()
             if exc is not None:
                 raise exc
 
     async def stop(self) -> None:
-        """Encerra bridge limpando recursos."""
+        """Encerra bridge limpando recursos.
+
+        Idempotente: pode ser chamado mais de uma vez (ex.: signal handler +
+        `finally` do main()) sem re-executar cleanup já feito.
+        """
         self._stop_event.set()
         if self._tuya_supervisor_task is not None:
             self._tuya_supervisor_task.cancel()
@@ -187,8 +195,10 @@ class PandaplusBridge:
             self._tuya = None
         if self._http_runner is not None:
             await self._http_runner.cleanup()
+            self._http_runner = None
         if self._telegram is not None:
             await self._telegram.__aexit__(None, None, None)
+            self._telegram = None
         logger.info("Bridge encerrado")
 
     async def _tuya_supervisor_loop(self) -> None:


### PR DESCRIPTION
## Summary
- Regressão do watchdog (#236) descoberta em produção logo após o primeiro restart pós-deploy: `AttributeError: 'NoneType' object has no attribute 'pre_shutdown'` no `_http_runner.cleanup()`.
- Causa: quando o supervisor é cancelado por um `stop()` externo (SIGTERM de `systemctl restart`), `start()` tentava `task.exception()` numa task cancelada — isso levanta `CancelledError`, que propagava e disparava um **segundo** `stop()` via `finally` do `main()`. `_http_runner.cleanup()` não era idempotente.
- Fix: `start()` ignora tasks com `task.cancelled()` em vez de chamar `task.exception()`; `stop()` zera `_http_runner`/`_telegram` após cleanup para tolerar chamada dupla.

## Test plan
- [x] `pytest tests/unit/test_pandaplus_bridge.py` — 49/49 (2 testes novos: `test_stop_is_idempotent`, `test_start_ignores_cancelled_supervisor_task`)
- [ ] Deploy em produção pendente (após merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)