### PR TITLE
fix(trading): backoff LLM + reconcilia llm.py (elimina resíduo de 503)

### DIFF
--- a/btc_trading_agent/llm.py
+++ b/btc_trading_agent/llm.py
@@ -30,6 +30,68 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Política global: SEMPRE logar erros (nunca engolir em debug/silêncio)
+# ---------------------------------------------------------------------------
+
+def log_error_always(
+    msg: str,
+    *args: Any,
+    exc: BaseException | None = None,
+    **extra: Any,
+) -> None:
+    """Loga em nível ERROR com extras; re-lança se pedirem via env (debug).
+
+    Hook global do projeto: falhas de LLM/API/infra não ficam só em debug.
+    """
+    if extra:
+        extras = " ".join(f"{k}={v!r}" for k, v in extra.items())
+        msg = f"{msg} | {extras}"
+    if exc is not None:
+        logger.error(msg, *args, exc_info=exc)
+    else:
+        logger.error(msg, *args)
+
+
+def _log_ollama_response_headers(
+    resp: httpx.Response,
+    *,
+    host: str,
+    model: str,
+    path: str,
+) -> None:
+    """Sempre registra erros HTTP e failovers do GPU coordinator."""
+    status = resp.status_code
+    ep = resp.headers.get("x-gpu-endpoint") or resp.headers.get("X-GPU-Endpoint") or "-"
+    tried = resp.headers.get("x-gpu-tried") or resp.headers.get("X-GPU-Tried") or ""
+    failover = (resp.headers.get("x-gpu-failover") or resp.headers.get("X-GPU-Failover") or "0").strip()
+    fail_n = resp.headers.get("x-gpu-failover-count") or resp.headers.get("X-GPU-Failover-Count") or "0"
+
+    if status >= 400:
+        body_snip = (resp.text or "")[:300].replace("\n", " ")
+        log_error_always(
+            "Ollama HTTP error status=%s path=%s host=%s model=%s endpoint=%s body=%s",
+            status,
+            path,
+            host,
+            model,
+            ep,
+            body_snip,
+        )
+    if failover in {"1", "true", "yes"}:
+        # Failover = erro no primeiro hop — log ERROR para não passar despercebido
+        log_error_always(
+            "Ollama GPU failover path=%s host=%s model=%s served_by=%s tried=%s failover_count=%s",
+            path,
+            host,
+            model,
+            ep,
+            tried or "-",
+            fail_n,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Endpoint registry
 # ---------------------------------------------------------------------------
@@ -200,38 +262,62 @@ class LLMRouter:
             self.GATE_TIMEOUT_MIN_SEC,
             timeout * self.GATE_TIMEOUT_MULTIPLIER,
         )
+        path = "/api/chat" if use_chat else "/api/generate"
         with _host_gate(host, timeout=gate_timeout):
             with httpx.Client(timeout=float(timeout)) as client:
+                try:
+                    if use_chat:
+                        messages = []
+                        if system_prompt:
+                            messages.append({"role": "system", "content": system_prompt})
+                        messages.append({"role": "user", "content": prompt})
+                        resp = client.post(
+                            f"{host}{path}",
+                            json={
+                                "model": model,
+                                "messages": messages,
+                                "stream": False,
+                                "format": "json",
+                                "options": options,
+                            },
+                        )
+                    else:
+                        resp = client.post(
+                            f"{host}{path}",
+                            json={
+                                "model": model,
+                                "prompt": prompt,
+                                "stream": False,
+                                "format": "json",
+                                "options": options,
+                            },
+                        )
+                except Exception as exc:
+                    log_error_always(
+                        "Ollama request failed path=%s host=%s model=%s: %s",
+                        path,
+                        host,
+                        model,
+                        exc,
+                        exc=exc,
+                    )
+                    raise
+                _log_ollama_response_headers(resp, host=host, model=model, path=path)
+                try:
+                    resp.raise_for_status()
+                except Exception as exc:
+                    log_error_always(
+                        "Ollama raise_for_status path=%s host=%s model=%s status=%s",
+                        path,
+                        host,
+                        model,
+                        resp.status_code,
+                        exc=exc,
+                    )
+                    raise
                 if use_chat:
