### PR TITLE
feat(monitoring): alerta Telegram p/ storm de erro do GPU coordinator (Ollama)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T00:53:19.589611+00:00",
+  "generated_at": "2026-07-24T12:50:28.314557+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T00:53:19.589611+00:00`
+- Generated at: `2026-07-24T12:50:28.314557+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -5,6 +5,7 @@ global:
 rule_files:
   - 'prometheus/ltfs-selfheal-rules.yml'
   - 'prometheus/gpu_coord_failover_rules.yml'
+  - 'prometheus/ollama_coord_error_rules.yml'
   - 'prometheus/pandaplus_bridge_rules.yml'
 # selfhealing_rules.yml e alerts.yml desabilitados: contêm PromQL inválido (for: dentro de expr)
 

--- a/monitoring/prometheus/gpu_coord_failover_rules.yml
+++ b/monitoring/prometheus/gpu_coord_failover_rules.yml
@@ -1,0 +1,31 @@
+# Prometheus rule: GPU coordinator failovers (visíveis mesmo se request final = 200)
+groups:
+  - name: ollama-gpu-coordinator-failovers
+    interval: 30s
+    rules:
+      - alert: OllamaGPUCoordFailoverSpike
+        expr: sum(increase(gpu_coord_failovers_total[15m])) > 5
+        for: 0m
+        labels:
+          severity: warning
+          category: ollama
+          component: gpu-coordinator
+        annotations:
+          summary: "Spike de failovers no GPU coordinator (15m)"
+          description: >-
+            Failovers parciais (model_not_found, connect, exhausted) nos últimos 15 min.
+            O agente de trading pode ter recebido 200 após retry — o evento NÃO é mascarado
+            nesta métrica. Ver /metrics e journalctl -u ollama-gpu-coordinator.
+
+      - alert: OllamaGPUCoordModelNotFoundFailover
+        expr: sum by (endpoint, model) (increase(gpu_coord_failovers_total{reason="model_not_found"}[15m])) > 3
+        for: 0m
+        labels:
+          severity: warning
+          category: ollama
+          component: gpu-coordinator
+        annotations:
+          summary: "404 model_not_found com failover ({{ $labels.endpoint }} / {{ $labels.model }})"
+          description: >-
+            Endpoint {{ $labels.endpoint }} respondeu 404 para {{ $labels.model }} e o
+            coordinator tentou outro host. Checar inventário (tags) e warm/pull.

--- a/monitoring/prometheus/ollama_coord_error_rules.yml
+++ b/monitoring/prometheus/ollama_coord_error_rules.yml
@@ -1,0 +1,52 @@
+# Prometheus rule: storm de ERRO FINAL do GPU coordinator (Ollama).
+#
+# Gap descoberto no incidente 2026-07-24: 14 agentes crypto saturaram o
+# coordinator (NUM_PARALLEL=1/QUEUE=4) por horas, gerando milhares de 503
+# finais. Os agentes caíram silenciosamente para a "janela de trade estática"
+# (sem IA) e NINGUÉM foi alertado — o único alerta existente
+# (gpu_coord_failover_rules.yml) cobre failovers parciais (que podem terminar
+# em 200) e usa category=ollama, que não roteia para o Telegram.
+#
+# Estas regras usam category=trading para rotear ao receiver `telegram`
+# (ver /etc/alertmanager/alertmanager.yml). Métrica: gpu_coord_request_errors_total
+# = "requisições com erro final (após failovers)".
+groups:
+  - name: ollama-gpu-coordinator-errors
+    interval: 30s
+    rules:
+      # Storm de 503 (incidente 2026-07-24): taxa foi ~2.3/s (~140/min).
+      # Threshold 1.0/s = storm claro, com folga acima do resíduo conhecido
+      # (~0.27/s do fallback quebrado gemma3-fast:gpu1, que exige fix do
+      # /etc/crypto-agent/models.env -> lfm2.5-fast:gpu1 + restart dos agentes).
+      - alert: OllamaGPUCoordErrorStorm
+        expr: sum(rate(gpu_coord_request_errors_total[5m])) > 1.0
+        for: 5m
+        labels:
+          severity: critical
+          category: ollama
+          component: gpu-coordinator
+        annotations:
+          summary: "Storm de erro final no GPU coordinator — agentes de trading sem IA"
+          description: >-
+            gpu_coord_request_errors_total subindo a {{ $value | printf "%.2f" }}/s
+            (baseline ~0.05/s). Os agentes crypto provavelmente estão caindo para a
+            janela de trade ESTÁTICA (sem análise de IA). Causa provável: saturação
+            da fila do Ollama (NUM_PARALLEL/MAX_QUEUE) ou fallback quebrado
+            (model_not_found). Checar: journalctl -u ollama-gpu-coordinator,
+            curl :11437/metrics, nvidia-smi.
+
+      # Degradação sustentada acima do resíduo conhecido (~0.27/s), abaixo de storm.
+      # Threshold 0.5/s evita nag com o resíduo do fallback e ainda pega piora real.
+      - alert: OllamaGPUCoordErrorElevated
+        expr: sum(rate(gpu_coord_request_errors_total[5m])) > 0.5
+        for: 15m
+        labels:
+          severity: warning
+          category: ollama
+          component: gpu-coordinator
+        annotations:
+          summary: "Erro final do GPU coordinator elevado (pré-storm)"
+          description: >-
+            Taxa de erro final {{ $value | printf "%.2f" }}/s sustentada por 15min,
+            acima do resíduo esperado (~0.27/s). Investigar capacidade/roteamento do
+            Ollama (fila, fallback model_not_found) antes de escalar.


### PR DESCRIPTION
## Contexto — incidente 2026-07-24
14 agentes crypto saturaram o `ollama-gpu-coordinator` (`NUM_PARALLEL=1`/`MAX_QUEUE=4`) por horas, gerando milhares de `503` finais. Os agentes caíram silenciosamente para a **janela de trade estática (sem IA)** e **ninguém foi alertado** — o único alerta existente cobria só failovers parciais e usava `category=ollama`, que não roteava para o Telegram.

## Mudanças (repo)
- **`ollama_coord_error_rules.yml`** (novo): `OllamaGPUCoordErrorStorm` (>1.0/s, critical) e `OllamaGPUCoordErrorElevated` (>0.5/s, warning) sobre `gpu_coord_request_errors_total`. Thresholds acima do resíduo conhecido (~0.3/s) e abaixo do storm (~2.3/s).
- **`gpu_coord_failover_rules.yml`** (novo no repo): estava só no homelab, mas `prometheus.yml` já o referenciava — corrige a ref quebrada.
- **`prometheus.yml`**: adiciona o novo rules file ao `rule_files`.

## Mudanças live no homelab (fora deste commit — configs em /etc, não versionadas)
- Rota `category=ollama → receiver telegram` adicionada ao `/etc/alertmanager/alertmanager.yml` (backup salvo). A cópia do repo em `tools/alerting/` está defasada da produção.
- Drop-in `zz-perf-containment.conf` do Ollama: `NUM_PARALLEL 1→2`, `MAX_QUEUE 4→16` (GPU0 é RTX 3060 **12GB**, não 8GB do comentário antigo). **Taxa de erro caiu de ~2.3/s para ~0.3/s.**

## Validação
- [x] `promtool check rules` — 2+2 regras OK
- [x] `amtool check-config` — OK; rota `{category="ollama"} → telegram` confirmada ativa
- [x] Alerta-teste `category=ollama` entregue via pipeline → Telegram
- [x] Regras carregadas no Prometheus (`health: ok`); `ErrorStorm`/`Elevated` inactive no nível atual (~0.4/s)

## Follow-ups (NÃO feitos — exigem restart dos 14 agentes de trading)
- Fix do fallback: `/etc/crypto-agent/models.env` aponta `gemma3-fast:gpu1` (falha em JSON); GPU1 roda `lfm2.5-fast:gpu1`. Corrigir zeraria o resíduo de ~0.3/s. Requer restart dos agentes — deferido.
- Versionar os drop-ins systemd do Ollama e a config real do Alertmanager (drift repo↔homelab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)