### PR TITLE
fix(systemd): remove Environment= morto e adiciona guarda (EnvironmentFile vence)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T19:38:41.335835+00:00",
+  "generated_at": "2026-07-25T21:57:32.092023+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/7f40a52f-d0fb-4e79-95e1-fa52123595d6/scratchpad/wt-dropins",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T19:38:41.335835+00:00`
+- Generated at: `2026-07-25T21:57:32.092023+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/docs/systemd/DROPIN_DEPLOY_PARITY.md
+++ b/docs/systemd/DROPIN_DEPLOY_PARITY.md
@@ -3,11 +3,11 @@
 Após a captura e a reconciliação, `check_systemd_dropin_drift.py` contra o host:
 
 ```
-Σ ok=12 missing=0 differs=1 redacted=0 not_synced=27 host_only=0
+Σ ok=13 missing=0 differs=0 redacted=0 not_synced=27 host_only=0
 ```
 
-Nada mais existe só no host. O único `differs` é **intencional**: o
-`OLLAMA_PLAN_MODEL` do perfil agressivo (ver abaixo), que o deploy vai aplicar. Os 27 `not_synced` são os drop-ins capturados que ainda não entraram na
+**Paridade total** nos arquivos sincronizáveis, e nada mais existindo só no
+host. Os 27 `not_synced` são os drop-ins capturados que ainda não entraram na
 allowlist — já idênticos ao host, versionados para não se perderem; entram um a
 um quando houver mudança a empurrar.
 
@@ -20,23 +20,52 @@ versão viva para o repo:
 | `ollama.service.d/zzzz-warmup-curl.conf` | `OLLAMA_MAX_LOADED_MODELS` |
 | `crypto-agent@.service.d/ollama-timeout.conf` | comentário ainda citava `gemma3-fast` |
 
-### A única divergência intencional
+### ⚠️ `EnvironmentFile=` vence `Environment=` — cuidado com linha morta
 
-`crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf` leva
-`OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1`, enquanto o host ainda tem
-`trading-analyst`. É decisão de 2026-07-25: o plano do perfil agressivo volta
-para a GPU1, para não competir com conservative/shadow na GPU0. Reverte o #247,
-que por sua vez revertera o #246.
+Medido no homelab em 2026-07-25, depois do deploy do #249:
 
