### PR TITLE
fix(trading): elimina storm de 503 do Ollama — num_ctx divergente do Modelfile

### DIFF
--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -1801,6 +1801,15 @@ class BitcoinTradingAgent(
     # trading-analyst a ~6 tok/s com num_predict=1024 leva ~170s; 200s dá margem.
     _OLLAMA_PLAN_TIMEOUT_SEC = float(os.getenv("OLLAMA_PLAN_TIMEOUT_SEC", "200"))
 
+    # Tem que bater com o "PARAMETER num_ctx" do Modelfile do modelo servido.
+    # Um num_ctx divergente força o Ollama a subir um runner novo; com
+    # MAX_LOADED_MODELS=1 e KEEP_ALIVE prendendo o runner residente, esse runner
+    # nunca é agendado e a request morre na fila devolvendo
+    # 503 "maximum pending requests exceeded" — mesmo com a GPU 100% ociosa.
+    # Um valor só para todas as chamadas: divergir daqui derruba o agente em 503.
+    # Para mudar, mude junto com o Modelfile.
+    _OLLAMA_NUM_CTX = 4096
+
     @staticmethod
     def _parse_ai_plan_controls(
         raw_text: str,
@@ -2276,7 +2285,7 @@ class BitcoinTradingAgent(
                 options={
                     "temperature": 0.0,
                     "num_predict": 256,
-                    "num_ctx": 2048,
+                    "num_ctx": self._OLLAMA_NUM_CTX,
                     "repeat_penalty": 1.05,
                     "top_k": 20,
                     "top_p": 0.70,
@@ -2555,7 +2564,7 @@ class BitcoinTradingAgent(
                 options={
                     "temperature": 0.0,
                     "num_predict": 256,
-                    "num_ctx": 2048,
+                    "num_ctx": self._OLLAMA_NUM_CTX,
                     "repeat_penalty": 1.05,
                     "top_k": 20,
                     "top_p": 0.70,
@@ -3145,15 +3154,17 @@ class BitcoinTradingAgent(
             plan_options = {
                 "temperature": 0.4,
                 "num_predict": 1024,
-                "num_ctx": 4096,
+                "num_ctx": self._OLLAMA_NUM_CTX,
                 "repeat_penalty": 1.3,
                 "repeat_last_n": 128,
                 "top_k": 40,
                 "top_p": 0.9,
             }
-            # GPU1 (GTX 1050 2GB) precisa de contexto menor para caber na VRAM
+            # O fallback vai para a GPU1, que também serve o modelo com num_ctx 4096
+            # (lfm2.5-fast:gpu1). Herdar o mesmo num_ctx é obrigatório: um valor
+            # menor aqui só produzia 503 "maximum pending requests exceeded".
             # num_predict=768 evita truncamento que causa respostas curtas sem vocabulário de trading
-            plan_options_fallback = {**plan_options, "num_ctx": 2048, "num_predict": 768}
+            plan_options_fallback = {**plan_options, "num_predict": 768}
 
             # Prompt compacto para modelos instruct pequenos (GPU1)
             # Usa vocabulário explícito de trading para passar no _sanitize_ai_plan

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-24T22:57:13.635828+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-07-25T00:17:20.276619+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-numctx",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-24T22:57:13.635828+00:00`
+- Generated at: `2026-07-25T00:17:20.276619+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/tests/test_ollama_num_ctx_consistency.py
+++ b/tests/test_ollama_num_ctx_consistency.py
@@ -1,0 +1,75 @@
+"""Guarda o num_ctx único usado nas chamadas Ollama do trading agent.
+
+Contexto (incidente 2026-07-24): as chamadas de trade window / trade controls
+mandavam num_ctx=2048 enquanto o Modelfile do trading-analyst fixa 4096. Um
+num_ctx divergente obriga o Ollama a subir um runner novo; com
+OLLAMA_MAX_LOADED_MODELS=1 e KEEP_ALIVE prendendo o runner residente, esse
+runner nunca é agendado e a request morre na fila devolvendo
+503 "maximum pending requests exceeded" — com a GPU 100% ociosa.
+
+O agente ficou com 94% das chamadas LLM em 503 e o sintoma se disfarça de
+"GPU sobrecarregada", que é o diagnóstico errado. Estes testes falham se
+alguém reintroduzir um literal divergente.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+AGENT_SRC = Path(__file__).resolve().parent.parent / "btc_trading_agent" / "trading_agent.py"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return AGENT_SRC.read_text(encoding="utf-8")
+
+
+def test_constante_num_ctx_existe_e_bate_com_o_modelfile(source: str) -> None:
+    """_OLLAMA_NUM_CTX tem que existir e valer 4096 (o num_ctx do Modelfile)."""
+    match = re.search(r"^\s*_OLLAMA_NUM_CTX\s*=\s*(\d+)\s*$", source, re.MULTILINE)
+    assert match, "_OLLAMA_NUM_CTX sumiu de trading_agent.py"
+    assert int(match.group(1)) == 4096, (
+        "_OLLAMA_NUM_CTX divergiu de 4096. Só mude junto com o "
+        "'PARAMETER num_ctx' do Modelfile do modelo servido — divergir "
+        "derruba o agente inteiro em 503."
+    )
+
+
+def test_nenhuma_chamada_usa_num_ctx_literal(source: str) -> None:
+    """Todo num_ctx nas options tem que referenciar a constante, nunca um literal."""
+    tree = ast.parse(source)
+    literais: list[tuple[int, int]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for chave, valor in zip(node.keys, node.values):
+            if not (isinstance(chave, ast.Constant) and chave.value == "num_ctx"):
+                continue
+            if isinstance(valor, ast.Constant) and isinstance(valor.value, int):
+                literais.append((valor.lineno, valor.value))
+
+    assert not literais, (
+        "num_ctx literal encontrado em "
+        + ", ".join(f"linha {ln} (={v})" for ln, v in literais)
+        + ". Use self._OLLAMA_NUM_CTX — um valor divergente do Modelfile "
+        "faz o Ollama devolver 503 'maximum pending requests exceeded'."
+    )
+
+
+def test_fallback_do_plano_herda_o_mesmo_num_ctx(source: str) -> None:
+    """O fallback do plano (GPU1) não pode sobrescrever num_ctx.
+
+    A GPU1 serve lfm2.5-fast:gpu1, que também é num_ctx 4096 desde 2026-07-10
+    (substituiu o gemma3-fast, esse sim 2048). Sobrescrever aqui reintroduz o 503.
+    """
+    match = re.search(r"plan_options_fallback\s*=\s*\{([^}]*)\}", source)
+    assert match, "plan_options_fallback não encontrado"
+    assert "num_ctx" not in match.group(1), (
+        "plan_options_fallback voltou a sobrescrever num_ctx. A GPU1 serve "
+        "lfm2.5-fast:gpu1 com num_ctx 4096; um valor menor só gera 503."
+    )


### PR DESCRIPTION
## Sintoma

O trading agent estava com **94% das chamadas LLM em 503** (`maximum pending requests exceeded`), com a RTX 3060 **100% ociosa** (`active_requests=0` amostrado a cada 2s). O sintoma se disfarça de "GPU sobrecarregada" — que é o diagnóstico errado e leva a mexer em `NUM_PARALLEL`/`MAX_QUEUE` sem efeito.

## Causa

`trade window` e `trade controls` mandavam `num_ctx=2048`, mas o Modelfile do `trading-analyst` fixa `PARAMETER num_ctx 4096`.

Um `num_ctx` divergente obriga o Ollama a subir um **runner novo**. Com `OLLAMA_MAX_LOADED_MODELS=1` e `KEEP_ALIVE` prendendo o runner residente, esse runner nunca é agendado — a request morre na fila e é rejeitada na hora.

Verificação determinística no host, com a GPU parada:

| `num_ctx` | HTTP |
|---|---|
| 4096 | **200** |
| 2048 | **503** |
| 8192 | **503** |
| 4096 | **200** |

## Segundo defeito, mais antigo

`plan_options_fallback` mandava `num_ctx: 2048` com o comentário *"GPU1 precisa de contexto menor para caber na VRAM"*.

O comentário ficou obsoleto em **2026-07-10**, quando a GPU1 passou de `gemma3-fast` (num_ctx 2048) para `lfm2.5-fast:gpu1` (num_ctx **4096**). Esse caminho de fallback estava quebrado silenciosamente desde então — confirmado no ring buffer do coordinator: `lfm2.5-fast:gpu1 → 503`.

## Correção

Unifica os quatro pontos em `_OLLAMA_NUM_CTX`, **deliberadamente não configurável por env** — divergir do Modelfile derruba o agente inteiro em 503, então não é um botão que deva existir.

Teste novo (`tests/test_ollama_num_ctx_consistency.py`) falha se alguém reintroduzir um literal, via AST, e se o fallback voltar a sobrescrever `num_ctx`.

## Escopo / segurança

Não altera `_get_guardrail_sell_verdict` nem qualquer caminho de execução de ordem — só o `num_ctx` das chamadas ao Ollama. O guardrail de SELL é determinístico e seguiu funcionando durante todo o incidente; o storm degradava apenas a camada consultiva de IA.

Deploy pelo caminho normal: restart **escalonado**, sem janela de frota parada (há US$ 4,7k de exposição real aberta).

## Testes

- `tests/test_ollama_num_ctx_consistency.py` — 3 novos
- `test_profile_rules`, `test_profile_trade_guards`, `test_runtime_safety_guards`, `test_buy_profitability_guard`, `test_fast_model_profile_scope` — 35 passam
- `test_llm_calls_logging`, `test_grafana_dashboard_queries` — 40 passam

🤖 Generated with [Claude Code](https://claude.com/claude-code)