### PR TITLE
feat(deploy): allowlist opt-in para sincronizar drop-ins systemd

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-25T18:46:34.653855+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-align",
+  "generated_at": "2026-07-25T18:56:04.003495+00:00",
+  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/63f6e958-79f8-497a-ba08-e1e33b38ef08/scratchpad/wt-guard",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T18:46:34.653855+00:00`
+- Generated at: `2026-07-25T18:56:04.003495+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/deploy/systemd-dropins-sync.allowlist
+++ b/deploy/systemd-dropins-sync.allowlist
@@ -1,0 +1,64 @@
+# Drop-ins systemd que PODEM ser sincronizados do repo para o host.
+#
+# Formato: um caminho por linha, relativo à raiz do repo. '#' inicia comentário.
+#
+# POR QUE ISSO EXISTE
+# Auditoria de 2026-07-25 comparou os drop-ins versionados com
+# /etc/systemd/system/ no homelab e achou divergência em duas direções:
+#
+#   1. Repo ATRÁS com placeholder — `crypto-agent@.service.d/common.conf` tem
+#      TELEGRAM_BOT_TOKEN, SECRETS_AGENT_API_KEY e ADMIN_CHAT_ID como valores de
+#      exemplo, e aponta OLLAMA_*_HOST para as GPUs diretas (:11434/:11435)
+#      enquanto produção usa o coordinator (:11437). Sincronizar esse arquivo
+#      derruba os 14 agentes: perdem coordinator e param os alertas do Telegram.
+#
+#   2. Repo ATRÁS de features — `ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf`
+#      não tinha OLLAMA_NAS_HOST nem GPU_COORD_POLL_INTERVAL_SEC, que existem em
+#      produção. Sincronizar removeria o terceiro endpoint do coordinator.
+#
+# Por isso a sincronização é OPT-IN por arquivo, nunca "tudo que está em systemd/".
+#
+# REGRAS (verificadas por tests/test_systemd_dropins_sync_guard.py)
+#   - Todo caminho listado precisa existir.
+#   - Arquivo listado não pode conter Environment= com chave de credencial
+#     (TOKEN / _KEY / SECRET / PASSWORD / CHAT_ID).
+#   - Arquivo listado não pode conter valor de placeholder (<algo>, your_, changeme).
+#   - Arquivo com credencial ou placeholder NÃO entra aqui: o host é a fonte de
+#     verdade desses, e o valor real nunca deve ser versionado.
+#
+# ANTES DE ADICIONAR UM ARQUIVO: compare com o host primeiro.
+#   diff <(ssh 192.168.15.2 "sudo cat /etc/systemd/system/<rel>") systemd/<rel>
+# Se o host estiver à frente, traga a mudança para o repo antes de listar.
+#
+# ─── FORA DA LISTA DE PROPÓSITO (auditoria 2026-07-25) ──────────────────────
+#
+# systemd/crypto-agent@.service.d/common.conf
+#   Template com credenciais de exemplo + rotas para GPU direta em vez do
+#   coordinator. Vale para os 14 agentes. Host é a fonte de verdade.
+#   Teste dedicado impede que volte: test_common_conf_nunca_e_sincronizavel.
+#
+# systemd/akash-sweep.service.d/secrets.conf
+#   SECRETS_AGENT_API_KEY como placeholder. Ausente no host.
+#
+# systemd/ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf
+#   Repo ATRÁS do host: faltam OLLAMA_NAS_HOST (192.168.15.4:11436) e
+#   GPU_COORD_POLL_INTERVAL_SEC=10. Sincronizar removeria o terceiro endpoint
+#   do coordinator. Reconciliar com o host antes de listar aqui.
+#
+# systemd/ollama.service.d/zzzz-warmup-curl.conf
+#   Diverge do host em 1 linha Environment=. Reconciliar antes de listar.
+#
+# Drop-ins de LTFS/fita (ltfs-*, lto6-*, nextcloud-tape-*, nvme-tape-*)
+#   Ausentes no homelab por design — o hardware de fita vive na NAS.
+
+systemd/crypto-agent@.service.d/deps.conf
+systemd/crypto-agent@.service.d/ollama-timeout.conf
+systemd/crypto-agent@.service.d/zz-ai-throttle.conf
+systemd/crypto-agent@BTC_USDT_aggressive.service.d/cpu-affinity.conf
+systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+systemd/crypto-agent@BTC_USDT_conservative.service.d/cpu-affinity.conf
+systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
+systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
+systemd/ollama-gpu1.service.d/memory-limit.conf
+systemd/ollama-gpu1.service.d/zzzz-warmup-curl.conf
+systemd/ollama.service.d/zz-gpu0-visible-device.conf

--- a/tests/test_systemd_dropins_sync_guard.py
+++ b/tests/test_systemd_dropins_sync_guard.py
@@ -1,0 +1,128 @@
+"""Impede que uma sincronização de drop-ins systemd derrube produção.
+
+Auditoria de 2026-07-25 comparou os drop-ins versionados com
+/etc/systemd/system/ no homelab. O repo diverge do host nas DUAS direções:
+
+  - `crypto-agent@.service.d/common.conf` (vale para os 14 agentes) tem
+    TELEGRAM_BOT_TOKEN, SECRETS_AGENT_API_KEY e ADMIN_CHAT_ID como PLACEHOLDER,
+    e aponta OLLAMA_*_HOST para as GPUs diretas (:11434/:11435) enquanto
+    produção usa o coordinator (:11437). Empurrar esse arquivo derruba a frota.
+  - `ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf` estava ATRÁS de
+    produção (faltavam OLLAMA_NAS_HOST e GPU_COORD_POLL_INTERVAL_SEC).
+
+Por isso a sincronização é opt-in por arquivo, via
+deploy/systemd-dropins-sync.allowlist. Estes testes protegem essa lista.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parent.parent
+ALLOWLIST = RAIZ / "deploy" / "systemd-dropins-sync.allowlist"
+
+# Chaves cujo valor real é segredo — o host é a fonte de verdade, nunca o git.
+CREDENCIAL = re.compile(r"(TOKEN|_KEY|SECRET|PASSWORD|PASSWD|CHAT_ID)", re.IGNORECASE)
+# Valores de exemplo que, se sincronizados, viram configuração literal quebrada.
+PLACEHOLDER = re.compile(r"<[^>]+>|your_|changeme|replace_me|change_me", re.IGNORECASE)
+
+
+def _entradas() -> list[str]:
+    linhas = ALLOWLIST.read_text(encoding="utf-8").splitlines()
+    return [ln.strip() for ln in linhas if ln.strip() and not ln.lstrip().startswith("#")]
+
+
+def _ambientes(conf: Path) -> list[tuple[str, str]]:
+    """Pares (chave, valor) de linhas Environment=, ignorando comentários."""
+    pares = []
+    for linha in conf.read_text(encoding="utf-8").splitlines():
+        if linha.lstrip().startswith("#"):
+            continue
+        match = re.match(r"\s*Environment=([^=]+)=(.*)$", linha)
+        if match:
+            pares.append((match.group(1), match.group(2)))
+    return pares
+
+
+@pytest.fixture(scope="module")
+def entradas() -> list[str]:
+    lista = _entradas()
+    assert lista, "allowlist vazia — sem isso a sincronização não tem entrada segura"
+    return lista
+
+
+def test_allowlist_so_lista_arquivos_existentes(entradas: list[str]) -> None:
+    faltando = [e for e in entradas if not (RAIZ / e).is_file()]
+    assert not faltando, f"allowlist aponta para arquivo inexistente: {faltando}"
+
+
+def test_allowlist_nao_tem_duplicatas(entradas: list[str]) -> None:
+    vistos, duplicados = set(), []
+    for e in entradas:
+        (duplicados.append(e) if e in vistos else vistos.add(e))
+    assert not duplicados, f"entradas duplicadas na allowlist: {duplicados}"
+
+
+def test_arquivo_sincronizavel_nao_carrega_credencial(entradas: list[str]) -> None:
+    """Nada com token/chave/segredo pode ser empurrado do git para o host."""
+    ofensores = [
+        f"{e} → {chave}"
+        for e in entradas
+        for chave, _ in _ambientes(RAIZ / e)
+        if CREDENCIAL.search(chave)
+    ]
+    assert not ofensores, (
+        "arquivo na allowlist declara credencial — o valor real vive no host, "
+        "não no git:\n  " + "\n  ".join(ofensores)
+    )
+
+
+def test_arquivo_sincronizavel_nao_tem_placeholder(entradas: list[str]) -> None:
+    """Placeholder sincronizado vira configuração literal quebrada em produção."""
+    ofensores = [
+        f"{e} → {chave}={valor}"
+        for e in entradas
+        for chave, valor in _ambientes(RAIZ / e)
+        if PLACEHOLDER.search(valor)
+    ]
+    assert not ofensores, (
+        "arquivo na allowlist tem valor de exemplo; sincronizar gravaria isso "
+        "literalmente no host:\n  " + "\n  ".join(ofensores)
+    )
+
+
+def test_conf_com_credencial_ou_placeholder_fica_fora(entradas: list[str]) -> None:
+    """Rede de segurança: quem tem segredo/exemplo não pode ser listado.
+
+    Complementa os testes acima olhando do outro lado — varre TODOS os drop-ins
+    e confirma que os perigosos não entraram na lista. Pega o caso de alguém
+    adicionar credencial a um arquivo que já estava allowlisted.
+    """
+    perigosos = set()
+    for conf in (RAIZ / "systemd").rglob("*.conf"):
+        for chave, valor in _ambientes(conf):
+            if CREDENCIAL.search(chave) or PLACEHOLDER.search(valor):
+                perigosos.add(str(conf.relative_to(RAIZ)))
+                break
+
+    listados_e_perigosos = sorted(perigosos.intersection(entradas))
+    assert not listados_e_perigosos, (
+        "drop-in com credencial ou placeholder está na allowlist de "
+        f"sincronização: {listados_e_perigosos}"
+    )
+
+
+def test_common_conf_nunca_e_sincronizavel(entradas: list[str]) -> None:
+    """common.conf vale para os 14 agentes e no git é template — nunca sincronizar.
+
+    Guarda nomeada porque este é o arquivo cujo empurrão causaria o dano maior:
+    os agentes perderiam o coordinator (:11437 → :11434/:11435) e os alertas do
+    Telegram parariam (token e chat_id virariam string de exemplo).
+    """
+    assert "systemd/crypto-agent@.service.d/common.conf" not in entradas, (
+        "common.conf entrou na allowlist. Ele é template no git e configura os "
+        "14 agentes; sincronizar derruba a frota. O host é a fonte de verdade."
+    )


### PR DESCRIPTION
## Por que agora

Há trabalho em curso para fazer o deploy sincronizar `systemd/**/*.service.d/` para o host. Auditei os **30 drop-ins versionados** contra `/etc/systemd/system/` no homelab antes que isso aterrisse.

**Uma sincronização ingênua derruba produção.** O repo diverge do host nas duas direções.

## Direção 1 — repo atrás, com placeholder

`systemd/crypto-agent@.service.d/common.conf` configura os **14 agentes**:

| Variável | Produção | Repo |
|---|---|---|
| `TELEGRAM_BOT_TOKEN` | valor real | **placeholder** |
| `SECRETS_AGENT_API_KEY` | valor real | **placeholder** |
| `ADMIN_CHAT_ID` | valor real | **`<your_telegram_chat_id>`** |
| `OLLAMA_PLAN_HOST` | `:11437` (coordinator) | `:11434` (GPU direta) |
| `OLLAMA_TRADE_PARAMS_HOST` | `:11437` | `:11435` |
| `OLLAMA_TRADE_WINDOW_HOST` | `:11437` | `:11435` |

Empurrar isso: a frota perde o coordinator (adeus balanceamento e failover) e os alertas do Telegram param, com o token virando a string de exemplo.

## Direção 2 — repo atrás de features

`systemd/ollama-gpu-coordinator.service.d/zz-dual-gpu-routing.conf` não tem `OLLAMA_NAS_HOST=http://192.168.15.4:11436` nem `GPU_COORD_POLL_INTERVAL_SEC=10`, que existem em produção. Sincronizar **removeria o terceiro endpoint** do coordinator.