-Override deliberado do default de `/etc/crypto-agent/models.env`
-(`OLLAMA_PLAN_MODEL=trading-analyst`), que **continua valendo para os outros 13
-perfis** — o drop-in é o mecanismo por-perfil justamente para não mover a frota
-inteira. `lfm2.5-fast:gpu1` está residente na GPU1 (`/api/ps`), então não força
-carga nova nem 503 sob `MAX_LOADED_MODELS=1`.
+```
+$ sudo systemctl cat crypto-agent@BTC_USDT_aggressive | grep -E '^# /|EnvironmentFile=|PLAN_MODEL'
+# .../crypto-agent@.service.d/common.conf
+EnvironmentFile=/etc/crypto-agent/models.env
+# .../crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf   ← mesclado DEPOIS
+Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
 
-> Antes de trocar o modelo aqui de novo, confira `/api/ps` **e** o valor vivo
-> com `systemctl show`. Foi a falta dessa checagem que gerou o vaivém
-> #246 → #247.
+$ sudo cat /proc/$(systemctl show crypto-agent@BTC_USDT_aggressive -p MainPID --value)/environ \
+    | tr '\0' '\n' | grep OLLAMA_PLAN_MODEL
+OLLAMA_PLAN_MODEL=trading-analyst        ← o models.env venceu
+```
+
+O drop-in é mesclado **depois** e ainda assim perde: no systemd,
+`EnvironmentFile=` sobrepõe `Environment=` para a mesma variável,
+independentemente da ordem. Logo, **todo `Environment=OLLAMA_*_MODEL` num
+drop-in de `crypto-agent@*` é linha morta** — os nomes de modelo vêm todos de
+`/etc/crypto-agent/models.env`.
+
+Foi exatamente sobre duas dessas linhas que os PRs #246 e #247 discordaram.
+Nenhuma jamais teve efeito: o `gemma3-fast:gpu1` do #246 não podia causar 503
+por esse caminho. As linhas foram removidas e
+`test_dropin_environment_never_shadowed_by_models_env` impede a recaída.
+
+#### O diagnóstico que engana
+
+`systemctl show <unit> -p Environment` **não expande `EnvironmentFile=`**. Ele
+mostra o valor do drop-in e dá a impressão de que o drop-in venceu — foi o que
+mascarou isso por três PRs. Junto com o caso do `ExecStartPost=` zerado por
+`zzzzz-idle-power-final.conf`, a regra prática é:
+
+| Quero saber | Comando |
+|---|---|
+| O que a unit **declara** | `systemctl cat <unit>` |
+| `Environment=` efetivo do **processo** | `sudo cat /proc/<MainPID>/environ \| tr '\0' '\n'` |
+| `ExecStartPost=` efetivo | `systemctl show <unit> -p ExecStartPost --value` |
+
+#### Como fazer override por perfil, se um dia precisar
+
+`Environment=` não serve. Seria preciso um `EnvironmentFile=` dedicado no
+drop-in da instância (mesclado depois do `common.conf`, e entre
+`EnvironmentFile=` o último vence), mais a etapa de deploy que o instale.
+Camada nova — só criar com motivo claro.
 
 Fora da allowlist e sem previsão de entrar: `crypto-agent@.service.d/cpuaffinity.conf`
 (`CPUAffinity=2-15`), que não existe no host e seria inerte — `zz-proxy-protect.conf`

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -3,21 +3,32 @@
 #   trading-analyst   → GPU0 (11434, RTX)
 #   lfm2.5-fast:gpu1  → GPU1 (11435, GTX 1050 2GB)
 #
-# DECISÃO 2026-07-25 (reverte o #247, que tinha revertido o #246): o PLANO do
-# perfil agressivo volta para a GPU1, para não competir com conservative/shadow
-# na GPU0. Override deliberado do default de /etc/crypto-agent/models.env
-# (OLLAMA_PLAN_MODEL=trading-analyst), que continua valendo para os demais
-# perfis — mexer no models.env moveria os 14 agentes de uma vez.
+# NÃO adicione Environment=OLLAMA_*_MODEL aqui — seria linha morta.
 #
-# lfm2.5-fast:gpu1 está residente na GPU1 (confirmado em /api/ps, 2026-07-25),
-# então não força carga nova nem devolve 503 sob MAX_LOADED_MODELS=1.
-# Ao trocar de modelo aqui, confira /api/ps ANTES — foi a falta dessa checagem
-# que gerou o vaivém #246 → #247.
+# Os nomes de modelo vêm de /etc/crypto-agent/models.env, carregado como
+# EnvironmentFile= em crypto-agent@.service.d/common.conf. No systemd,
+# EnvironmentFile= SOBREPÕE Environment=, independente da ordem de merge dos
+# drop-ins.
+#
+# Medido no homelab em 2026-07-25: este arquivo é mesclado DEPOIS do
+# common.conf (confirmado por `systemctl cat`), e mesmo assim
+# /proc/<pid>/environ do agente mostrava o valor do models.env.
+#
+# Cuidado ao diagnosticar: `systemctl show -p Environment` NÃO expande
+# EnvironmentFile=. Ele mostra o valor do drop-in e dá a impressão errada de
+# que o drop-in venceu. A fonte de verdade é /proc/<pid>/environ.
+#
+# Foi sobre duas dessas linhas mortas que os PRs #246 e #247 discordaram —
+# nenhuma das duas jamais teve efeito. A guarda
+# test_dropin_environment_never_shadowed_by_models_env impede a recaída.
+#
+# Para trocar o modelo de plano: edite models.env (vale para os 14 agentes).
+# Override por perfil exigiria um EnvironmentFile= dedicado — ver
+# docs/systemd/DROPIN_DEPLOY_PARITY.md antes de criar essa camada.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
-Environment=OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1
+# (sem Environment=OLLAMA_*_MODEL aqui — ver cabeçalho)

