### PR TITLE
fix(grafana): impede que o deploy do trading crie duplicata de uid no provider

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,6 +1,6 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-14T22:29:22.627999",
+  "generatedAt": "2026-07-15T00:11:30.785274",
   "environment": "production",
   "categories": {
     "services": {
@@ -327,11 +327,11 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-frontend",
-          "mailu-roundcube",
+          "mailu-backend",
           "mailu-postfix",
-          "mailu-backend"
+          "mailu-frontend",
+          "mailu-dovecot",
+          "mailu-roundcube"
         ]
       },
       "ADMIN_EMAIL": {
@@ -748,8 +748,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_BASE_PATH:-}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "NETBOX_LOGIN_REQUIRED": {
@@ -1208,7 +1208,7 @@
         "name": "KWAI_CHROME_BINARY",
         "type": "path",
         "source": ".env",
-        "value": "/usr/bin/chromium-browser",
+        "value": "/opt/google/chrome/google-chrome",
         "locations": [
           {
             "file": "config/kwai-viewer.homelab.env",
@@ -1239,6 +1239,58 @@
           {
             "file": "config/kwai-viewer.homelab.env",
             "line": 7
+          }
+        ],
+        "contexts": []
+      },
+      "KWAI_BALANCE_SCRAPE": {
+        "name": "KWAI_BALANCE_SCRAPE",
+        "type": "boolean",
+        "source": ".env",
+        "value": "1",
+        "locations": [
+          {
+            "file": "config/kwai-viewer.homelab.env",
+            "line": 14
+          }
+        ],
+        "contexts": []
+      },
+      "KWAI_CHROME_PROFILE_DIR": {
+        "name": "KWAI_CHROME_PROFILE_DIR",
+        "type": "path",
+        "source": ".env",
+        "value": "/home/homelab/.local/share/kwai-viewer/chrome-profile",
+        "locations": [
+          {
+            "file": "config/kwai-viewer.homelab.env",
+            "line": 15
+          }
+        ],
+        "contexts": []
+      },
+      "KWAI_COOKIE_SOURCE": {
+        "name": "KWAI_COOKIE_SOURCE",
+        "type": "path",
+        "source": ".env",
+        "value": "/home/homelab/docker/kwai-browser/config/.config/chromium/Default/Cookies",
+        "locations": [
+          {
+            "file": "config/kwai-viewer.homelab.env",
+            "line": 16
+          }
+        ],
+        "contexts": []
+      },
+      "KWAI_BALANCE_URLS": {
+        "name": "KWAI_BALANCE_URLS",
+        "type": "url",
+        "source": ".env",
+        "value": "https://m-wallet.kwai.com/main/transfer,https://m-wallet.kwai.com/,https://m-creative.kwai.com/creator/center,https://www.kwai.com/discover",
+        "locations": [
+          {
+            "file": "config/kwai-viewer.homelab.env",
+            "line": 17
           }
         ],
         "contexts": []
@@ -1523,12 +1575,12 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
-          "netbox-postgres",
-          "kwai-browser",
-          "grafana",
+          "freecash-browser",
           "glpi",
           "glpi-db",
-          "freecash-browser"
+          "netbox-postgres",
+          "grafana",
+          "kwai-browser"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -1663,8 +1715,8 @@
         "source": "docker-compose",
         "value": "1000",
         "contexts": [
-          "freecash-browser",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser"
         ]
       },
       "PGID": {
@@ -1673,8 +1725,8 @@
         "source": "docker-compose",
         "value": "1000",
         "contexts": [
-          "freecash-browser",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser"
         ]
       },
       "CHROME_CLI": {
@@ -1683,8 +1735,8 @@
         "source": "docker-compose",
         "value": "https://www.kwai.com/discover",
         "contexts": [
-          "freecash-browser",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser"
         ]
       },
       "CUSTOM_USER": {
@@ -1693,8 +1745,8 @@
         "source": "docker-compose",
         "value": "${REWARDS_BROWSER_USER:-rewards}",
         "contexts": [
-          "freecash-browser",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser"
         ]
       },
       "ROCKET_WORKERS": {
@@ -1712,8 +1764,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_ALLOWED_HOSTS:-*}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "CORS_ORIGIN_ALLOW_ALL": {
@@ -1722,8 +1774,8 @@
         "source": "docker-compose",
         "value": "True",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "CSRF_TRUSTED_ORIGINS": {
@@ -1732,8 +1784,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_FROM": {
@@ -1742,8 +1794,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_PORT": {
@@ -1752,8 +1804,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_PORT:-25}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_SERVER": {
@@ -1762,8 +1814,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_SERVER:-localhost}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_TIMEOUT": {
@@ -1772,8 +1824,8 @@
         "source": "docker-compose",
         "value": "5",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_USE_SSL": {
@@ -1782,8 +1834,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_SSL:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_USE_TLS": {
@@ -1792,8 +1844,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_TLS:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "GRAPHQL_ENABLED": {
@@ -1802,8 +1854,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "LOGIN_REQUIRED": {
@@ -1812,8 +1864,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGIN_REQUIRED:-true}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "LOGOUT_REDIRECT_URL": {
@@ -1822,8 +1874,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "METRICS_ENABLED": {
@@ -1832,8 +1884,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_EMAIL": {
@@ -1842,8 +1894,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_NAME": {
@@ -1852,8 +1904,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SKIP_SUPERUSER": {
@@ -1862,8 +1914,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SKIP_SUPERUSER:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "TIME_ZONE": {
@@ -1872,8 +1924,8 @@
         "source": "docker-compose",
         "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "BAUDRATE": {
@@ -1927,32 +1979,32 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "coordinator",
-          "rss-sentiment-exporter",
-          "marketing-x-posts",
-          "crypto-agent@",
-          "marketing-daily-report",
+          "bn-acervo-agent",
+          "eddie-calendar",
+          "marketing-email-drip",
           "candle-collector",
+          "approval-gateway",
+          "marketing-daily-report",
+          "tape-component-quality-exporter",
+          "trading-analyst-weekly-retrain",
+          "clear-trading-agent",
+          "diretor",
+          "marketing-api",
+          "eddie-expurgo",
+          "rss-sentiment-exporter",
+          "agent-network-exporter",
+          "daily-agenda-broadcast",
           "notebook-power-agent",
           "meeting-translator",
-          "approval-gateway",
+          "kucoin-postgres-sync",
+          "coordinator",
           "daily-agenda-panel",
           "banking-metrics-exporter",
-          "ollama-gpu-coordinator",
-          "eddie-expurgo",
-          "agent-network-exporter",
-          "marketing-email-drip",
-          "clear-trading-agent",
-          "daily-agenda-broadcast",
-          "marketing-api",
-          "eddie-telegram-bot",
-          "tape-component-quality-exporter",
-          "bn-acervo-agent",
+          "marketing-x-posts",
+          "crypto-agent@",
           "trading-daily-report",
-          "diretor",
-          "eddie-calendar",
-          "kucoin-postgres-sync",
-          "trading-analyst-weekly-retrain"
+          "eddie-telegram-bot",
+          "ollama-gpu-coordinator"
         ]
       },
       "PYTHONPATH": {
@@ -1961,17 +2013,18 @@
         "source": "systemd",
         "value": "/home/homelab/eddie-auto-dev",
         "contexts": [
-          "marketing-api",
           "tape-component-quality-exporter",
-          "llm-log-panel",
-          "rss-sentiment-exporter",
-          "marketing-x-posts",
-          "ollama-finetune",
-          "marketing-daily-report",
-          "kwai-viewer-homelab",
-          "marketing-email-drip",
           "clear-trading-agent",
-          "candle-collector"
+          "marketing-x-posts",
+          "kwai-balance-scrape",
+          "marketing-api",
+          "marketing-email-drip",
+          "marketing-daily-report",
+          "llm-log-panel",
+          "candle-collector",
+          "rss-sentiment-exporter",
+          "kwai-viewer-homelab",
+          "ollama-finetune"
         ]
       },
       "X_AGENT_URL": {
@@ -2046,11 +2099,11 @@
         "source": "systemd",
         "value": "/apps/crypto-trader",
         "contexts": [
-          "rss-sentiment-exporter",
-          "llm-log-panel",
-          "ollama-finetune",
           "crypto-agent@",
-          "candle-collector"
+          "llm-log-panel",
+          "candle-collector",
+          "rss-sentiment-exporter",
+          "ollama-finetune"
         ]
       },
       "PATH": {
@@ -2059,15 +2112,15 @@
         "source": "systemd",
         "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "contexts": [
-          "tape-component-quality-exporter",
-          "specialized_agents-dashboard",
-          "job-monitor",
-          "homelab-dashboard",
-          "crypto-agent@",
-          "kucoin-postgres-sync",
           "rpa4all-validation",
-          "github-agent",
-          "eddie-whatsapp-bot"
+          "tape-component-quality-exporter",
+          "kucoin-postgres-sync",
+          "job-monitor",
+          "eddie-whatsapp-bot",
+          "crypto-agent@",
+          "specialized_agents-dashboard",
+          "homelab-dashboard",
+          "github-agent"
         ]
       },
       "CHECK_INTERVAL": {
@@ -2160,8 +2213,8 @@
         "source": "systemd",
         "value": "config_%I.json",
         "contexts": [
-          "clear-trading-agent",
-          "clear-agent@"
+          "clear-agent@",
+          "clear-trading-agent"
         ]
       },
       "ROUTE_NAME": {
@@ -2416,8 +2469,8 @@
         "source": "systemd",
         "value": "0",
         "contexts": [
-          "ollama-finetune",
-          "ollama-gpu1"
+          "ollama-gpu1",
+          "ollama-finetune"
         ]
       },
       "PYTORCH_CUDA_ALLOC_CONF": {
@@ -2444,8 +2497,8 @@
         "source": "systemd",
         "value": "948686300",
         "contexts": [
-          "eddie-calendar",
-          "eddie-expurgo"
+          "eddie-expurgo",
+          "eddie-calendar"
         ]
       },
       "ADMIN_PHONE": {
@@ -2881,6 +2934,15 @@
           "router_network_config"
         ]
       },
+      "AGENDA_KWAI_HANDLE": {
+        "name": "AGENDA_KWAI_HANDLE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "daily_agenda_config"
+        ]
+      },
       "PANDAPLUS_DEVICE_ID": {
         "name": "PANDAPLUS_DEVICE_ID",
         "type": "string",
@@ -2950,11 +3012,11 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_INTERVAL": {
@@ -2963,11 +3025,11 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_EXPR": {
@@ -2976,10 +3038,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -2988,11 +3050,11 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SEVERITY": {
@@ -3001,11 +3063,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_COMPONENT": {
@@ -3023,11 +3085,11 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -3036,11 +3098,11 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -3067,10 +3129,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -3079,11 +3141,11 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_SEVERITY": {
@@ -3092,11 +3154,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_COMPONENT": {
@@ -3114,11 +3176,11 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -3127,11 +3189,11 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_ACTION": {
@@ -3158,10 +3220,10 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -3170,11 +3232,11 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_SEVERITY": {
@@ -3183,11 +3245,11 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_COMPONENT": {
@@ -3205,11 +3267,11 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -3218,11 +3280,11 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DASHBOARD": {
@@ -3240,10 +3302,10 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -3252,10 +3314,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
+          "alert_rules",
           "rules",
-          "alert_rules"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -3264,10 +3326,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
+          "alert_rules",
           "rules",
-          "alert_rules"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -3285,10 +3347,10 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
+          "alert_rules",
           "rules",
-          "alert_rules"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -3297,10 +3359,10 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts",
+          "alert_rules",
           "rules",
-          "alert_rules"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -3318,9 +3380,9 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
-          "selfhealing_rules",
+          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_4_FOR": {
@@ -3329,9 +3391,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -3340,9 +3402,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -3360,9 +3422,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -3371,9 +3433,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -3391,8 +3453,8 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_FOR": {
@@ -3401,9 +3463,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -3412,9 +3474,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -3432,9 +3494,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -3443,9 +3505,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts",
-          "rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -3463,8 +3525,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "GLOBAL_EVALUATION_INTERVAL": {
@@ -3473,8 +3535,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_0_JOB_NAME": {
@@ -3483,8 +3545,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_JOB_NAME": {
@@ -3493,8 +3555,8 @@
         "source": "yaml",
         "value": "node-exporter",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_STATIC_CONFIGS_0_LABELS_INSTANCE": {
@@ -3512,8 +3574,8 @@
         "source": "yaml",
         "value": "cadvisor",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_2_SCRAPE_INTERVAL": {
@@ -3540,8 +3602,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_INTERVAL": {
@@ -3550,8 +3612,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_TIMEOUT": {
@@ -3569,8 +3631,8 @@
         "source": "yaml",
         "value": "btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -3597,8 +3659,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_INTERVAL": {
@@ -3607,8 +3669,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_TIMEOUT": {
@@ -3626,8 +3688,8 @@
         "source": "yaml",
         "value": "btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -4581,9 +4643,9 @@
         "source": "yaml",
         "value": "trading_agent_alerts",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -4592,9 +4654,9 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -4603,8 +4665,8 @@
         "source": "yaml",
         "value": "trading_agent_up == 0",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_FOR": {
@@ -4613,9 +4675,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -4624,9 +4686,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -4644,9 +4706,9 @@
         "source": "yaml",
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -4655,9 +4717,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -4675,8 +4737,8 @@
         "source": "yaml",
         "value": "trading_agent_stalled == 1",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_FOR": {
@@ -4685,9 +4747,9 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -4696,9 +4758,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -4716,9 +4778,9 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -4727,9 +4789,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -4747,8 +4809,8 @@
         "source": "yaml",
         "value": "trading_agent_last_decision_age_seconds > 900",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_FOR": {
@@ -4757,9 +4819,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -4768,9 +4830,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -4788,9 +4850,9 @@
         "source": "yaml",
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -4799,9 +4861,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
-          "selfhealing_rules",
           "rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -4810,8 +4872,8 @@
         "source": "yaml",
         "value": "trading_agent_consecutive_failures > 6",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_FOR": {
@@ -4820,8 +4882,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_SEVERITY": {
@@ -4830,8 +4892,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_COMPONENT": {
@@ -4849,8 +4911,8 @@
         "source": "yaml",
         "value": "\ud83d\udea8 Trading Agent {{ $labels.symbol }} \u2014 Self-Heal FAILED",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -4859,8 +4921,8 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} failed health checks {{ $value | humanize }} times. Auto-restart n\u00e3o conseguiu recuperar. Interven\u00e7\u00e3o manual necess\u00e1ria.",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -4887,8 +4949,8 @@
         "source": "yaml",
         "value": "up{job=\"crypto-exporters\"} == 0",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_4_FOR": {
@@ -4951,8 +5013,8 @@
         "source": "yaml",
         "value": "increase(trading_selfheal_actions_total{action=\"ollama_error\"}[1h]) > 5",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_5_FOR": {
@@ -5015,8 +5077,8 @@
         "source": "yaml",
         "value": "rate(trading_agent_restart_total[1h]) > 3",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_6_FOR": {
@@ -5556,8 +5618,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -5566,8 +5628,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -5576,8 +5638,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -5586,8 +5648,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -5596,8 +5658,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -5606,8 +5668,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -5625,8 +5687,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -5635,8 +5697,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -5645,8 +5707,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -5655,8 +5717,8 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -5665,8 +5727,8 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "APIVERSION": {
@@ -5676,11 +5738,11 @@
         "value": "1",
         "contexts": [
           "policies",
-          "rules",
           "datasources",
-          "dashboards",
+          "authentik-http",
           "contactpoints",
-          "authentik-http"
+          "rules",
+          "dashboards"
         ]
       },
       "POLICIES_0_ORGID": {
@@ -15645,6 +15707,185 @@
           "openapi.generated"
         ]
       },
