### PR TITLE
fix(ollama): alinha drop-in do BTC_USDT_aggressive ao estado real de produção

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-25T17:30:37.292781+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-gpu1",
+  "generated_at": "2026-07-25T18:46:34.653855+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-align",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T17:30:37.292781+00:00`
+- Generated at: `2026-07-25T18:46:34.653855+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -1,16 +1,10 @@
 [Service]
-# Roteamento via coordenador (11437) — GPU routing automático por modelo.
-# Plano vai para a GPU1 para não competir com conservative/shadow no GPU0.
-#   trading-analyst   → GPU0 (11434, RTX 3060 12GB)
-#   lfm2.5-fast:gpu1  → GPU1 (11435, GTX 1050 2GB)
-# O modelo da GPU1 é lfm2.5-fast:gpu1 desde 2026-07-10 (substituiu gemma3-fast).
-# Apontar para um modelo não residente força carga nova e, com
-# MAX_LOADED_MODELS=1, devolve 503 — manter alinhado com deploy/crypto-agent/models.env.
+# Roteamento via coordenador (11437) — trading-analyst (llama3.1:8b) em todos os perfis.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
+Environment=OLLAMA_PLAN_MODEL=trading-analyst
 Environment=OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1

--- a/tests/test_gpu1_model_consistency.py
+++ b/tests/test_gpu1_model_consistency.py
@@ -53,19 +53,40 @@ def test_fallbacks_do_models_env_usam_o_modelo_da_gpu1(modelo_gpu1: str) -> None
     )
 
 
-def test_dropins_systemd_nao_contradizem_models_env(modelo_gpu1: str) -> None:
-    """Nenhum drop-in pode fixar um modelo :gpu1 diferente do canônico."""
+def _modelos_do_models_env() -> dict[str, str]:
+    """Todas as chaves *_MODEL declaradas em models.env."""
+    texto = MODELS_ENV.read_text(encoding="utf-8")
+    return dict(re.findall(r"^(\w*_MODEL)=(\S+)\s*$", texto, re.MULTILINE))
+
+
+def test_dropins_systemd_nao_contradizem_models_env() -> None:
+    """Drop-in não pode fixar um *_MODEL com valor diferente do models.env.
+
+    Verifica a chave INTEIRA, não só valores ':gpu1'. Uma versão anterior deste
+    teste só comparava sufixo ':gpu1' e por isso deixou passar um drop-in que
+    mandava OLLAMA_PLAN_MODEL para a GPU1 enquanto o models.env (e a produção)
+    diziam 'trading-analyst' — trocava a GPU de destino do plano sem ninguém ver.
+    """
+    canonico = _modelos_do_models_env()
+    assert canonico, "nenhuma chave *_MODEL encontrada em models.env"
+
     ofensores: list[str] = []
     for conf in (RAIZ / "systemd").rglob("*.conf"):
         for linha_num, linha in enumerate(conf.read_text(encoding="utf-8").splitlines(), 1):
             if linha.lstrip().startswith("#"):
                 continue
-            # [^=\s]* para casar só o valor após o ÚLTIMO '=' (Environment=CHAVE=valor)
-            for valor in re.findall(r"=([^=\s]*:gpu1)\b", linha):
-                if valor != modelo_gpu1:
-                    ofensores.append(f"{conf.relative_to(RAIZ)}:{linha_num} → {valor}")
+            match = re.match(r"\s*Environment=(\w*_MODEL)=(\S+)\s*$", linha)
+            if not match:
+                continue
+            chave, valor = match.groups()
+            esperado = canonico.get(chave)
+            if esperado is not None and valor != esperado:
+                ofensores.append(
+                    f"{conf.relative_to(RAIZ)}:{linha_num} → {chave}={valor} "
+                    f"(models.env diz {esperado})"
+                )
     assert not ofensores, (
-        f"drop-in systemd aponta para modelo de GPU1 diferente de {modelo_gpu1!r}:\n  "
+        "drop-in systemd contradiz deploy/crypto-agent/models.env:\n  "
         + "\n  ".join(ofensores)
     )
 


### PR DESCRIPTION
## Regressão que eu introduzi em #246

Ao corrigir o nome do modelo da GPU1 naquele PR, preservei a intenção do comentário antigo do arquivo — *"plano vai para a GPU1 para não competir com conservative/shadow no GPU0"* — e defini:

```
Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
```

**Essa intenção já tinha sido abandonada.** Produção e `deploy/crypto-agent/models.env` dizem:

```
Environment=OLLAMA_PLAN_MODEL=trading-analyst
```

com o comentário *"trading-analyst (llama3.1:8b) em todos os perfis"*.

Eu estava sem acesso à LAN quando abri o #246 e não pude conferir o host — assumi que o comentário versionado refletia a decisão vigente. Não refletia. Sinalizei a incerteza na hora, mas mergeei mesmo assim; era o que eu deveria ter segurado.

## Impacto

Trocaria a GPU de destino do plano do `BTC_USDT_aggressive` sem ninguém pedir.

Ficaria **latente**: o deploy hoje não sincroniza `.service.d/`, então nada mudaria em produção — até alguém implementar essa sincronização, que é exatamente o trabalho em curso. Aí o valor errado seria empurrado para o host.

## Correção

O arquivo passa a ser cópia exata do que está em `/etc/systemd/system/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf` no homelab.

## O teste também falhou

O teste que escrevi em #246 comparava apenas valores com sufixo `:gpu1` — e `trading-analyst` não tem esse sufixo, então o erro passou.

Agora compara **a chave inteira** contra o `models.env`: qualquer `Environment=*_MODEL` cujo valor divirja da fonte de verdade reprova. Verifiquei reintroduzindo o valor errado:

```
zz-direct-ollama.conf:9 → OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1 (models.env diz trading-analyst)
```

5 testes passam com o valor correto.

## Nota

O restante do #246 segue válido e confirmado contra o host: a GPU1 serve `lfm2.5-fast:gpu1`, e o `OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1` está correto em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)