--- a/tests/test_systemd_dropin_parity.py
+++ b/tests/test_systemd_dropin_parity.py
@@ -394,3 +394,53 @@ def test_managed_dropins_only_reference_models_declared_in_models_env() -> None:
         "drop-in aponta para modelo ausente de deploy/crypto-agent/models.env "
         "(com MAX_LOADED_MODELS=1 isso devolve 503): " + "; ".join(offenders)
     )
+
+
+# --------------------------------------------------------------------------
+# Environment= morto: sombreado por EnvironmentFile=
+# --------------------------------------------------------------------------
+
+def test_dropin_environment_never_shadowed_by_models_env() -> None:
+    """`EnvironmentFile=` VENCE `Environment=` no systemd, independente da ordem
+    de merge dos drop-ins.
+
+    Medido no homelab em 2026-07-25: `zz-direct-ollama.conf` (instância) traz
+    `Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1` e é mesclado DEPOIS de
+    `common.conf` (que tem `EnvironmentFile=/etc/crypto-agent/models.env`) —
+    e mesmo assim `/proc/<pid>/environ` do agente mostra o valor do models.env.
+
+    Consequência: qualquer `Environment=` de drop-in cujo nome também esteja no
+    models.env é LINHA MORTA. Foi sobre duas dessas linhas que os PRs #246 e
+    #247 discordaram — nenhuma delas jamais teve efeito.
+
+    Cuidado ao diagnosticar: `systemctl show -p Environment` NÃO expande
+    `EnvironmentFile=`, então ele mostra o valor do drop-in e dá a impressão
+    errada de que o drop-in venceu. A fonte de verdade é `/proc/<pid>/environ`.
+    """
+    models_env = REPO_ROOT / "deploy" / "crypto-agent" / "models.env"
+    shadowing = {
+        line.split("=", 1)[0].strip()
+        for line in models_env.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#") and "=" in line
+    }
+    assert shadowing, "models.env vazio — regex quebrada?"
+
+    dead: list[str] = []
+    for rel_dir in _allowed_dirs():
+        if not rel_dir.startswith("crypto-agent@"):
+            continue  # models.env é EnvironmentFile só dos crypto-agent
+        for conf in sorted((REPO_ROOT / "systemd" / rel_dir).glob("*.conf")):
+            for name in re.findall(
+                r'^Environment="?([A-Z][A-Z0-9_]*)=',
+                conf.read_text(encoding="utf-8"),
+                flags=re.MULTILINE,
+            ):
+                if name in shadowing:
+                    dead.append(f"{rel_dir}/{conf.name}: {name}")
+
+    assert not dead, (
+        "Environment= de drop-in sombreado por EnvironmentFile=/etc/crypto-agent/models.env "
+        "— a linha não tem efeito nenhum em runtime. Mude o valor no models.env "
+        "(vale para os 14 agentes) ou use um EnvironmentFile= por perfil, que é "
+        "mesclado depois. Linhas mortas: " + "; ".join(dead)
+    )


### PR DESCRIPTION
## O que a medição pós-deploy do #249 revelou

Com a paridade de drop-ins finalmente funcionando, deu para conferir o efeito **real** da configuração. Ele não é o que três PRs seguidos assumiram.

```
$ sudo systemctl cat crypto-agent@BTC_USDT_aggressive | grep -E '^# /|EnvironmentFile=|PLAN_MODEL'
# .../crypto-agent@.service.d/common.conf
EnvironmentFile=/etc/crypto-agent/models.env
# .../crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf   ← mesclado DEPOIS
Environment=OLLAMA_PLAN_MODEL=lfm2.5-fast:gpu1
```