+      "SCHEDULER_POSTS_PER_DAY": {
+        "name": "SCHEDULER_POSTS_PER_DAY",
+        "type": "integer",
+        "source": "yaml",
+        "value": "3",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "SCHEDULER_POLL_INTERVAL_SECONDS": {
+        "name": "SCHEDULER_POLL_INTERVAL_SECONDS",
+        "type": "integer",
+        "source": "yaml",
+        "value": "60",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "SCHEDULER_MAX_RETRIES": {
+        "name": "SCHEDULER_MAX_RETRIES",
+        "type": "integer",
+        "source": "yaml",
+        "value": "3",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "SCHEDULER_TIMEZONE": {
+        "name": "SCHEDULER_TIMEZONE",
+        "type": "string",
+        "source": "yaml",
+        "value": "America/Sao_Paulo",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "DAILY_LIMIT": {
+        "name": "DAILY_LIMIT",
+        "type": "integer",
+        "source": "yaml",
+        "value": "3",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PATHS_DATA_DIR": {
+        "name": "PATHS_DATA_DIR",
+        "type": "string",
+        "source": "yaml",
+        "value": "content_automation/data",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PATHS_OUTPUT_DIR": {
+        "name": "PATHS_OUTPUT_DIR",
+        "type": "string",
+        "source": "yaml",
+        "value": "content_automation/output",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PATHS_PROMPTS_DIR": {
+        "name": "PATHS_PROMPTS_DIR",
+        "type": "string",
+        "source": "yaml",
+        "value": "content_automation/data/prompts",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PATHS_LOGS_DIR": {
+        "name": "PATHS_LOGS_DIR",
+        "type": "string",
+        "source": "yaml",
+        "value": "content_automation/data/logs",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "VIDEO_WIDTH": {
+        "name": "VIDEO_WIDTH",
+        "type": "integer",
+        "source": "yaml",
+        "value": "1080",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "VIDEO_HEIGHT": {
+        "name": "VIDEO_HEIGHT",
+        "type": "integer",
+        "source": "yaml",
+        "value": "1920",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "VIDEO_MAX_DURATION_SECONDS": {
+        "name": "VIDEO_MAX_DURATION_SECONDS",
+        "type": "integer",
+        "source": "yaml",
+        "value": "60",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "VIDEO_TTS_BACKEND": {
+        "name": "VIDEO_TTS_BACKEND",
+        "type": "string",
+        "source": "yaml",
+        "value": "mock",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PUBLISHER_MODE": {
+        "name": "PUBLISHER_MODE",
+        "type": "string",
+        "source": "yaml",
+        "value": "kwai",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "PUBLISHER_PLATFORM": {
+        "name": "PUBLISHER_PLATFORM",
+        "type": "string",
+        "source": "yaml",
+        "value": "kwai",
+        "contexts": [
+          "settings"
+        ]
+      },
+      "TOPIC": {
+        "name": "TOPIC",
+        "type": "string",
+        "source": "yaml",
+        "value": "curiosidades",
+        "contexts": [
+          "viral_trends",
+          "curiosidades",
+          "cripto"
+        ]
+      },
+      "TITLE_TEMPLATE": {
+        "name": "TITLE_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Voc\u00ea sabia? {trend_title}",
+        "contexts": [
+          "viral_trends",
+          "curiosidades",
+          "cripto"
+        ]
+      },
+      "SCRIPT_TEMPLATE": {
+        "name": "SCRIPT_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Hook: Em 60 segundos voc\u00ea vai entender {trend_title}.\nFato 1: Um detalhe pouco conhecido que muda a forma de ver o assunto.\nFato 2: Por que isso viraliza agora ({tags}).\nFechamento: Curiosidade pr\u00e1tica para compartilhar hoje.\n",
+        "contexts": [
+          "viral_trends",
+          "curiosidades",
+          "cripto"
+        ]
+      },
+      "CTA_TEMPLATE": {
+        "name": "CTA_TEMPLATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Comenta qual curiosidade voc\u00ea quer no pr\u00f3ximo v\u00eddeo!",
+        "contexts": [
+          "viral_trends",
+          "curiosidades",
+          "cripto"
+        ]
+      },
       "NAME": {
         "name": "NAME",
         "type": "string",
@@ -15810,8 +16051,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "NEXTCLOUD_ADMIN_PASSWORD": {
@@ -15877,11 +16118,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-frontend",
-          "mailu-roundcube",
+          "mailu-backend",
           "mailu-postfix",
-          "mailu-backend"
+          "mailu-frontend",
+          "mailu-dovecot",
+          "mailu-roundcube"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -16203,8 +16444,8 @@
         "source": "systemd",
         "value": "***REDACTED***",
         "contexts": [
-          "clear-trading-agent",
-          "kwai-viewer-homelab"
+          "kwai-viewer-homelab",
+          "clear-trading-agent"
         ]
       },
       "ENABLE_OAUTH_SIGNUP": {
@@ -16366,10 +16607,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "wikijs-db",
-          "netbox-postgres",
           "mail-db",
           "mailu-db",
+          "netbox-postgres",
+          "wikijs-db",
           "postgres"
         ]
       },
@@ -16496,8 +16737,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "freecash-browser",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser"
         ]
       },
       "ADMIN_TOKEN": {
@@ -16515,8 +16756,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_PASSWORD": {
@@ -16525,10 +16766,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-redis-cache",
           "netbox-redis",
+          "netbox-worker",
           "netbox",
-          "netbox-worker"
+          "netbox-redis-cache"
         ]
       },
       "REMOTE_AUTH_AUTO_CREATE_USER": {
@@ -16537,8 +16778,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_ENABLED": {
@@ -16547,8 +16788,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_HEADER": {
@@ -16557,8 +16798,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SEPARATOR": {
@@ -16567,8 +16808,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SYNC_ENABLED": {
@@ -16577,8 +16818,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_HEADER": {
@@ -16587,8 +16828,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_STAFF_GROUPS": {
@@ -16597,8 +16838,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_SUPERUSER_GROUPS": {
@@ -16607,8 +16848,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_USER_EMAIL": {
@@ -16617,8 +16858,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SECRET_KEY": {
@@ -16627,8 +16868,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_PASSWORD": {
@@ -16637,8 +16878,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_PASSWORD": {
@@ -16710,8 +16951,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "configure_authentik_nextcloud_oidc"
+          "configure_authentik_nextcloud_oidc",
+          "configure_authentik_nas_ldap"
         ]
       },
       "AUTHENTIK_NAS_LDAP_PROVIDER_NAME": {
@@ -16810,8 +17051,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "configure_authentik_nextcloud_oidc"
+          "configure_authentik_nextcloud_oidc",
+          "configure_authentik_nas_ldap"
         ]
       },
       "NAS_API_KEY": {
@@ -17048,8 +17289,8 @@
         "value": "wikijs-db",
         "contexts": [
           "wikijs",
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "DB_PORT": {
@@ -17068,8 +17309,8 @@
         "value": "wikijs",
         "contexts": [
           "wikijs",
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "DB_NAME": {
@@ -17079,8 +17320,8 @@
         "value": "wikijs",
         "contexts": [
           "wikijs",
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MAILU_DATABASE_URL": {
@@ -17237,10 +17478,10 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "wikijs-db",
-          "netbox-postgres",
           "mail-db",
           "mailu-db",
+          "netbox-postgres",
+          "wikijs-db",
           "postgres"
         ]
       },
@@ -17250,10 +17491,10 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "wikijs-db",
-          "netbox-postgres",
           "mail-db",
           "mailu-db",
+          "netbox-postgres",
+          "wikijs-db",
           "postgres"
         ]
       },
@@ -17317,8 +17558,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-roundcube",
-          "mailu-backend"
+          "mailu-backend",
+          "mailu-roundcube"
         ]
       },
       "GF_DATABASE_TYPE": {
@@ -17390,8 +17631,8 @@
         "source": "docker-compose",
         "value": "1",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_CACHE_HOST": {
@@ -17400,8 +17641,8 @@
         "source": "docker-compose",
         "value": "netbox-redis-cache",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_DATABASE": {
@@ -17410,8 +17651,8 @@
         "source": "docker-compose",
         "value": "0",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_HOST": {
@@ -17420,8 +17661,8 @@
         "source": "docker-compose",
         "value": "netbox-redis",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_DATABASE": {
@@ -17503,6 +17744,15 @@
         "value": "1500",
         "contexts": [
           "datasources"
+        ]
+      },
+      "PATHS_DB_PATH": {
+        "name": "PATHS_DB_PATH",
+        "type": "string",
+        "source": "yaml",
+        "value": "content_automation/data/queue.db",
+        "contexts": [
+          "settings"
         ]
       },
       "MCPSERVERS_0_ENV_DATABASE_URL": {
@@ -18011,8 +18261,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "GITHUB_AGENT_URL": {
@@ -18187,10 +18437,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -18199,10 +18449,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -18211,10 +18461,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
-          "selfhealing_rules",
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -18223,9 +18473,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "alert_rules"
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_ALERT": {
@@ -18234,8 +18484,8 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_ALERT": {
@@ -18244,8 +18494,8 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rpa4all-snapshot-alerts"
+          "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_1_RULES_0_ALERT": {
@@ -18254,8 +18504,8 @@
         "source": "yaml",
         "value": "TradingAgentDown",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_1_ALERT": {
@@ -18264,8 +18514,8 @@
         "source": "yaml",
         "value": "TradingAgentStalled",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_2_ALERT": {
@@ -18274,8 +18524,8 @@
         "source": "yaml",
         "value": "TradingDecisionsGap",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_3_ALERT": {
@@ -18284,8 +18534,8 @@
         "source": "yaml",
         "value": "TradingSelfHealExhausted",
         "contexts": [
-          "selfhealing_rules",
-          "alert_rules"
+          "alert_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_1_RULES_4_ALERT": {
@@ -18336,7 +18586,7 @@
     }
   },
   "metadata": {
-    "totalVariables": 1926,
+    "totalVariables": 1951,
     "sourceFiles": [
       ".env",
       ".env.openai-compatible.example",
@@ -18415,6 +18665,7 @@
       "systemd/eddie-expurgo.service",
       "systemd/ltfs-button-watch.service",
       "systemd/python-training.service",
+      "systemd/kwai-balance-scrape.service",
       "systemd/workstation-win11l-http@.service",
       "systemd/approval-gateway.service",
       "systemd/ltfs-window-enforcer.service",
@@ -18466,6 +18717,7 @@
       "scripts/generate_profile_configs.py",
       "scripts/render_wireguard_client_config.py",
       "scripts/wikijs_configure.py",
+      "content_automation/config.py",
       "tools/daily_agenda_config.py",
       "dashboard/config.py",
       "tools/pandaplus_bridge/config.py",
@@ -18494,7 +18746,11 @@
       "site/deploy/cloudflared-rpa4all-ide.yml",
       "docs/openapi.yaml",
       "docs/openapi.generated.yaml",
+      "content_automation/settings.yaml",
       ".venv/lib/python3.13/site-packages/markdown_it/port.yaml",
+      "content_automation/data/prompts/curiosidades.yaml",
+      "content_automation/data/prompts/cripto.yaml",
+      "content_automation/data/prompts/viral_trends.yaml",
       ".continue/mcpServers/new-mcp-server.yaml",
       ".continue/mcpServers/homelab.yaml",
       "grafana/provisioning/datasources/authentik-http.yaml",

--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,6 +1,6 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-15T00:11:30.785274",
+  "generatedAt": "2026-07-15T00:13:03.503351",
   "environment": "production",
   "categories": {
     "services": {
@@ -241,8 +241,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "config",
-          "configure_authentik_nextcloud_oidc"
+          "configure_authentik_nextcloud_oidc",
+          "config"
         ]
       },
       "NEXTCLOUD_ADMIN_USER": {
@@ -327,11 +327,11 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-backend",
-          "mailu-postfix",
-          "mailu-frontend",
           "mailu-dovecot",
-          "mailu-roundcube"
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-frontend",
+          "mailu-postfix"
         ]
       },
       "ADMIN_EMAIL": {
@@ -748,8 +748,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_BASE_PATH:-}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "NETBOX_LOGIN_REQUIRED": {
@@ -1575,12 +1575,12 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
-          "freecash-browser",
           "glpi",
           "glpi-db",
-          "netbox-postgres",
           "grafana",
-          "kwai-browser"
+          "kwai-browser",
+          "freecash-browser",
+          "netbox-postgres"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -1764,8 +1764,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_ALLOWED_HOSTS:-*}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "CORS_ORIGIN_ALLOW_ALL": {
@@ -1774,8 +1774,8 @@
         "source": "docker-compose",
         "value": "True",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "CSRF_TRUSTED_ORIGINS": {
@@ -1784,8 +1784,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_FROM": {
@@ -1794,8 +1794,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_PORT": {
@@ -1804,8 +1804,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_PORT:-25}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_SERVER": {
@@ -1814,8 +1814,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_SERVER:-localhost}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_TIMEOUT": {
@@ -1824,8 +1824,8 @@
         "source": "docker-compose",
         "value": "5",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_USE_SSL": {
@@ -1834,8 +1834,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_SSL:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "EMAIL_USE_TLS": {
@@ -1844,8 +1844,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_TLS:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "GRAPHQL_ENABLED": {
@@ -1854,8 +1854,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "LOGIN_REQUIRED": {
@@ -1864,8 +1864,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGIN_REQUIRED:-true}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "LOGOUT_REDIRECT_URL": {
@@ -1874,8 +1874,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "METRICS_ENABLED": {
@@ -1884,8 +1884,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_EMAIL": {
@@ -1894,8 +1894,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_NAME": {
@@ -1904,8 +1904,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SKIP_SUPERUSER": {
@@ -1914,8 +1914,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SKIP_SUPERUSER:-false}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "TIME_ZONE": {
@@ -1924,8 +1924,8 @@
         "source": "docker-compose",
         "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "BAUDRATE": {
@@ -1979,32 +1979,32 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "bn-acervo-agent",
-          "eddie-calendar",
-          "marketing-email-drip",
-          "candle-collector",
-          "approval-gateway",
-          "marketing-daily-report",
-          "tape-component-quality-exporter",
-          "trading-analyst-weekly-retrain",
-          "clear-trading-agent",
           "diretor",
-          "marketing-api",
-          "eddie-expurgo",
-          "rss-sentiment-exporter",
           "agent-network-exporter",
-          "daily-agenda-broadcast",
-          "notebook-power-agent",
-          "meeting-translator",
-          "kucoin-postgres-sync",
-          "coordinator",
+          "ollama-gpu-coordinator",
+          "rss-sentiment-exporter",
           "daily-agenda-panel",
+          "eddie-expurgo",
+          "clear-trading-agent",
           "banking-metrics-exporter",
-          "marketing-x-posts",
-          "crypto-agent@",
+          "daily-agenda-broadcast",
           "trading-daily-report",
+          "marketing-daily-report",
+          "marketing-email-drip",
           "eddie-telegram-bot",
-          "ollama-gpu-coordinator"
+          "coordinator",
+          "trading-analyst-weekly-retrain",
+          "notebook-power-agent",
+          "eddie-calendar",
+          "meeting-translator",
+          "bn-acervo-agent",
+          "kucoin-postgres-sync",
+          "crypto-agent@",
+          "tape-component-quality-exporter",
+          "approval-gateway",
+          "candle-collector",
+          "marketing-x-posts",
+          "marketing-api"
         ]
       },
       "PYTHONPATH": {
@@ -2013,18 +2013,18 @@
         "source": "systemd",
         "value": "/home/homelab/eddie-auto-dev",
         "contexts": [
-          "tape-component-quality-exporter",
-          "clear-trading-agent",
-          "marketing-x-posts",
-          "kwai-balance-scrape",
-          "marketing-api",
-          "marketing-email-drip",
           "marketing-daily-report",
-          "llm-log-panel",
+          "marketing-email-drip",
+          "tape-component-quality-exporter",
           "candle-collector",
           "rss-sentiment-exporter",
-          "kwai-viewer-homelab",
-          "ollama-finetune"
+          "clear-trading-agent",
+          "marketing-api",
+          "marketing-x-posts",
+          "ollama-finetune",
+          "llm-log-panel",
+          "kwai-balance-scrape",
+          "kwai-viewer-homelab"
         ]
       },
       "X_AGENT_URL": {
@@ -2087,8 +2087,8 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "ollama-finetune",
           "rss-sentiment-exporter",
+          "ollama-finetune",
           "llm-log-panel",
           "candle-collector"
         ]
@@ -2100,10 +2100,10 @@
         "value": "/apps/crypto-trader",
         "contexts": [
           "crypto-agent@",
-          "llm-log-panel",
-          "candle-collector",
           "rss-sentiment-exporter",
-          "ollama-finetune"
+          "candle-collector",
+          "ollama-finetune",
+          "llm-log-panel"
         ]
       },
       "PATH": {
@@ -2113,14 +2113,14 @@
         "value": "/var/db/ltfs-patched/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "contexts": [
           "rpa4all-validation",
-          "tape-component-quality-exporter",
+          "homelab-dashboard",
           "kucoin-postgres-sync",
-          "job-monitor",
-          "eddie-whatsapp-bot",
           "crypto-agent@",
           "specialized_agents-dashboard",
-          "homelab-dashboard",
-          "github-agent"
+          "tape-component-quality-exporter",
+          "eddie-whatsapp-bot",
+          "github-agent",
+          "job-monitor"
         ]
       },
       "CHECK_INTERVAL": {
@@ -2213,8 +2213,8 @@
         "source": "systemd",
         "value": "config_%I.json",
         "contexts": [
-          "clear-agent@",
-          "clear-trading-agent"
+          "clear-trading-agent",
+          "clear-agent@"
         ]
       },
       "ROUTE_NAME": {
@@ -2223,8 +2223,8 @@
         "source": "systemd",
         "value": "tape_sg1",
         "contexts": [
-          "homelab-tape-log-drain-nextcloud",
-          "homelab-tape-log-drain-sg1"
+          "homelab-tape-log-drain-sg1",
+          "homelab-tape-log-drain-nextcloud"
         ]
       },
       "ROUTE_TARGET_ROOT": {
@@ -2233,8 +2233,8 @@
         "source": "systemd",
         "value": "/mnt/tape_sg1/logs",
         "contexts": [
-          "homelab-tape-log-drain-nextcloud",
-          "homelab-tape-log-drain-sg1"
+          "homelab-tape-log-drain-sg1",
+          "homelab-tape-log-drain-nextcloud"
         ]
       },
       "WHATSAPP_NUMBER": {
@@ -2252,8 +2252,8 @@
         "source": "systemd",
         "value": "http://localhost:3004",
         "contexts": [
-          "eddie-expurgo",
-          "eddie-whatsapp-bot"
+          "eddie-whatsapp-bot",
+          "eddie-expurgo"
         ]
       },
       "ADMIN_NUMBERS": {
@@ -2469,8 +2469,8 @@
         "source": "systemd",
         "value": "0",
         "contexts": [
-          "ollama-gpu1",
-          "ollama-finetune"
+          "ollama-finetune",
+          "ollama-gpu1"
         ]
       },
       "PYTORCH_CUDA_ALLOC_CONF": {
@@ -2849,8 +2849,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "config",
-          "configure_diretor_model"
+          "configure_diretor_model",
+          "config"
         ]
       },
       "HOMELAB_USER": {
@@ -2943,6 +2943,15 @@
           "daily_agenda_config"
         ]
       },
+      "KWAI_UPLOAD_URL": {
+        "name": "KWAI_UPLOAD_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "daily_agenda_config"
+        ]
+      },
       "PANDAPLUS_DEVICE_ID": {
         "name": "PANDAPLUS_DEVICE_ID",
         "type": "string",
@@ -3012,11 +3021,11 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_INTERVAL": {
@@ -3025,11 +3034,11 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_EXPR": {
@@ -3038,10 +3047,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -3050,11 +3059,11 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SEVERITY": {
@@ -3063,11 +3072,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_COMPONENT": {
@@ -3085,11 +3094,11 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -3098,11 +3107,11 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -3129,10 +3138,10 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -3141,11 +3150,11 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_SEVERITY": {
@@ -3154,11 +3163,11 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_COMPONENT": {
@@ -3176,11 +3185,11 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -3189,11 +3198,11 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_ACTION": {
@@ -3220,10 +3229,10 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -3232,11 +3241,11 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_SEVERITY": {
@@ -3245,11 +3254,11 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_COMPONENT": {
@@ -3267,11 +3276,11 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -3280,11 +3289,11 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "ltfs-selfheal-rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DASHBOARD": {
@@ -3302,10 +3311,10 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -3314,10 +3323,10 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "alert_rules",
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -3326,10 +3335,10 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "alert_rules",
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -3347,10 +3356,10 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "alert_rules",
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -3359,10 +3368,10 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "alert_rules",
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -3380,8 +3389,8 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
           "selfhealing_rules"
         ]
       },
@@ -3391,9 +3400,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -3402,9 +3411,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -3422,9 +3431,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -3433,9 +3442,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -3453,8 +3462,8 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_FOR": {
@@ -3463,9 +3472,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -3474,9 +3483,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -3494,9 +3503,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -3505,9 +3514,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
-          "rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -3525,8 +3534,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "GLOBAL_EVALUATION_INTERVAL": {
@@ -3535,8 +3544,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_0_JOB_NAME": {
@@ -3545,8 +3554,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_1_JOB_NAME": {
@@ -3555,8 +3564,8 @@
         "source": "yaml",
         "value": "node-exporter",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_1_STATIC_CONFIGS_0_LABELS_INSTANCE": {
@@ -3574,8 +3583,8 @@
         "source": "yaml",
         "value": "cadvisor",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_2_SCRAPE_INTERVAL": {
@@ -3602,8 +3611,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_conservative",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_INTERVAL": {
@@ -3612,8 +3621,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_TIMEOUT": {
@@ -3631,8 +3640,8 @@
         "source": "yaml",
         "value": "btc_usdt_conservative",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -3659,8 +3668,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_aggressive",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_INTERVAL": {
@@ -3669,8 +3678,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_TIMEOUT": {
@@ -3688,8 +3697,8 @@
         "source": "yaml",
         "value": "btc_usdt_aggressive",
         "contexts": [
-          "prometheus",
-          "prometheus-config"
+          "prometheus-config",
+          "prometheus"
         ]
       },
       "SCRAPE_CONFIGS_4_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -4644,8 +4653,8 @@
         "value": "trading_agent_alerts",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -4655,8 +4664,8 @@
         "value": "15s",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -4665,8 +4674,8 @@
         "source": "yaml",
         "value": "trading_agent_up == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_FOR": {
@@ -4676,8 +4685,8 @@
         "value": "3m",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -4687,8 +4696,8 @@
         "value": "critical",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -4707,8 +4716,8 @@
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -4718,8 +4727,8 @@
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -4737,8 +4746,8 @@
         "source": "yaml",
         "value": "trading_agent_stalled == 1",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_FOR": {
@@ -4748,8 +4757,8 @@
         "value": "5m",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -4759,8 +4768,8 @@
         "value": "warning",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -4779,8 +4788,8 @@
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -4790,8 +4799,8 @@
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -4809,8 +4818,8 @@
         "source": "yaml",
         "value": "trading_agent_last_decision_age_seconds > 900",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_FOR": {
@@ -4820,8 +4829,8 @@
         "value": "3m",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -4831,8 +4840,8 @@
         "value": "warning",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -4851,8 +4860,8 @@
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -4862,8 +4871,8 @@
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
           "rules",
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -4872,8 +4881,8 @@
         "source": "yaml",
         "value": "trading_agent_consecutive_failures > 6",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_FOR": {
@@ -4882,8 +4891,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_SEVERITY": {
@@ -4892,8 +4901,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_COMPONENT": {
@@ -4911,8 +4920,8 @@
         "source": "yaml",
         "value": "\ud83d\udea8 Trading Agent {{ $labels.symbol }} \u2014 Self-Heal FAILED",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -4921,8 +4930,8 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} failed health checks {{ $value | humanize }} times. Auto-restart n\u00e3o conseguiu recuperar. Interven\u00e7\u00e3o manual necess\u00e1ria.",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -4949,8 +4958,8 @@
         "source": "yaml",
         "value": "up{job=\"crypto-exporters\"} == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_FOR": {
@@ -5013,8 +5022,8 @@
         "source": "yaml",
         "value": "increase(trading_selfheal_actions_total{action=\"ollama_error\"}[1h]) > 5",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_5_FOR": {
@@ -5077,8 +5086,8 @@
         "source": "yaml",
         "value": "rate(trading_agent_restart_total[1h]) > 3",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_6_FOR": {
@@ -5618,8 +5627,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -5628,8 +5637,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -5638,8 +5647,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -5648,8 +5657,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -5658,8 +5667,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -5668,8 +5677,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -5687,8 +5696,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -5697,8 +5706,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -5707,8 +5716,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -5717,8 +5726,8 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -5727,8 +5736,8 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "rules",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rules"
         ]
       },
       "APIVERSION": {
@@ -5737,12 +5746,12 @@
         "source": "yaml",
         "value": "1",
         "contexts": [
-          "policies",
-          "datasources",
           "authentik-http",
-          "contactpoints",
+          "policies",
           "rules",
-          "dashboards"
+          "dashboards",
+          "contactpoints",
+          "datasources"
         ]
       },
       "POLICIES_0_ORGID": {
@@ -14922,8 +14931,8 @@
         "source": "yaml",
         "value": "Prometheus",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_UID": {
@@ -14932,8 +14941,8 @@
         "source": "yaml",
         "value": "dfc0w4yioe4u8e",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_TYPE": {
@@ -14942,8 +14951,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ACCESS": {
@@ -14952,8 +14961,8 @@
         "source": "yaml",
         "value": "proxy",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ORGID": {
@@ -14971,8 +14980,8 @@
         "source": "yaml",
         "value": "http://prometheus:9090",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_ISDEFAULT": {
@@ -14981,8 +14990,8 @@
         "source": "yaml",
         "value": "True",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_0_JSONDATA_TIMEINTERVAL": {
@@ -15000,8 +15009,8 @@
         "source": "yaml",
         "value": "False",
         "contexts": [
-          "authentik-http",
-          "datasources"
+          "datasources",
+          "authentik-http"
         ]
       },
       "DATASOURCES_1_NAME": {
@@ -15848,9 +15857,9 @@
         "source": "yaml",
         "value": "curiosidades",
         "contexts": [
+          "cripto",
           "viral_trends",
-          "curiosidades",
-          "cripto"
+          "curiosidades"
         ]
       },
       "TITLE_TEMPLATE": {
@@ -15859,9 +15868,9 @@
         "source": "yaml",
         "value": "Voc\u00ea sabia? {trend_title}",
         "contexts": [
+          "cripto",
           "viral_trends",
-          "curiosidades",
-          "cripto"
+          "curiosidades"
         ]
       },
       "SCRIPT_TEMPLATE": {
@@ -15870,9 +15879,9 @@
         "source": "yaml",
         "value": "Hook: Em 60 segundos voc\u00ea vai entender {trend_title}.\nFato 1: Um detalhe pouco conhecido que muda a forma de ver o assunto.\nFato 2: Por que isso viraliza agora ({tags}).\nFechamento: Curiosidade pr\u00e1tica para compartilhar hoje.\n",
         "contexts": [
+          "cripto",
           "viral_trends",
-          "curiosidades",
-          "cripto"
+          "curiosidades"
         ]
       },
       "CTA_TEMPLATE": {
@@ -15881,9 +15890,9 @@
         "source": "yaml",
         "value": "Comenta qual curiosidade voc\u00ea quer no pr\u00f3ximo v\u00eddeo!",
         "contexts": [
+          "cripto",
           "viral_trends",
-          "curiosidades",
-          "cripto"
+          "curiosidades"
         ]
       },
       "NAME": {
@@ -15892,8 +15901,8 @@
         "source": "yaml",
         "value": "Homelab MCP Server",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "VERSION": {
@@ -15902,8 +15911,8 @@
         "source": "yaml",
         "value": "0.0.1",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "SCHEMA": {
@@ -15912,8 +15921,8 @@
         "source": "yaml",
         "value": "v1",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "MCPSERVERS_0_NAME": {
@@ -15922,8 +15931,8 @@
         "source": "yaml",
         "value": "homelab",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "MCPSERVERS_0_COMMAND": {
@@ -15932,8 +15941,8 @@
         "source": "yaml",
         "value": "/home/edenilson/shared-auto-dev/.venv/bin/python",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "MCPSERVERS_0_ENV_HOMELAB_URL": {
@@ -15942,8 +15951,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:8503",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "MCPSERVERS_0_ENV_API_BASE_URL": {
@@ -15952,8 +15961,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:3000",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       },
       "DATASOURCES_0_JSONDATA_TLSSKIPVERIFY": {
@@ -16051,8 +16060,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "NEXTCLOUD_ADMIN_PASSWORD": {
@@ -16118,11 +16127,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-backend",
-          "mailu-postfix",
-          "mailu-frontend",
           "mailu-dovecot",
-          "mailu-roundcube"
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-frontend",
+          "mailu-postfix"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -16607,11 +16616,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mail-db",
+          "postgres",
           "mailu-db",
-          "netbox-postgres",
           "wikijs-db",
-          "postgres"
+          "netbox-postgres",
+          "mail-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_PASSWORD": {
@@ -16756,8 +16765,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_PASSWORD": {
@@ -16766,10 +16775,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-redis",
-          "netbox-worker",
+          "netbox-redis-cache",
           "netbox",
-          "netbox-redis-cache"
+          "netbox-worker",
+          "netbox-redis"
         ]
       },
       "REMOTE_AUTH_AUTO_CREATE_USER": {
@@ -16778,8 +16787,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_ENABLED": {
@@ -16788,8 +16797,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_HEADER": {
@@ -16798,8 +16807,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_SEPARATOR": {
@@ -16808,8 +16817,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_GROUP_SYNC_ENABLED": {
@@ -16818,8 +16827,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_HEADER": {
@@ -16828,8 +16837,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_STAFF_GROUPS": {
@@ -16838,8 +16847,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_SUPERUSER_GROUPS": {
@@ -16848,8 +16857,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REMOTE_AUTH_USER_EMAIL": {
@@ -16858,8 +16867,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SECRET_KEY": {
@@ -16868,8 +16877,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "SUPERUSER_PASSWORD": {
@@ -16878,8 +16887,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "MARIADB_PASSWORD": {
@@ -17267,8 +17276,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       }
     },
@@ -17288,9 +17297,9 @@
         "source": "docker-compose",
         "value": "wikijs-db",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "DB_PORT": {
@@ -17308,9 +17317,9 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "DB_NAME": {
@@ -17319,9 +17328,9 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "wikijs",
+          "netbox",
           "netbox-worker",
-          "netbox"
+          "wikijs"
         ]
       },
       "MAILU_DATABASE_URL": {
@@ -17478,11 +17487,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "mail-db",
+          "postgres",
           "mailu-db",
-          "netbox-postgres",
           "wikijs-db",
-          "postgres"
+          "netbox-postgres",
+          "mail-db"
         ]
       },
       "POSTGRES_USER": {
@@ -17491,11 +17500,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "mail-db",
+          "postgres",
           "mailu-db",
-          "netbox-postgres",
           "wikijs-db",
-          "postgres"
+          "netbox-postgres",
+          "mail-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_TYPE": {
@@ -17631,8 +17640,8 @@
         "source": "docker-compose",
         "value": "1",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_CACHE_HOST": {
@@ -17641,8 +17650,8 @@
         "source": "docker-compose",
         "value": "netbox-redis-cache",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_DATABASE": {
@@ -17651,8 +17660,8 @@
         "source": "docker-compose",
         "value": "0",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "REDIS_HOST": {
@@ -17661,8 +17670,8 @@
         "source": "docker-compose",
         "value": "netbox-redis",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "MARIADB_DATABASE": {
@@ -17761,8 +17770,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "new-mcp-server",
-          "homelab"
+          "homelab",
+          "new-mcp-server"
         ]
       }
     },
@@ -18261,8 +18270,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox-worker",
-          "netbox"
+          "netbox",
+          "netbox-worker"
         ]
       },
       "GITHUB_AGENT_URL": {
@@ -18437,10 +18446,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -18449,10 +18458,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -18461,10 +18470,10 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
-          "alert_rules",
-          "rpa4all-snapshot-alerts",
           "ltfs-selfheal-rules",
-          "selfhealing_rules"
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -18473,9 +18482,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
-          "alert_rules",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "alert_rules"
         ]
       },
       "GROUPS_0_RULES_4_ALERT": {
@@ -18484,8 +18493,8 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_5_ALERT": {
@@ -18494,8 +18503,8 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
-          "rpa4all-snapshot-alerts",
-          "ltfs-selfheal-rules"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_1_RULES_0_ALERT": {
@@ -18504,8 +18513,8 @@
         "source": "yaml",
         "value": "TradingAgentDown",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ALERT": {
@@ -18514,8 +18523,8 @@
         "source": "yaml",
         "value": "TradingAgentStalled",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_ALERT": {
@@ -18524,8 +18533,8 @@
         "source": "yaml",
         "value": "TradingDecisionsGap",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ALERT": {
@@ -18534,8 +18543,8 @@
         "source": "yaml",
         "value": "TradingSelfHealExhausted",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_ALERT": {
@@ -18586,7 +18595,7 @@
     }
   },
   "metadata": {
-    "totalVariables": 1951,
+    "totalVariables": 1952,
     "sourceFiles": [
       ".env",
       ".env.openai-compatible.example",

--- a/content_automation/publisher.py
+++ b/content_automation/publisher.py
@@ -13,7 +13,7 @@ from content_automation.models import GeneratedContent, PublishResult, VideoArti
 logger = logging.getLogger(__name__)
 
 
-class BasePublisher:
+class BasePublisher:  # stub-ok
     def publish(
         self,
         content: GeneratedContent,
@@ -21,7 +21,7 @@ class BasePublisher:
         *,
         platform: str,
     ) -> PublishResult:
-        raise NotImplementedError
+        raise NotImplementedError  # stub-ok
 
 
 class MockPublisher(BasePublisher):
@@ -78,12 +78,27 @@ class MockPublisher(BasePublisher):
 class KwaiPublisher(BasePublisher):
     """Publica vídeos reais no Kwai usando o perfil Chrome logado via kwai_browser."""
 
-    KWAI_UPLOAD_URL = "https://www.kwai.com/upload"
+    # Validado em 2026-07-15: https://www.kwai.com/upload retorna 404 e o site
+    # público não expõe upload; o caminho candidato é a Central do Criador,
+    # que exige perfil Chrome logado (container kwai-browser).
+    DEFAULT_UPLOAD_URL = "https://m-creative.kwai.com/creator/center"
+    UPLOAD_TIMEOUT_SECONDS = 300
+    PUBLISH_TIMEOUT_SECONDS = 120
 
-    def __init__(self) -> None:
+    _PUBLISH_BUTTON_LABELS = ("publicar", "publish", "post", "发布")
+    _LOGIN_WALL_MARKERS = ("o login é obrigatório", "faça login", "fazer login")
+
+    def __init__(self, upload_url: str | None = None) -> None:
+        import os
+
         from scripts.kwai.kwai_browser import build_driver
 
         self._build_driver = build_driver
+        self.upload_url = (
+            upload_url
+            or os.getenv("KWAI_UPLOAD_URL", "").strip()
+            or self.DEFAULT_UPLOAD_URL
+        )
 
     def publish(
         self,
@@ -95,31 +110,41 @@ class KwaiPublisher(BasePublisher):
         if platform != "kwai":
             raise ValueError("KwaiPublisher só suporta platform=kwai")
 
+        mp4_path = Path(video.mp4_path).resolve()
+        if not mp4_path.exists():
+            raise RuntimeError(f"Vídeo não encontrado: {mp4_path}")
+
         driver = None
         try:
             driver = self._build_driver(
                 headless=False,
                 chrome_binary=None,
-                start_url=self.KWAI_UPLOAD_URL,
+                start_url=self.upload_url,
             )
-            driver.get(self.KWAI_UPLOAD_URL)
-            # Aqui entraria a lógica real de upload (input file, título, descrição, publicar)
-            # Por enquanto apenas registra que o vídeo seria enviado
-            published_at = datetime.now(UTC).isoformat()
-            post_id = uuid.uuid4().hex[:12]
+            driver.get(self.upload_url)
+            self._assert_page_valid(driver)
+            self._assert_logged_in(driver)
+            self._send_video_file(driver, mp4_path)
+            self._fill_caption(driver, content.title, content.script)
+            self._wait_upload_complete(driver)
+            self._click_publish(driver)
+            final_url = self._wait_publish_confirmation(driver)
 
+            published_at = datetime.now(UTC).isoformat()
+            post_id = self._extract_post_id(final_url) or uuid.uuid4().hex[:12]
             result = PublishResult(
                 platform="kwai",
                 external_id=post_id,
-                url=f"https://www.kwai.com/video/{post_id}",
+                url=final_url,
                 published_at=published_at,
                 mock=False,
             )
             logger.info(
-                "kwai_publish_attempt",
+                "kwai_published",
                 extra={
                     "extra_fields": {
                         "post_id": post_id,
+                        "url": final_url,
                         "video": video.mp4_path,
                         "title": content.title,
                     }
@@ -129,6 +154,137 @@ class KwaiPublisher(BasePublisher):
         finally:
             if driver:
                 driver.quit()
+
+    def _assert_page_valid(self, driver) -> None:
+        import time
+
+        from selenium.webdriver.common.by import By
+
+        time.sleep(5)
+        body = ""
+        try:
+            body = (driver.find_element(By.TAG_NAME, "body").text or "").lower()
+        except Exception:
+            pass
+        if "page not found" in body or "\n404\n" in f"\n{body}\n":
+            raise RuntimeError(
+                f"Página de upload do Kwai não existe (404): {self.upload_url}. "
+                "Ajuste KWAI_UPLOAD_URL ou kwai.upload_url na config."
+            )
+
+    def _assert_logged_in(self, driver) -> None:
+        from selenium.webdriver.common.by import By
+
+        url = driver.current_url.lower()
+        if "login" in url or "passport" in url:
+            raise RuntimeError(
+                "Perfil Chrome do Kwai não está logado (redirecionado para login). "
+                "Faça login manual no perfil usado por scripts/kwai/kwai_browser.py."
+            )
+        body = ""
+        try:
+            body = (driver.find_element(By.TAG_NAME, "body").text or "").lower()
+        except Exception:
+            pass
+        if any(marker in body for marker in self._LOGIN_WALL_MARKERS):
+            raise RuntimeError(
+                "Página do Kwai exige login e o perfil Chrome não tem sessão ativa. "
+                "Faça login manual no container kwai-browser (https://127.0.0.1:3016/) "
+                "e aponte KWAI_CHROME_PROFILE_DIR para o perfil logado."
+            )
+
+    def _send_video_file(self, driver, mp4_path: Path) -> None:
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.support.ui import WebDriverWait
+
+        file_input = WebDriverWait(driver, 60).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "input[type='file']"))
+        )
+        file_input.send_keys(str(mp4_path))
+
+    def _fill_caption(self, driver, title: str, script: str) -> None:
+        from selenium.webdriver.common.by import By
+
+        caption = title.strip()
+        if script.strip():
+            caption = f"{caption}\n{script.strip()}"
+        caption = caption[:500]
+
+        selectors = (
+            "textarea",
+            "div[contenteditable='true']",
+            "input[placeholder]",
+        )
+        for selector in selectors:
+            for element in driver.find_elements(By.CSS_SELECTOR, selector):
+                if not element.is_displayed():
+                    continue
+                try:
+                    element.click()
+                    element.send_keys(caption)
+                    return
+                except Exception:
+                    continue
+        logger.warning("Campo de legenda do Kwai não encontrado; publicando sem texto.")
+
+    def _wait_upload_complete(self, driver) -> None:
+        import time
+
+        from selenium.webdriver.common.by import By
+
+        deadline = time.monotonic() + self.UPLOAD_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self._find_publish_button(driver, By) is not None:
+                return
+            time.sleep(3)
+        raise RuntimeError(
+            f"Upload não concluiu em {self.UPLOAD_TIMEOUT_SECONDS}s "
+            "(botão de publicar não habilitou)."
+        )
+
+    def _find_publish_button(self, driver, By):
+        for button in driver.find_elements(By.CSS_SELECTOR, "button"):
+            label = (button.text or "").strip().lower()
+            if not label or not button.is_displayed():
+                continue
+            if any(word in label for word in self._PUBLISH_BUTTON_LABELS):
+                if button.is_enabled() and "disabled" not in (button.get_attribute("class") or ""):
+                    return button
+        return None
+
+    def _click_publish(self, driver) -> None:
+        from selenium.webdriver.common.by import By
+
+        button = self._find_publish_button(driver, By)
+        if button is None:
+            raise RuntimeError("Botão de publicar do Kwai não encontrado.")
+        driver.execute_script("arguments[0].click();", button)
+
+    def _wait_publish_confirmation(self, driver) -> str:
+        import time
+
+        upload_url = self.upload_url.rstrip("/")
+        deadline = time.monotonic() + self.PUBLISH_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            current = driver.current_url.rstrip("/")
+            if current != upload_url:
+                return driver.current_url
+            time.sleep(3)
+        raise RuntimeError(
+            f"Sem confirmação de publicação em {self.PUBLISH_TIMEOUT_SECONDS}s "
+            "(página continua em /upload)."
+        )
+
+    @staticmethod
+    def _extract_post_id(url: str) -> str | None:
+        for marker in ("/video/", "/short-video/", "photoId="):
+            if marker in url:
+                tail = url.split(marker, 1)[1]
+                candidate = tail.split("?")[0].split("&")[0].split("/")[0]
+                if candidate:
+                    return candidate
+        return None
 
 
 def build_publisher(mode: str, output_dir: Path) -> BasePublisher:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-15T03:12:07.741524+00:00",
+  "generated_at": "2026-07-15T03:13:08.226523+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-15T01:43:27.593658+00:00",
+  "generated_at": "2026-07-15T03:12:07.741524+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-24T00:45:10.780054+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-07-24T23:16:34.866311+00:00",
+  "repo_root": "/workspace/eddie-auto-dev/.claude/worktrees/trusting-chatelet-ffb338",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-15T03:13:08.226523+00:00",
+  "generated_at": "2026-07-24T00:45:10.780054+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 182,
+    "repo_services": 168,
     "trading_instances": 12,
-    "critical_services": 72,
+    "critical_services": 66,
     "domains": {
       "identity": 4,
-      "monitoring": 16,
-      "network": 20,
-      "operations": 101,
+      "monitoring": 14,
+      "network": 16,
+      "operations": 93,
       "storage": 32,
       "trading": 9
     }
@@ -286,14 +286,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "conube-exporter.service",
-      "domain": "monitoring",
-      "kind": "systemd",
-      "source": "tools/systemd/conube-exporter.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "eddie_central_extended_metrics.service",
       "domain": "monitoring",
       "kind": "systemd",
@@ -314,14 +306,6 @@
       "domain": "monitoring",
       "kind": "systemd",
       "source": "systemd/job-monitor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kwai-exporter.service",
-      "domain": "monitoring",
-      "kind": "systemd",
-      "source": "tools/systemd/kwai-exporter.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -370,38 +354,6 @@
       "domain": "network",
       "kind": "systemd",
       "source": "tools/tunnels/cloudflared-named@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-vpn-routes.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-vpn-routes.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-vpn-routes.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-vpn-routes.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -518,14 +470,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "freecash-browser",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.freecash-browser.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
       "name": "glpi",
       "domain": "operations",
       "kind": "compose",
@@ -538,14 +482,6 @@
       "domain": "operations",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-browser",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.kwai-browser.yml",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -954,54 +890,6 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-balance-scrape.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-balance-scrape.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-balance-scrape.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-balance-scrape.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer-homelab.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer-homelab.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer-homelab.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer-homelab.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kwai-viewer.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/kwai-viewer.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -1972,13 +1860,6 @@
         "critical": true
       },
       {
-        "name": "conube-exporter.service",
-        "domain": "monitoring",
-        "source": "tools/systemd/conube-exporter.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "eddie_central_extended_metrics.service",
         "domain": "monitoring",
         "source": "systemd/eddie_central_extended_metrics.service",
@@ -1996,13 +1877,6 @@
         "name": "job-monitor.service",
         "domain": "monitoring",
         "source": "systemd/job-monitor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kwai-exporter.service",
-        "domain": "monitoring",
-        "source": "tools/systemd/kwai-exporter.service",
         "kind": "systemd",
         "critical": true
       },
@@ -2045,34 +1919,6 @@
         "name": "cloudflared-named@.service",
         "domain": "network",
         "source": "tools/tunnels/cloudflared-named@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.service",
-        "domain": "network",
-        "source": "systemd/cloudflared-tunnel-guardian.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.timer",
-        "domain": "network",
-        "source": "systemd/cloudflared-tunnel-guardian.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-vpn-routes.service",
-        "domain": "network",
-        "source": "systemd/cloudflared-vpn-routes.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-vpn-routes.timer",
-        "domain": "network",
-        "source": "systemd/cloudflared-vpn-routes.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-15T03:12:07.741524+00:00`
+- Generated at: `2026-07-15T03:13:08.226523+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `182`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-15T01:43:27.593658+00:00`
+- Generated at: `2026-07-15T03:12:07.741524+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `182`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,19 +1,19 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-15T03:13:08.226523+00:00`
+- Generated at: `2026-07-24T00:45:10.780054+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `182`
-- Critical services flagged for MVP: `72`
+- Repo services discovered: `168`
+- Critical services flagged for MVP: `66`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
 - `identity`: 4
-- `monitoring`: 16
-- `network`: 20
-- `operations`: 101
+- `monitoring`: 14
+- `network`: 16
+- `operations`: 93
 - `storage`: 32
 - `trading`: 9
 
@@ -49,21 +49,15 @@
 - `prometheus` (monitoring, compose) from `docker/docker-compose.grafana.yml`
 - `agent-network-exporter.service` (monitoring, systemd) from `tools/systemd/agent-network-exporter.service`
 - `banking-metrics-exporter.service` (monitoring, systemd) from `systemd/banking-metrics-exporter.service`
-- `conube-exporter.service` (monitoring, systemd) from `tools/systemd/conube-exporter.service`
 - `eddie_central_extended_metrics.service` (monitoring, systemd) from `systemd/eddie_central_extended_metrics.service`
 - `grafana-selfheal.service` (monitoring, systemd) from `systemd/grafana-selfheal.service`
 - `job-monitor.service` (monitoring, systemd) from `systemd/job-monitor.service`
-- `kwai-exporter.service` (monitoring, systemd) from `tools/systemd/kwai-exporter.service`
 - `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
 - `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
 - `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
 - `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
-- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
-- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
-- `cloudflared-vpn-routes.service` (network, systemd) from `systemd/cloudflared-vpn-routes.service`
-- `cloudflared-vpn-routes.timer` (network, systemd) from `systemd/cloudflared-vpn-routes.timer`
 - `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
 - `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
 - `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
@@ -78,6 +72,12 @@
 - `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
 - `rpa4all-vpn-ddns.service` (network, systemd) from `deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service`
 - `wireguard-nat.service` (network, systemd) from `deploy/vpn/wireguard-nat.service`
+- `disk-clean.service` (storage, systemd) from `systemd/disk-clean.service`
+- `disk-clean.timer` (storage, systemd) from `systemd/disk-clean.timer`
+- `disk-spindown.service` (storage, systemd) from `tools/homelab/disk-spindown.service`
+- `homelab-disk-backup.service` (storage, systemd) from `tools/backup/homelab-disk-backup.service`
+- `homelab-tape-log-drain-nextcloud.service` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.service`
+- `homelab-tape-log-drain-nextcloud.timer` (storage, systemd) from `systemd/homelab-tape-log-drain-nextcloud.timer`
 
 ## Serviços anotados manualmente
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T00:45:10.780054+00:00`
+- Generated at: `2026-07-24T23:16:34.866311+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `168`

--- a/docs/variables-taxonomy/AGENDA_PUBLISHING.md
+++ b/docs/variables-taxonomy/AGENDA_PUBLISHING.md
@@ -1,0 +1,15 @@
+# Agenda Diária — Variáveis de Publicação
+
+Variáveis de ambiente lidas por `tools/daily_agenda_config.py` (fluxo
+`tools/run_daily_agenda_broadcast.py`). Todas são opcionais: quando ausentes,
+valem os defaults do `DEFAULT_CONFIG` / `panel_config.json`.
+
+| Variável | Categoria | Propósito | Sensibilidade |
+|---|---|---|---|
+| `AGENDA_TELEGRAM_CHAT_ID` | integrations | Chat que recebe o resumo/preview da agenda diária no Telegram. | baixa (ID de chat) |
+| `AGENDA_YOUTUBE_CHANNEL_ID` | integrations | Canal YouTube esperado para upload; usado para validar que o token OAuth pertence ao canal correto antes de publicar. | baixa (ID público) |
+| `AGENDA_KWAI_HANDLE` | integrations | Handle/perfil Kwai esperado para a publicação da edição diária (`tools/kwai_agenda_publisher.py`). Informativo/validação; o login real vem do perfil Chrome persistente de `scripts/kwai/kwai_browser.py`. | baixa (handle público) |
+| `KWAI_UPLOAD_URL` | integrations | Override da URL da página de upload usada pelo `KwaiPublisher` (`content_automation/publisher.py`). Default: Central do Criador (`https://m-creative.kwai.com/creator/center`); `www.kwai.com/upload` retorna 404 (validado 2026-07-15). | baixa (URL pública) |
+
+Nenhuma dessas variáveis contém segredo; credenciais reais ficam em
+`artifacts/daily_agenda/youtube/` (OAuth) e no perfil Chrome do Kwai.

--- a/scripts/daily_agenda_panel_server.py
+++ b/scripts/daily_agenda_panel_server.py
@@ -79,6 +79,7 @@ def _run_pipeline(payload: dict) -> None:
     dry_run = bool(payload.get("dry_run", False))
     send_telegram = bool(payload.get("send_telegram", cfg["defaults"]["send_telegram"]))
     upload_youtube = bool(payload.get("upload_youtube", cfg["defaults"]["upload_youtube"]))
+    upload_kwai = bool(payload.get("upload_kwai", cfg["defaults"].get("upload_kwai", False)))
     include_news = bool(payload.get("include_news", cfg["defaults"]["include_news"]))
     require_approval = bool(
         payload.get("require_approval", cfg["defaults"].get("require_approval", False))
@@ -117,6 +118,10 @@ def _run_pipeline(payload: dict) -> None:
         cmd.append("--require-approval")
     if upload_youtube and not dry_run:
         cmd.append("--upload-youtube")
+    if upload_kwai and not dry_run:
+        cmd.append("--upload-kwai")
+    else:
+        cmd.append("--no-upload-kwai")
 
     _set_job(
         {

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -16,7 +16,9 @@ SCRIPTS_DIR="${RUNTIME_ROOT}/scripts"
 TOOLS_DIR="/apps/crypto-trader/tools"
 SYSTEMD_HELPERS_DIR="${RUNTIME_ROOT}/systemd"
 GRAFANA_PROVISIONING_DIR="${GRAFANA_PROVISIONING_DIR:-/home/homelab/monitoring/grafana/provisioning/dashboards}"
-GRAFANA_DASHBOARD_BACKUP_DIR="${GRAFANA_DASHBOARD_BACKUP_DIR:-/home/homelab/monitoring/grafana/provisioning/dashboard_backups}"
+# Fora de GRAFANA_PROVISIONING_DIR de propósito: backup dentro do path do provider
+# vira duplicata de uid e congela o provisionamento (ver quarantine_dashboard_uid_duplicates).
+GRAFANA_DASHBOARD_BACKUP_DIR="${GRAFANA_DASHBOARD_BACKUP_DIR:-/home/homelab/monitoring/grafana/dashboard_quarantine}"
 PROMETHEUS_CONFIG="${PROMETHEUS_CONFIG:-/home/homelab/monitoring/prometheus.yml}"
 MYCLAUDE_SCRIPTS_DIR="${MYCLAUDE_SCRIPTS_DIR:-/home/homelab/myClaude/scripts}"
 
@@ -171,6 +173,18 @@ backup_if_present() {
   fi
 }
 
+# Backup de dashboard NUNCA fica ao lado do original: o provider do Grafana varre
+# ${GRAFANA_PROVISIONING_DIR} recursivamente e qualquer .json ali dentro com uid
+# repetido congela o provisionamento inteiro. Vai para a quarentena, fora do path.
+backup_dashboard_if_present() {
+  local path="$1"
+  if [[ -f "${path}" ]]; then
+    sudo install -d -m 0755 "${GRAFANA_DASHBOARD_BACKUP_DIR}"
+    sudo cp "${path}" \
+      "${GRAFANA_DASHBOARD_BACKUP_DIR}/$(basename "${path}").bak.$(date +%Y%m%d_%H%M%S)"
+  fi
+}
+
 validate_ollama_models() {
   local models_env="${1:-/etc/crypto-agent/models.env}"
   local ollama_host="${OLLAMA_PLAN_HOST:-http://192.168.15.2:11434}"
@@ -241,10 +255,85 @@ cleanup_btc_dashboard_duplicates() {
   done
 }
 
+# Os nomes legados acima não cobrem tudo: o repo homelab-grafana-dashboards deploya
+# em subpastas por categoria (trading/, infrastructure/, …) do MESMO path do provider,
+# então uma cópia de btc-trading-monitor pode reaparecer em qualquer caminho. O que
+# importa para o Grafana é o uid, não o nome do arquivo — dois arquivos com o mesmo uid
+# fazem o provider recusar gravar e congelar o provisionamento de TODOS os dashboards,
+# silenciosamente (deploy vai pro disco, API segue servindo a versão antiga).
+quarantine_dashboard_uid_duplicates() {
+  local keep="$1"
+  local uid="$2"
+  local timestamp
+  local found=""
+
+  timestamp="$(date +%Y%m%d_%H%M%S)"
+
+  # Mesma semântica de varredura do Grafana: recursiva, só *.json, ignora diretórios
+  # cujo nome começa com ponto.
+  while IFS= read -r found; do
+    [[ -n "${found}" ]] || continue
+    [[ "${found}" != "${keep}" ]] || continue
+    echo "  ⚠️  uid '${uid}' duplicado em ${found} — movendo para quarentena"
+    sudo install -d -m 0755 "${GRAFANA_DASHBOARD_BACKUP_DIR}"
+    sudo mv "${found}" \
+      "${GRAFANA_DASHBOARD_BACKUP_DIR}/$(basename "${found}").duplicate.${timestamp}"
+  done < <(
+    sudo find "${GRAFANA_PROVISIONING_DIR}" -name '.*' -prune -o -name '*.json' -type f -print \
+      | sort \
+      | while IFS= read -r candidate; do
+          sudo python3 -c "
+import json, sys
+try:
+    if json.load(open(sys.argv[1])).get('uid') == sys.argv[2]:
+        print(sys.argv[1])
+except Exception:
+    pass
+" "${candidate}" "${uid}"
+        done
+  )
+}
+
+assert_no_duplicate_dashboard_uids() {
+  local report
+  report="$(
+    sudo find "${GRAFANA_PROVISIONING_DIR}" -name '.*' -prune -o -name '*.json' -type f -print \
+      | sudo python3 -c "
+import json, sys
+from collections import defaultdict
+
+by_uid = defaultdict(list)
+for line in sys.stdin.read().splitlines():
+    if not line:
+        continue
+    try:
+        uid = json.load(open(line)).get('uid')
+    except Exception:
+        continue
+    if uid:
+        by_uid[uid].append(line)
+
+for uid, paths in sorted(by_uid.items()):
+    if len(paths) > 1:
+        print(f\"{uid}: {' | '.join(paths)}\")
+"
+  )"
+
+  if [[ -n "${report}" ]]; then
+    echo "❌ uid duplicado sob ${GRAFANA_PROVISIONING_DIR} — provisionamento vai congelar:" >&2
+    printf '   %s\n' "${report}" >&2
+    echo "   Eleja uma fonte de verdade e mova a outra cópia para ${GRAFANA_DASHBOARD_BACKUP_DIR}" >&2
+    exit 1
+  fi
+  echo "  ✅ Nenhum uid duplicado sob o path do provider"
+}
+
 sync_btc_grafana_dashboard() {
-  backup_if_present "${BTC_DASHBOARD_DST}"
+  backup_dashboard_if_present "${BTC_DASHBOARD_DST}"
   sync_grafana_dashboard_file "${BTC_DASHBOARD_SRC}" "${BTC_DASHBOARD_DST}"
   cleanup_btc_dashboard_duplicates
+  quarantine_dashboard_uid_duplicates "${BTC_DASHBOARD_DST}" "btc-trading-monitor"
+  assert_no_duplicate_dashboard_uids
 }
 
 sync_multi_coin_configs() {

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -23,9 +23,52 @@ def test_script_archives_duplicate_btc_dashboard_files_before_grafana_restart() 
     content = _load_script()
     assert '"${GRAFANA_PROVISIONING_DIR}/btc_trading_monitor.json"' in content
     assert '"${GRAFANA_PROVISIONING_DIR}/btc_trading_dashboard_v3_prometheus.json"' in content
-    assert "dashboard_backups" in content
     assert "cleanup_btc_dashboard_duplicates" in content
     assert content.index("cleanup_btc_dashboard_duplicates") < content.index("restart_grafana_if_present")
+
+
+def test_dashboard_backups_never_land_inside_the_provider_path() -> None:
+    """Um .json de backup ao lado do original é duplicata de uid permanente.
+
+    O provider `eddie-dashboards` varre GRAFANA_PROVISIONING_DIR recursivamente;
+    dois arquivos com o mesmo uid fazem o Grafana recusar gravar e congelar o
+    provisionamento de todos os dashboards, sem erro visível no deploy.
+    """
+    content = _load_script()
+    assert (
+        'GRAFANA_DASHBOARD_BACKUP_DIR="${GRAFANA_DASHBOARD_BACKUP_DIR:-'
+        '/home/homelab/monitoring/grafana/dashboard_quarantine}"' in content
+    )
+    assert "backup_dashboard_if_present" in content
+    # o backup do dashboard vai para a quarentena, não para "${path}.bak.TIMESTAMP"
+    assert 'backup_dashboard_if_present "${BTC_DASHBOARD_DST}"' in content
+    assert 'backup_if_present "${BTC_DASHBOARD_DST}"' not in content
+
+
+def test_script_quarantines_uid_duplicates_not_just_legacy_filenames() -> None:
+    """O repo homelab-grafana-dashboards deploya em subpastas do MESMO provider.
+
+    Uma cópia de btc-trading-monitor pode reaparecer em qualquer caminho sob o
+    provider (ex.: trading/btc-trading-monitor.json), então a limpeza por nome de
+    arquivo legado não basta — o que colide para o Grafana é o uid.
+    """
+    content = _load_script()
+    assert "quarantine_dashboard_uid_duplicates" in content
+    assert 'quarantine_dashboard_uid_duplicates "${BTC_DASHBOARD_DST}" "btc-trading-monitor"' in content
+    # varredura com a mesma semântica do Grafana: ignora diretórios iniciados por ponto
+    assert "-name '.*' -prune -o -name '*.json' -type f -print" in content
+
+
+def test_script_fails_deploy_when_provider_path_has_duplicate_uids() -> None:
+    content = _load_script()
+    assert "assert_no_duplicate_dashboard_uids" in content
+    assert (
+        content.index("quarantine_dashboard_uid_duplicates \"${BTC_DASHBOARD_DST}\"")
+        < content.index("assert_no_duplicate_dashboard_uids\n}")
+    )
+    assert content.index("assert_no_duplicate_dashboard_uids") < content.index(
+        "restart_grafana_if_present"
+    )
 
 
 def test_script_defaults_to_live_crypto_agent_service_user() -> None:

--- a/tests/test_kwai_agenda_publisher.py
+++ b/tests/test_kwai_agenda_publisher.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import kwai_agenda_publisher as kwai  # noqa: E402
+
+
+def test_build_caption_e_factual() -> None:
+    title, script = kwai.build_caption("2026-07-14")
+    assert "14/07/2026" in title
+    assert "Flávio Bolsonaro" in title
+    assert "agenda pública" in script
+    assert "Fontes:" in script
+
+
+def test_publish_edition_reusa_mp4_e_grava_meta(tmp_path, monkeypatch) -> None:
+    day = tmp_path / "2026-07-14"
+    day.mkdir()
+    (day / "locution.wav").write_bytes(b"wav")
+    (day / "locution.mp4").write_bytes(b"mp4")
+    (day / "publish_meta.json").write_text(
+        json.dumps({"youtube_video_id": "abc123"}), encoding="utf-8"
+    )
+
+    class FakePublisher:
+        def __init__(self, upload_url=None):
+            self.upload_url = upload_url
+
+        def publish(self, content, video, *, platform):
+            assert platform == "kwai"
+            assert video.mp4_path.endswith("locution.mp4")
+
+            class Result:
+                external_id = "kwai42"
+                url = "https://www.kwai.com/video/kwai42"
+
+            return Result()
+
+    from content_automation import publisher as pub_mod
+
+    monkeypatch.setattr(pub_mod, "KwaiPublisher", FakePublisher)
+
+    result = kwai.publish_edition("2026-07-14", artifacts_dir=tmp_path)
+    assert result.post_id == "kwai42"
+    assert result.post_url == "https://www.kwai.com/video/kwai42"
+
+    meta = json.loads((day / "publish_meta.json").read_text(encoding="utf-8"))
+    assert meta["kwai_post_id"] == "kwai42"
+    assert meta["kwai_url"] == "https://www.kwai.com/video/kwai42"
+    assert meta["youtube_video_id"] == "abc123"
+
+
+def test_publish_edition_renderiza_mp4_quando_ausente(tmp_path, monkeypatch) -> None:
+    day = tmp_path / "2026-07-14"
+    day.mkdir()
+    (day / "locution.wav").write_bytes(b"wav")
+
+    import youtube_agenda_publisher as yt
+
+    def fake_render(*, wav_path, output_mp4, cover_image=None):
+        output_mp4.write_bytes(b"mp4")
+        return output_mp4
+
+    monkeypatch.setattr(yt, "render_audio_video", fake_render)
+
+    class FakePublisher:
+        def __init__(self, upload_url=None):
+            self.upload_url = upload_url
+
+        def publish(self, content, video, *, platform):
+            class Result:
+                external_id = "novo1"
+                url = "https://www.kwai.com/video/novo1"
+
+            return Result()
+
+    from content_automation import publisher as pub_mod
+
+    monkeypatch.setattr(pub_mod, "KwaiPublisher", FakePublisher)
+
+    result = kwai.publish_edition("2026-07-14", artifacts_dir=tmp_path)
+    assert result.post_id == "novo1"
+    assert (day / "locution.mp4").exists()

--- a/tools/daily_agenda_config.py
+++ b/tools/daily_agenda_config.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "include_news": True,
         "send_telegram": True,
         "upload_youtube": True,
+        "upload_kwai": True,
         "require_approval": True,
         "deep_search": True,
     },
@@ -56,6 +57,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "telegram": {
         "enabled": True,
         "chat_id": os.getenv("AGENDA_TELEGRAM_CHAT_ID", ""),
+    },
+    "kwai": {
+        "enabled": True,
+        "profile_handle": os.getenv("AGENDA_KWAI_HANDLE", ""),
+        "upload_url": "",
     },
     "editorial": {
         "stance": "pro_bolsonaro_allies",
@@ -170,6 +176,8 @@ def list_editions(artifacts_dir: Path | None = None) -> list[dict[str, Any]]:
                 "has_mp4": (day_dir / "locution.mp4").exists(),
                 "youtube_video_id": meta.get("youtube_video_id", ""),
                 "youtube_url": meta.get("youtube_url", ""),
+                "kwai_post_id": meta.get("kwai_post_id", ""),
+                "kwai_url": meta.get("kwai_url", ""),
                 "updated_at": meta.get("updated_at", ""),
             }
         )

--- a/tools/daily_agenda_config.py
+++ b/tools/daily_agenda_config.py
@@ -61,7 +61,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "kwai": {
         "enabled": True,
         "profile_handle": os.getenv("AGENDA_KWAI_HANDLE", ""),
-        "upload_url": "",
+        "upload_url": os.getenv("KWAI_UPLOAD_URL", ""),
     },
     "editorial": {
         "stance": "pro_bolsonaro_allies",

--- a/tools/kwai_agenda_publisher.py
+++ b/tools/kwai_agenda_publisher.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Publica a edição da agenda diária no Kwai (reaproveita o mp4 do YouTube)."""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from daily_agenda_config import load_config, resolve_repo_path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KwaiPublishResult:
+    post_id: str
+    post_url: str
+    title: str
+
+
+def build_caption(date_str: str) -> tuple[str, str]:
+    from youtube_agenda_publisher import build_video_title
+
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    title = build_video_title(date_str)
+    script = (
+        f"Boletim automatizado da agenda pública do senador Flávio Bolsonaro "
+        f"para {dt.strftime('%d/%m/%Y')}. "
+        "Fontes: Congresso Nacional, comissões do Senado e cobertura da imprensa."
+    )
+    return title, script
+
+
+def _ensure_mp4(date_str: str, day_dir: Path, cfg: dict[str, Any]) -> Path:
+    from youtube_agenda_publisher import render_audio_video
+
+    mp4_path = day_dir / "locution.mp4"
+    if mp4_path.exists():
+        return mp4_path
+    wav_path = day_dir / "locution.wav"
+    if not wav_path.exists():
+        raise RuntimeError(f"Áudio ausente para {date_str}: {wav_path}")
+    cover_image = resolve_repo_path(cfg["youtube"].get("cover_image", ""))
+    return render_audio_video(
+        wav_path=wav_path,
+        output_mp4=mp4_path,
+        cover_image=cover_image,
+    )
+
+
+def publish_edition(
+    date_str: str,
+    *,
+    artifacts_dir: Path,
+    config: dict[str, Any] | None = None,
+) -> KwaiPublishResult:
+    cfg = config or load_config()
+    kwai_cfg = cfg.get("kwai", {})
+    if not kwai_cfg.get("enabled", True):
+        raise RuntimeError("Publicação Kwai desabilitada na configuração.")
+
+    day_dir = artifacts_dir / date_str
+    mp4_path = _ensure_mp4(date_str, day_dir, cfg)
+
+    from content_automation.models import GeneratedContent, VideoArtifact
+    from content_automation.publisher import KwaiPublisher
+
+    title, script = build_caption(date_str)
+    content = GeneratedContent(
+        topic="agenda-diaria",
+        title=title,
+        script=script,
+        cta="",
+    )
+    video = VideoArtifact(
+        mp4_path=str(mp4_path),
+        wav_path=str(day_dir / "locution.wav"),
+        srt_path="",
+        cover_path="",
+        duration_seconds=0.0,
+    )
+
+    upload_url = (kwai_cfg.get("upload_url") or "").strip() or None
+    result = KwaiPublisher(upload_url=upload_url).publish(content, video, platform="kwai")
+
+    meta_path = day_dir / "publish_meta.json"
+    meta: dict[str, Any] = {}
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta.update(
+        {
+            "kwai_post_id": result.external_id,
+            "kwai_url": result.url,
+            "kwai_title": title,
+            "updated_at": datetime.now().isoformat(timespec="seconds"),
+        }
+    )
+    meta_path.write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    logger.info("Kwai publicado: %s", result.url)
+    return KwaiPublishResult(
+        post_id=result.external_id,
+        post_url=result.url,
+        title=title,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    if len(sys.argv) < 2:
+        print("Uso: python3 tools/kwai_agenda_publisher.py YYYY-MM-DD [artifacts_dir]")
+        sys.exit(1)
+    date_arg = sys.argv[1]
+    artifacts = (
+        Path(sys.argv[2])
+        if len(sys.argv) > 2
+        else REPO_ROOT / "artifacts" / "daily_agenda"
+    )
+    published = publish_edition(date_arg, artifacts_dir=artifacts)
+    print(f"Kwai: {published.post_url}")

--- a/tools/run_daily_agenda_broadcast.py
+++ b/tools/run_daily_agenda_broadcast.py
@@ -376,6 +376,12 @@ def parse_args() -> argparse.Namespace:
         help="Publica no canal YouTube após gerar o áudio.",
     )
     parser.add_argument(
+        "--upload-kwai",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Publica também no Kwai após gerar o áudio.",
+    )
+    parser.add_argument(
         "--require-approval",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -410,6 +416,57 @@ def _publish_youtube(date_str: str, artifacts_dir: Path, panel_cfg: dict) -> str
     return yt_result.video_url
 
 
+def _publish_kwai(date_str: str, artifacts_dir: Path, panel_cfg: dict) -> str:
+    from kwai_agenda_publisher import publish_edition as publish_kwai_edition
+
+    kwai_result = publish_kwai_edition(
+        date_str,
+        artifacts_dir=artifacts_dir,
+        config=panel_cfg,
+    )
+    return kwai_result.post_url
+
+
+def _publish_platforms(
+    *,
+    date_str: str,
+    artifacts_dir: Path,
+    panel_cfg: dict,
+    upload_youtube: bool,
+    upload_kwai: bool,
+) -> tuple[str, str]:
+    """Publica nas plataformas habilitadas; falha em uma não bloqueia a outra."""
+    youtube_url = ""
+    kwai_url = ""
+    if upload_youtube:
+        try:
+            youtube_url = _publish_youtube(date_str, artifacts_dir, panel_cfg)
+        except Exception:
+            logger.warning("Falha ao publicar no YouTube.", exc_info=True)
+    if upload_kwai:
+        try:
+            kwai_url = _publish_kwai(date_str, artifacts_dir, panel_cfg)
+        except Exception:
+            logger.warning("Falha ao publicar no Kwai.", exc_info=True)
+    return youtube_url, kwai_url
+
+
+def _publish_summary_message(
+    date_str: str,
+    youtube_url: str,
+    kwai_url: str,
+    *,
+    upload_youtube: bool,
+    upload_kwai: bool,
+) -> str:
+    lines = [f"✅ Agenda {date_str} publicada:"]
+    if upload_youtube:
+        lines.append(f"YouTube: {youtube_url}" if youtube_url else "YouTube: falhou ⚠️")
+    if upload_kwai:
+        lines.append(f"Kwai: {kwai_url}" if kwai_url else "Kwai: falhou ⚠️")
+    return "\n".join(lines)
+
+
 def _run_with_optional_approval(
     *,
     args: argparse.Namespace,
@@ -417,7 +474,7 @@ def _run_with_optional_approval(
     date_str: str,
     media_plan,
     telegram_chat_id: str | None,
-) -> tuple[BroadcastArtifacts, str, str]:
+) -> tuple[BroadcastArtifacts, str, str, str]:
     approval_cfg = panel_cfg.get("approval", {})
     require_approval = (
         args.require_approval
@@ -428,6 +485,11 @@ def _run_with_optional_approval(
         args.upload_youtube
         if args.upload_youtube is not None
         else panel_cfg["defaults"].get("upload_youtube", False)
+    )
+    upload_kwai = (
+        args.upload_kwai
+        if args.upload_kwai is not None
+        else panel_cfg["defaults"].get("upload_kwai", False)
     )
     timeout_minutes = (
         args.approval_timeout_minutes
@@ -452,6 +514,7 @@ def _run_with_optional_approval(
     if args.retries == 4 and search_cfg.get("retries"):
         args.retries = int(search_cfg["retries"])
     youtube_url = ""
+    kwai_url = ""
     approval_note = ""
 
     while True:
@@ -479,12 +542,15 @@ def _run_with_optional_approval(
         )
 
         if args.dry_run or not require_approval:
-            if upload_youtube and not args.dry_run and result.wav_path:
-                try:
-                    youtube_url = _publish_youtube(date_str, args.artifacts_dir, panel_cfg)
-                except Exception:
-                    logger.warning("Falha ao publicar no YouTube.", exc_info=True)
-            return result, youtube_url, approval_note
+            if not args.dry_run and result.wav_path:
+                youtube_url, kwai_url = _publish_platforms(
+                    date_str=date_str,
+                    artifacts_dir=args.artifacts_dir,
+                    panel_cfg=panel_cfg,
+                    upload_youtube=upload_youtube,
+                    upload_kwai=upload_kwai,
+                )
+            return result, youtube_url, kwai_url, approval_note
 
         if not telegram_chat_id:
             raise RuntimeError("require_approval exige telegram_chat_id configurado.")
@@ -500,21 +566,30 @@ def _run_with_optional_approval(
         )
         if decision == "approved":
             approval_note = "Aprovado no Telegram."
-            if upload_youtube and result.wav_path:
-                try:
-                    youtube_url = _publish_youtube(date_str, args.artifacts_dir, panel_cfg)
-                    send_telegram_message(
-                        f"✅ Agenda publicada no YouTube\n{youtube_url}",
-                        chat_id=telegram_chat_id,
-                    )
-                except Exception:
-                    logger.warning("Falha ao publicar no YouTube após aprovação.", exc_info=True)
-            else:
+            if (upload_youtube or upload_kwai) and result.wav_path:
+                youtube_url, kwai_url = _publish_platforms(
+                    date_str=date_str,
+                    artifacts_dir=args.artifacts_dir,
+                    panel_cfg=panel_cfg,
+                    upload_youtube=upload_youtube,
+                    upload_kwai=upload_kwai,
+                )
                 send_telegram_message(
-                    "✅ Agenda aprovada. Publicação YouTube desabilitada.",
+                    _publish_summary_message(
+                        date_str,
+                        youtube_url,
+                        kwai_url,
+                        upload_youtube=upload_youtube,
+                        upload_kwai=upload_kwai,
+                    ),
                     chat_id=telegram_chat_id,
                 )
-            return result, youtube_url, approval_note
+            else:
+                send_telegram_message(
+                    "✅ Agenda aprovada. Publicação em plataformas desabilitada.",
+                    chat_id=telegram_chat_id,
+                )
+            return result, youtube_url, kwai_url, approval_note
 
         if decision == "regenerate" and attempt <= max_regenerations:
             attempt += 1
@@ -536,7 +611,7 @@ def _run_with_optional_approval(
                 f"⏹️ Agenda {date_str} não publicada ({decision}).",
                 chat_id=telegram_chat_id,
             )
-        return result, "", approval_note
+        return result, "", "", approval_note
 
 
 def main() -> int:
@@ -569,7 +644,7 @@ def main() -> int:
     if not telegram_chat_id:
         telegram_chat_id = get_agenda_telegram_chat_id() or None
 
-    result, youtube_url, approval_note = _run_with_optional_approval(
+    result, youtube_url, kwai_url, approval_note = _run_with_optional_approval(
         args=args,
         panel_cfg=panel_cfg,
         date_str=date_str,
@@ -592,6 +667,10 @@ def main() -> int:
         print(f"Fontes utilizadas: {', '.join(result.sources_used)}")
     if result.sources_failed:
         print(f"Fontes sem resultado: {', '.join(result.sources_failed)}")
+    if youtube_url:
+        print(f"YouTube: {youtube_url}")
+    if kwai_url:
+        print(f"Kwai: {kwai_url}")
     if args.dry_run:
         print("\nDry-run: Telegram nao foi acionado.")
     elif approval_note:


### PR DESCRIPTION
Lado eddie-auto-dev do par com eddiejdi/homelab-grafana-dashboards#5.

## Problema

O provider `eddie-dashboards` aponta para a **raiz** de `/home/homelab/monitoring/grafana/provisioning/dashboards/` e varre **recursivamente**. Se dois arquivos quaisquer ali dentro tiverem o mesmo `uid`, o Grafana emite

```
dashboards provisioning provider has no database write permissions because of duplicates
```

e congela o provisionamento de **todos** os dashboards. O sintoma é silencioso: o deploy grava no disco, o job fica verde, e a API continua servindo a versão antiga. Foi o bloqueio de 22/07 a 24/07 de 2026.

Duas coisas neste script podiam causar isso:

**1. Backup dentro do path do provider.** `backup_if_present "${BTC_DASHBOARD_DST}"` criava `btc-trading-monitor.json.bak.TIMESTAMP` ao lado do original. Hoje esses arquivos são inertes por acidente (o Grafana só lê sufixo `.json` exato), mas basta um backup com nome terminado em `.json` para armar a bomba. A variável `GRAFANA_DASHBOARD_BACKUP_DIR` já existia e estava morta — nada a usava.

**2. Limpeza de duplicatas por nome de arquivo.** `cleanup_btc_dashboard_duplicates` cobria só dois nomes legados (`btc_trading_monitor.json`, `btc_trading_dashboard_v3_prometheus.json`). O repo `homelab-grafana-dashboards` deploya em subpastas por categoria do **mesmo** path, então a cópia dele reaparecia em `trading/btc-trading-monitor.json` e escapava — foi exatamente essa a colisão. O que colide para o Grafana é o `uid`, não o nome do arquivo.

## Solução

- `backup_dashboard_if_present` escreve na quarentena; default de `GRAFANA_DASHBOARD_BACKUP_DIR` passa a ser `/home/homelab/monitoring/grafana/dashboard_quarantine` (fora do path do provider).
- `quarantine_dashboard_uid_duplicates` varre o provider **por uid**, com a mesma semântica do Grafana (recursiva, só `*.json`, ignora diretórios iniciados por ponto), e move o intruso para a quarentena.
- `assert_no_duplicate_dashboard_uids` falha o deploy se sobrar qualquer uid duplicado sob o provider — inclusive de dashboards que este script não gerencia.

Não estendi o check 7 do `.githooks/pre-commit` (UID uniqueness) para `grafana/dashboards/**`: aquele diretório é staging, não espelho do provider, e já contém duplicatas legítimas (`storj-node-monitor` em 3 arquivos, `tape-component-quality-v1` em 2) que nunca coexistem no servidor. A checagem correta é em tempo de deploy, contra o path real.

## Verificação

Funções extraídas e exercitadas em sandbox com `sudo` stubado:

- intruso em `prov/trading/btc-trading-monitor.json` → movido para a quarentena; canônico preservado
- cópia em `prov/.bak-1/btc-trading-monitor.json` (dot-dir) → corretamente ignorada, como o Grafana faz
- colisão de uid **não-BTC** (`outro-dash` em dois caminhos) → `assert` falha com exit 1

Testes do gate do workflow, todos passando:

```
tests/test_deploy_btc_trading_profiles_script.py  11 passed
tests/test_grafana_dashboard_queries.py
tests/test_multi_entry_sell_behavior.py
tests/unit/test_position_manager_mixin.py          76 passed
```

Quatro leftovers foram removidos do path do provider no servidor e movidos para `dashboard_quarantine/20260724_leftovers/` — um deles (`btc-trading-monitor.json.bak.20260724_201255`) foi criado por um deploy que rodou durante esta análise, confirmando que o vazamento estava ativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)