## Solução

`deploy/systemd-dropins-sync.allowlist` — sincronização **opt-in por arquivo**, nunca "tudo que está em `systemd/`". 11 arquivos listados; o cabeçalho documenta também **o que ficou de fora e por quê**, para a omissão ser intencional e não acidental.

## Testes

`tests/test_systemd_dropins_sync_guard.py`:

- arquivo listado tem que existir; sem duplicatas
- listado não pode declarar credencial (`TOKEN`/`_KEY`/`SECRET`/`PASSWORD`/`CHAT_ID`)
- listado não pode ter valor de placeholder (`<algo>`, `your_`, `changeme`)
- varredura **inversa**: nenhum `.conf` perigoso entrou na lista (pega o caso de alguém adicionar credencial a um arquivo já listado)
- guarda nomeada para o `common.conf`, cujo empurrão causaria o dano maior

Verificado que reprova de fato:

- adicionar `common.conf` à lista → **4 testes quebram**
- injetar `Environment=MEU_TOKEN=...` em arquivo já listado → **2 testes quebram**

## Escopo

Só adiciona allowlist + testes. **Nenhum drop-in existente foi alterado** e nada é sincronizado por este PR — ele apenas dá ao mecanismo futuro uma entrada segura.

Auditoria completa: 3 arquivos divergem em `Environment=`, 11 ausentes no host (LTFS/fita, que vive na NAS — esperado), o resto idêntico ou só comentário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)