-                    messages = []
-                    if system_prompt:
-                        messages.append({"role": "system", "content": system_prompt})
-                    messages.append({"role": "user", "content": prompt})
-                    resp = client.post(
-                        f"{host}/api/chat",
-                        json={
-                            "model": model,
-                            "messages": messages,
-                            "stream": False,
-                            "format": "json",
-                            "options": options,
-                        },
-                    )
-                    resp.raise_for_status()
                     return (resp.json().get("message") or {}).get("content", "").strip()
-                else:
-                    resp = client.post(
-                        f"{host}/api/generate",
-                        json={
-                            "model": model,
-                            "prompt": prompt,
-                            "stream": False,
-                            "format": "json",
-                            "options": options,
-                        },
-                    )
-                    resp.raise_for_status()
-                    return resp.json().get("response", "").strip()
+                return resp.json().get("response", "").strip()
 
     def _do_chat(
         self,
@@ -245,19 +331,41 @@ class LLMRouter:
             self.GATE_TIMEOUT_MIN_SEC,
             timeout * self.GATE_TIMEOUT_MULTIPLIER,
         )
+        path = "/api/chat"
         with _host_gate(host, timeout=gate_timeout):
             with httpx.Client(timeout=float(timeout)) as client:
-                resp = client.post(
-                    f"{host}/api/chat",
-                    json={
-                        "model": model,
-                        "messages": messages,
-                        "stream": False,
-                        "format": "json",
-                        "options": options,
-                    },
-                )
-                resp.raise_for_status()
+                try:
+                    resp = client.post(
+                        f"{host}{path}",
+                        json={
+                            "model": model,
+                            "messages": messages,
+                            "stream": False,
+                            "format": "json",
+                            "options": options,
+                        },
+                    )
+                except Exception as exc:
+                    log_error_always(
+                        "Ollama chat request failed host=%s model=%s: %s",
+                        host,
+                        model,
+                        exc,
+                        exc=exc,
+                    )
+                    raise
+                _log_ollama_response_headers(resp, host=host, model=model, path=path)
+                try:
+                    resp.raise_for_status()
+                except Exception as exc:
+                    log_error_always(
+                        "Ollama chat raise_for_status host=%s model=%s status=%s",
+                        host,
+                        model,
+                        resp.status_code,
+                        exc=exc,
+                    )
+                    raise
                 return (resp.json().get("message") or {}).get("content", "").strip()
 
     # ------------------------------------------------------------------
@@ -313,7 +421,14 @@ class LLMRouter:
             except Exception as exc:
                 ep.invalidate_health()
                 errors.append(f"{ep.name}/{model}: {type(exc).__name__}: {exc}")
