### PR TITLE
fix(ollama): alinha config da GPU1 ao modelo realmente servido (lfm2.5-fast)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -45,7 +45,7 @@
         "LLM_GPU1_HOST": "http://192.168.15.2:11545",
         "LLM_NAS_HOST": "http://192.168.15.4:11546",
         "LLM_GPU0_MODEL": "trading-analyst",
-        "LLM_GPU1_MODEL": "gemma3-fast:gpu1",
+        "LLM_GPU1_MODEL": "lfm2.5-fast:gpu1",
         "LLM_NAS_MODEL": "phi4-mini:latest"
       }
     }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-25T00:17:20.276619+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-numctx",
+  "generated_at": "2026-07-25T17:30:37.292781+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-gpu1",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T00:17:20.276619+00:00`
+- Generated at: `2026-07-25T17:30:37.292781+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/scripts/ollama_mcp_server.py
+++ b/scripts/ollama_mcp_server.py
@@ -4,7 +4,7 @@ Ollama MCP Server — exposes local GPU cluster (3 GPUs) as Claude Code tools.
 
 Saves Claude API tokens by routing eligible tasks to local LLMs:
   GPU0  RTX 3060 12GB  192.168.15.2:11544  (proxy → 11434)  trading-analyst / heavy
-  GPU1  GTX 1050  2GB  192.168.15.2:11545  (proxy → 11435)  gemma3-fast:gpu1 / fast
+  GPU1  GTX 1050  2GB  192.168.15.2:11545  (proxy → 11435)  lfm2.5-fast:gpu1 / fast
   NAS   RTX 2060  8GB  192.168.15.4:11546  (proxy → 11436)  phi4-mini:latest / mid-tier
 
 Tools exposed to Claude Code:
