### PR TITLE
fix(ci): destrava deploy de trading (test de restart escalonado)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T16:44:16.966811+00:00",
+  "generated_at": "2026-07-24T16:52:31.275511+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-24T16:52:31.275511+00:00",
+  "generated_at": "2026-07-24T22:57:13.635828+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T16:44:16.966811+00:00`
+- Generated at: `2026-07-24T16:52:31.275511+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T16:52:31.275511+00:00`
+- Generated at: `2026-07-24T22:57:13.635828+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -1546,7 +1546,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(extract(epoch from bucket_hour)::bigint, $__interval)) AS \"time\",\n  profile || ' TRS' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_trs * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM btc.decisions_track_record_hourly\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1",
+          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(bucket_epoch, $__interval)) AS \"time\",\n  profile || ' TRS' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_trs * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM (\n  SELECT\n    extract(epoch from bucket_hour)::bigint AS bucket_epoch,\n    profile,\n    avg_trs,\n    avg_boost,\n    sample_count\n  FROM btc.decisions_track_record_hourly\n  WHERE symbol = '$coin'\n    AND profile IN (${profile:sqlstring})\n    AND (\n      '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n    )\n    AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\n) sub\nGROUP BY 1, 2\nORDER BY 1",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -1560,7 +1560,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(extract(epoch from bucket_hour)::bigint, $__interval)) AS \"time\",\n  profile || ' boost' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_boost * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM btc.decisions_track_record_hourly\nWHERE symbol = '$coin'\n  AND profile IN (${profile:sqlstring})\n  AND (\n    '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n  )\n  AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY 1, 2\nORDER BY 1",
+          "rawSql": "SELECT\n  to_timestamp($__unixEpochGroup(bucket_epoch, $__interval)) AS \"time\",\n  profile || ' boost' AS metric,\n  CASE WHEN sum(sample_count) > 0 THEN sum(avg_boost * sample_count) / sum(sample_count) ELSE NULL END AS value\nFROM (\n  SELECT\n    extract(epoch from bucket_hour)::bigint AS bucket_epoch,\n    profile,\n    avg_trs,\n    avg_boost,\n    sample_count\n  FROM btc.decisions_track_record_hourly\n  WHERE symbol = '$coin'\n    AND profile IN (${profile:sqlstring})\n    AND (\n      '${servidor:raw}' = '.*' OR '${servidor:raw}' = '*' OR servidor = '${servidor:raw}'\n    )\n    AND bucket_hour BETWEEN $__timeFrom() AND $__timeTo()\n) sub\nGROUP BY 1, 2\nORDER BY 1",
           "refId": "B",
           "timeColumns": [
             "time"

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -126,9 +126,10 @@ def test_script_verifies_deploy_completeness_after_restart() -> None:
     # E é efetivamente invocada no fluxo do deploy (não só definida).
     invocations = content.count("verify_agents_running_current_code")
     assert invocations >= 2, "função definida mas não chamada no fluxo"
-    # Roda depois de reiniciar os agents.
+    # Roda depois de reiniciar os agents. O restart é escalonado (loop por svc,
+    # não em massa — ver asserts acima), então o marcador é o restart do loop.
     assert content.rindex("verify_agents_running_current_code") > content.index(
-        'systemctl restart "${AGENT_SERVICES[@]}"'
+        'sudo systemctl restart "${svc}"'
     )
 
 


### PR DESCRIPTION
## Causa raiz
`test_script_verifies_deploy_completeness_after_restart` procurava `systemctl restart "${AGENT_SERVICES[@]}"` (restart em massa), mas o `deploy_btc_trading_profiles.sh` migrou para **restart escalonado** (loop por svc — os asserts das linhas 70-72 já validam que o massa NÃO existe). A linha 131 ficou como resquício → `ValueError: substring not found` → **todos os deploys de trading falhavam no test gate**, nunca chegando ao deploy/restart.

Isso explica o **drift de 214 linhas** entre o `llm.py` do repo e produção (deploys não landavam desde ~2026-07-01) e por que a PR #241 (backoff LLM) não chegou em prod.

## Fix
Alinha o marcador da asserção ao restart escalonado (`sudo systemctl restart "${svc}"`). 9/9 testes do arquivo passam.

Após merge: re-disparo o deploy (workflow_dispatch) → gate passa → deploya o `llm.py` já em main (#241) + rolling restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)