-                logger.warning("LLM falhou em %s: %s", ep.name, exc)
+                log_error_always(
+                    "LLM falhou em %s/%s host=%s: %s",
+                    ep.name,
+                    model,
+                    ep.host,
+                    exc,
+                    exc=exc,
+                )
 
         raise RuntimeError(
             f"LLMRouter.generate({model!r}) falhou em {len(order)} endpoints: "
@@ -359,7 +474,14 @@ class LLMRouter:
             except Exception as exc:
                 ep.invalidate_health()
                 errors.append(f"{ep.name}/{model}: {type(exc).__name__}: {exc}")
-                logger.warning("LLM chat falhou em %s: %s", ep.name, exc)
+                log_error_always(
+                    "LLM chat falhou em %s/%s host=%s: %s",
+                    ep.name,
+                    model,
+                    ep.host,
+                    exc,
+                    exc=exc,
+                )
 
         raise RuntimeError(
             f"LLMRouter.chat({model!r}) falhou em {len(order)} endpoints: "
@@ -470,8 +592,16 @@ class LLMRouter:
                     "fallback_used": target_index > 1,
                 }
             except Exception as exc:
-                errors.append(f"{model}@{host}#{attempt_no}: {type(exc).__name__}: {exc}")
+                err = f"{model}@{host}#{attempt_no}: {type(exc).__name__}: {exc}"
+                errors.append(err)
+                log_error_always("LLM %s attempt failed: %s", label, err, exc=exc)
 
+        log_error_always(
+            "LLM %s exhausted %s attempts: %s",
+            label,
+            len(all_attempts),
+            " | ".join(errors[:4]),
+        )
         raise RuntimeError(
             f"{label} failed after {len(all_attempts)} attempts: " + " | ".join(errors[:4])
         )

--- a/btc_trading_agent/llm.py
+++ b/btc_trading_agent/llm.py
@@ -561,13 +561,19 @@ class LLMRouter:
             for _ in range(max(1, int(retries_per_target))):
                 explicit_pairs.append((host, model, t))
 
-        # Terceiro tier: endpoints do router não incluídos acima
+        # Terceiro tier: endpoints do router não incluídos acima.
+        # Modelos pinados a uma GPU (:gpuN/:nas) só existem no endpoint pinado —
+        # fan-out para outros hosts gera model_not_found garantido (ex.:
+        # lfm2.5-fast:gpu1 no NAS, que nem tem o modelo) e infla o retry-storm.
+        # Só faz fan-out de modelos NÃO-pinados.
         tried_hosts = {h for h, _, _ in explicit_pairs}
         extra_pairs: list[tuple[str, str, float]] = []
         extra_model = (fallback_model or primary_model).strip()
-        for ep in self._endpoints:
-            if ep.host not in tried_hosts and ep.is_healthy(probe_timeout=2.0):
-                extra_pairs.append((ep.host, extra_model, fallback_timeout_sec))
+        extra_is_pinned = bool(re.search(r":(gpu\d+|nas)$", extra_model))
+        if not extra_is_pinned:
+            for ep in self._endpoints:
+                if ep.host not in tried_hosts and ep.is_healthy(probe_timeout=2.0):
+                    extra_pairs.append((ep.host, extra_model, fallback_timeout_sec))
 
         all_attempts = explicit_pairs + extra_pairs
         errors: list[str] = []
@@ -595,6 +601,11 @@ class LLMRouter:
                 err = f"{model}@{host}#{attempt_no}: {type(exc).__name__}: {exc}"
                 errors.append(err)
                 log_error_always("LLM %s attempt failed: %s", label, err, exc=exc)
+                # Backoff com jitter entre tentativas: evita martelar o GPU
+                # coordinator em rajada quando os 14 agentes falham juntos
+                # (amplificação de 503). Jitter desincroniza os ciclos.
+                if attempt_no < len(all_attempts):
+                    time.sleep(min(0.25 * attempt_no, 1.0) + random.uniform(0.0, 0.15))
 
         log_error_always(
             "LLM %s exhausted %s attempts: %s",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T16:28:45.405568+00:00",
+  "generated_at": "2026-07-24T16:41:08.457444+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T16:41:08.457444+00:00",
+  "generated_at": "2026-07-24T16:44:16.966811+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T16:28:45.405568+00:00`
+- Generated at: `2026-07-24T16:41:08.457444+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T16:41:08.457444+00:00`
+- Generated at: `2026-07-24T16:44:16.966811+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`


### PR DESCRIPTION
Fecha o resíduo de 503 pós-incidente 2026-07-24 (após storm já 87% resolvido pela config do Ollama).

## Commits
1. **reconcilia llm.py com produção** — o repo estava em 2026-07-01; `/apps` (não-git) recebeu hotfixes de error-logging (`log_error_always`, `_log_ollama_response_headers`) nunca commitados. Traz prod→repo (ZERO mudança de comportamento) para o deploy não regredir.
2. **backoff + sem fan-out de modelo pinado**:
   - Não faz fan-out de modelos `:gpuN`/`:nas` (ex.: `lfm2.5-fast:gpu1`) para hosts que não têm o modelo (NAS) → elimina `model_not_found` garantido que inflava o storm.
   - Backoff com jitter entre tentativas falhas (`min(0.25*n,1.0)+rand`) → espalha retries e desincroniza os 14 agentes, cortando a amplificação de 503.

## Deploy
Via workflow `deploy-btc-trading-profiles.yml` (dispara no push a `btc_trading_agent/llm.py`): deploya + **restart escalonado** dos agentes (autorizado pelo usuário). dry_run inalterado (11 live / 3 paper).

## Testes
20 core (config/valley/cenário3/selfheal) + 28 llm/ollama passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)