@@ -46,7 +46,7 @@ ENDPOINTS = [
     {
         "name": "gpu1-gtx1050",
         "host": os.environ.get("LLM_GPU1_HOST", "http://192.168.15.2:11545"),
-        "model": os.environ.get("LLM_GPU1_MODEL", "gemma3-fast:gpu1"),
+        "model": os.environ.get("LLM_GPU1_MODEL", "lfm2.5-fast:gpu1"),
         "vram_gb": 2,
         "speed": "fast",
     },

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -1,13 +1,16 @@
 [Service]
 # Roteamento via coordenador (11437) — GPU routing automático por modelo.
-# Plano usa gemma3-fast (GPU1) para não competir com conservative/shadow no GPU0.
-#   trading-analyst → GPU0 (11434, RTX 2060)
-#   gemma3-fast:gpu1 → GPU1 (11435, GTX 1050)
+# Plano vai para a GPU1 para não competir com conservative/shadow no GPU0.
+#   trading-analyst   → GPU0 (11434, RTX 3060 12GB)
+#   lfm2.5-fast:gpu1  → GPU1 (11435, GTX 1050 2GB)
+# O modelo da GPU1 é lfm2.5-fast:gpu1 desde 2026-07-10 (substituiu gemma3-fast).
+# Apontar para um modelo não residente força carga nova e, com
+# MAX_LOADED_MODELS=1, devolve 503 — manter alinhado com deploy/crypto-agent/models.env.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_MODEL=gemma3-fast:gpu1
-Environment=OLLAMA_PLAN_FALLBACK_MODEL=gemma3-fast:gpu1
+Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
+Environment=OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1

--- a/systemd/ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf
+++ b/systemd/ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf
@@ -1,7 +1,7 @@
 [Service]
 # Roteamento pós-upgrade:
 # - GPU0/11434: RTX 3060 12GB para trading-analyst e modelos pesados.
-# - GPU1/11435: RTX 2060 SUPER 8GB para gemma3-fast:gpu1 e janelas rápidas.
+# - GPU1/11435: GTX 1050 2GB para lfm2.5-fast:gpu1 e janelas rápidas.
 Environment=OLLAMA_GPU0_HOST=http://192.168.15.2:11434
 Environment=OLLAMA_GPU1_HOST=http://192.168.15.2:11435
 # O busy check atual usa /api/ps, que mostra modelos keep_alive como "ocupados".

--- a/systemd/ollama-gpu1.service.d/zzzz-warmup-curl.conf
+++ b/systemd/ollama-gpu1.service.d/zzzz-warmup-curl.conf
@@ -1,4 +1,4 @@
 [Service]
 # Warmup nao interativo e limitado por timeout para a GPU1.
 ExecStartPost=
-ExecStartPost=/usr/bin/python3 /apps/crypto-trader/tools/ollama_warmup.py --host http://127.0.0.1:11435 --default-model gemma3-fast:gpu1 --timeout 90 --delay 8
+ExecStartPost=/usr/bin/python3 /apps/crypto-trader/tools/ollama_warmup.py --host http://127.0.0.1:11435 --default-model lfm2.5-fast:gpu1 --timeout 90 --delay 8

--- a/tests/test_gpu1_model_consistency.py
+++ b/tests/test_gpu1_model_consistency.py
@@ -1,0 +1,99 @@
+"""Guarda o modelo da GPU1 contra desvio entre config e realidade.
+
+Contexto: a GPU1 passou de `gemma3-fast:gpu1` para `lfm2.5-fast:gpu1` em
+2026-07-10, mas vários lugares continuaram apontando para o modelo antigo.
+Apontar para um modelo NÃO residente força o Ollama a subir um runner novo; com
+OLLAMA_MAX_LOADED_MODELS=1 isso devolve 503 "maximum pending requests exceeded"
+(ver tests/test_ollama_num_ctx_consistency.py — mesma classe de defeito).
+
+`deploy/crypto-agent/models.env` é a fonte de verdade declarada ("edite APENAS
+este arquivo para trocar de modelo"). Estes testes exigem que os demais pontos
+não a contradigam.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parent.parent
+MODELS_ENV = RAIZ / "deploy" / "crypto-agent" / "models.env"
+
+
+@pytest.fixture(scope="module")
+def modelo_gpu1() -> str:
+    """Lê o modelo da GPU1 da fonte de verdade (models.env)."""
+    texto = MODELS_ENV.read_text(encoding="utf-8")
+    match = re.search(r"^OLLAMA_SMALL_MODEL=(\S+)\s*$", texto, re.MULTILINE)
+    assert match, "OLLAMA_SMALL_MODEL não encontrado em models.env"
+    return match.group(1)
+
+
+def test_models_env_define_modelo_gpu1(modelo_gpu1: str) -> None:
+    assert modelo_gpu1.endswith(":gpu1"), (
+        f"OLLAMA_SMALL_MODEL={modelo_gpu1!r} deveria ter sufixo :gpu1 — "
+        "o coordinator usa esse sufixo para pinar o roteamento na GPU1."
+    )
+
+
+def test_fallbacks_do_models_env_usam_o_modelo_da_gpu1(modelo_gpu1: str) -> None:
+    """Todos os *_FALLBACK_MODEL apontam para a GPU1, não para um modelo velho."""
+    texto = MODELS_ENV.read_text(encoding="utf-8")
+    divergentes = [
+        (chave, valor)
+        for chave, valor in re.findall(r"^(\w*FALLBACK_MODEL)=(\S+)\s*$", texto, re.MULTILINE)
+        if valor.endswith(":gpu1") and valor != modelo_gpu1
+    ]
+    assert not divergentes, (
+        "fallback aponta para modelo de GPU1 diferente de "
+        f"{modelo_gpu1!r}: {divergentes}"
+    )
+
+
+def test_dropins_systemd_nao_contradizem_models_env(modelo_gpu1: str) -> None:
+    """Nenhum drop-in pode fixar um modelo :gpu1 diferente do canônico."""
+    ofensores: list[str] = []
+    for conf in (RAIZ / "systemd").rglob("*.conf"):
+        for linha_num, linha in enumerate(conf.read_text(encoding="utf-8").splitlines(), 1):
+            if linha.lstrip().startswith("#"):
+                continue
+            # [^=\s]* para casar só o valor após o ÚLTIMO '=' (Environment=CHAVE=valor)
+            for valor in re.findall(r"=([^=\s]*:gpu1)\b", linha):
+                if valor != modelo_gpu1:
+                    ofensores.append(f"{conf.relative_to(RAIZ)}:{linha_num} → {valor}")
+    assert not ofensores, (
+        f"drop-in systemd aponta para modelo de GPU1 diferente de {modelo_gpu1!r}:\n  "
+        + "\n  ".join(ofensores)
+    )
+
+
+def test_mcp_ollama_local_usa_o_modelo_da_gpu1(modelo_gpu1: str) -> None:
+    """O MCP ollama-local não pode rotear a GPU1 para um modelo não residente."""
+    mcp = json.loads((RAIZ / ".mcp.json").read_text(encoding="utf-8"))
+    env = mcp["mcpServers"]["ollama-local"]["env"]
+    assert env["LLM_GPU1_MODEL"] == modelo_gpu1, (
+        f"LLM_GPU1_MODEL={env['LLM_GPU1_MODEL']!r} diverge de "
+        f"{modelo_gpu1!r} (models.env)."
+    )
+
+
+def test_selfheal_conhece_o_modelo_da_gpu1(modelo_gpu1: str) -> None:
+    """O selfheal precisa tratar o modelo da GPU1 como leve e repô-lo após limpeza."""
+    fonte = (RAIZ / "tools" / "ollama_gpu_selfheal.py").read_text(encoding="utf-8")
+
+    light = re.search(r"LIGHT_MODELS\s*=\s*\{([^}]*)\}", fonte)
+    assert light, "LIGHT_MODELS não encontrado"
+    assert modelo_gpu1 in light.group(1), (
+        f"{modelo_gpu1!r} fora de LIGHT_MODELS — se for pinado no GPU0, "
+        "o selfheal não detecta."
+    )
+
+    warmup = re.search(r'GPU1_WARMUP_MODEL\s*=\s*os\.environ\.get\(\s*"GPU1_WARMUP_MODEL"\s*,\s*"([^"]+)"', fonte)
+    assert warmup, "GPU1_WARMUP_MODEL não encontrado"
+    assert warmup.group(1) == modelo_gpu1, (
+        f"GPU1_WARMUP_MODEL default={warmup.group(1)!r} diverge de {modelo_gpu1!r} — "
+        "a limpeza reporia o modelo errado na GPU1."
+    )

--- a/tools/ollama_gpu_selfheal.py
+++ b/tools/ollama_gpu_selfheal.py
@@ -48,9 +48,12 @@ TELEGRAM_TOKEN  = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT   = os.environ.get("TELEGRAM_CHAT_ID", "")
 
 # Modelo que deve ficar no GPU1 (leve, <2GB) — não no GPU0
-LIGHT_MODELS = {"gemma3:1b", "gemma3-fast:gpu1", "llama3.2:1b"}
-# Modelo padrão a pré-carregar no GPU1 após limpeza
-GPU1_WARMUP_MODEL = os.environ.get("GPU1_WARMUP_MODEL", "gemma3:1b")
+# lfm2.5-fast:gpu1 é o modelo da GPU1 desde 2026-07-10 (substituiu gemma3-fast).
+LIGHT_MODELS = {"gemma3:1b", "gemma3-fast:gpu1", "lfm2.5-fast:gpu1", "llama3.2:1b"}
+# Modelo padrão a pré-carregar no GPU1 após limpeza — tem que ser o modelo
+# realmente servido pela GPU1, senão a limpeza repõe o modelo errado e as
+# chamadas seguintes forçam carga nova (503 com MAX_LOADED_MODELS=1).
+GPU1_WARMUP_MODEL = os.environ.get("GPU1_WARMUP_MODEL", "lfm2.5-fast:gpu1")
 
 PROBE_TIMEOUT = 15  # segundos para a probe request ao coordinator
 UNLOAD_TIMEOUT = 30


### PR DESCRIPTION
## Contexto

A GPU1 passou de `gemma3-fast:gpu1` para `lfm2.5-fast:gpu1` em **2026-07-10**, mas cinco pontos continuaram apontando para o modelo antigo.

Apontar para um modelo **não residente** força o Ollama a subir um runner novo. Com `OLLAMA_MAX_LOADED_MODELS=1`, esse runner nunca é agendado e a request volta como `503 maximum pending requests exceeded` — **mesma classe de defeito** do `num_ctx` corrigido em #245.

## Fonte de verdade contradita

`deploy/crypto-agent/models.env` se declara única (*"edite APENAS este arquivo para trocar de modelo"*) e já está correto (`OLLAMA_SMALL_MODEL=lfm2.5-fast:gpu1`). Era contradito por:

| Arquivo | Problema |
|---|---|
| `systemd/crypto-agent@BTC_USDT_aggressive.../zz-direct-ollama.conf` | Fixava `OLLAMA_PLAN_MODEL`/`FALLBACK` em `gemma3-fast:gpu1`. Drop-in `zz-` é aplicado **depois** do `EnvironmentFile`, então vencia o `models.env`. |
| `systemd/ollama-gpu1.service.d/zzzz-warmup-curl.conf` | Aquecia o modelo errado no boot da GPU1. |
| `tools/ollama_gpu_selfheal.py` | `lfm2.5` fora de `LIGHT_MODELS` (não detectava se fosse pinado no GPU0); `GPU1_WARMUP_MODEL` repunha `gemma3:1b` após limpeza. |
| `.mcp.json` + `scripts/ollama_mcp_server.py` | Rota GPU1 do MCP `ollama-local`. |

No drop-in do `BTC_USDT_aggressive` mantive o **roteamento do plano para a GPU1** (intenção original: não competir com conservative/shadow no GPU0) e corrigi só o modelo.

## Comentários factualmente errados, corrigidos

- GPU0 descrita como *RTX 2060* → é **RTX 3060 12GB**
- GPU1 descrita como *RTX 2060 SUPER 8GB* → é **GTX 1050 2GB**

## Teste

`tests/test_gpu1_model_consistency.py` deriva o modelo esperado **do próprio `models.env`** e falha se qualquer drop-in systemd, o MCP ou o selfheal divergirem. Verifiquei que reprova de fato: revertendo o `.mcp.json` para `gemma3-fast:gpu1`, o teste quebra.

5 testes novos passam. As 2 falhas de `test_ollama_gpu_selfheal_script.py` são **pré-existentes** (faltam diretórios `/var/lib/ollama-selfheal/` no ambiente; o teste exercita um `.sh` não tocado aqui) — reproduzem na `main` sem estas mudanças.

## Deploy

O drop-in do `BTC_USDT_aggressive` só passa a valer com restart do agente — restart **escalonado** pelo workflow, sem janela de frota parada.

**NAS intocada** a pedido (offline temporariamente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)