```
$ sudo cat /proc/$(systemctl show crypto-agent@BTC_USDT_aggressive -p MainPID --value)/environ \
    | tr '\0' '\n' | grep OLLAMA_PLAN_MODEL
OLLAMA_PLAN_MODEL=trading-analyst
```

O drop-in é mesclado **depois** e mesmo assim perde: no systemd, `EnvironmentFile=` sobrepõe `Environment=` para a mesma variável, independentemente da ordem de merge.

**Logo: todo `Environment=OLLAMA_*_MODEL` em drop-in de `crypto-agent@*` é linha morta.** Os nomes de modelo vêm todos de `/etc/crypto-agent/models.env`.

A varredura acusou exatamente **2 ocorrências**, ambas no `zz-direct-ollama.conf` do perfil agressivo: `OLLAMA_PLAN_MODEL` e `OLLAMA_PLAN_FALLBACK_MODEL`. São precisamente as duas linhas sobre as quais o [#246](https://github.com/eddiejdi/eddie-auto-dev/pull/246) e o [#247](https://github.com/eddiejdi/eddie-auto-dev/pull/247) discordaram. Nenhuma jamais teve efeito — o `gemma3-fast:gpu1` do #246 não podia causar 503 por esse caminho.

### O diagnóstico que mascarou isso

`systemctl show -p Environment` **não expande `EnvironmentFile=`**. Ele mostra o valor do drop-in e parece confirmar que o drop-in venceu. Era, inclusive, o critério de verificação pedido na tarefa que originou o #249 — e me enganou no primeiro check.

| Quero saber | Comando |
|---|---|
| O que a unit **declara** | `systemctl cat <unit>` |
| `Environment=` efetivo do **processo** | `sudo cat /proc/<MainPID>/environ \| tr '\0' '\n'` |
| `ExecStartPost=` efetivo | `systemctl show <unit> -p ExecStartPost --value` |

É o segundo caso do mesmo tipo neste ciclo — o primeiro foi o `zzzzz-idle-power-final.conf` zerando todo `ExecStartPost=` do Ollama, o que já tornava inerte o warmup "corrigido" no #246.

## O que muda

- **Removidas as 2 linhas mortas.** O plano do agressivo segue em `trading-analyst` (GPU0), com `lfm2.5-fast:gpu1` já atuando como fallback.
- **Guarda:** `test_dropin_environment_never_shadowed_by_models_env` compara os `Environment=` dos drop-ins com as chaves de `deploy/crypto-agent/models.env` e falha em qualquer colisão. Impede o vaivém de recomeçar.
- **Doc:** `docs/systemd/DROPIN_DEPLOY_PARITY.md` ganha a seção com a medição, a tabela de comandos de diagnóstico e como seria um override por perfil de verdade (`EnvironmentFile=` dedicado no drop-in da instância), caso um dia se justifique.

### Por que não recriei o override para a GPU1

A intenção original ("plano do agressivo na GPU1 para não competir na GPU0") não se sustenta hoje:

1. A contenção da GPU0 foi resolvida no incidente de 2026-07-24 — `OLLAMA_NUM_PARALLEL` 1→4 e `OLLAMA_MAX_QUEUE` 4→32 em `zz-perf-containment.conf`.
2. A GPU1 roda com `NUM_PARALLEL=1` — um slot só. Não é menos disputada que a GPU0 com 4.
3. `lfm2.5-fast:gpu1` é 1.2B contra `trading-analyst` (llama3.1:8b). Rebaixar o modelo que gera plano de trade com dinheiro real, para vencer uma disputa de GPU já resolvida, é mau negócio.
4. O fallback para a GPU1 já existe e cobre a falha da GPU0.

## Impacto do deploy

**No-op de runtime** — as linhas removidas já não tinham efeito. O deploy roda o restart escalonado habitual dos 14 agents.

```
python3 -m pytest tests/test_systemd_dropin_parity.py -q
# 24 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)