### PR TITLE
fix(trading): elimina deadlock de migração de schema no start dos agents

### DIFF
--- a/btc_trading_agent/training_db.py
+++ b/btc_trading_agent/training_db.py
@@ -181,6 +181,25 @@ ALTER TABLE {SCHEMA}.ai_plans
     ALTER COLUMN profile SET NOT NULL;
 """
 
+# Estado final garantido por PROFILE_MIGRATION_SQL: (tabela, coluna, default).
+# Serve para PULAR a migração quando ela já foi aplicada — ver
+# _profile_migration_applied(). Manter em paridade com o SQL acima;
+# tests/test_training_db_schema_migration.py falha se divergir.
+PROFILE_MIGRATION_COLUMNS = (
+    ("trades", "profile", "default"),
+    ("trades", "servidor", "homelab"),
+    ("decisions", "servidor", "homelab"),
+    ("decisions", "profile", "default"),
+    ("ai_plans", "profile", "default"),
+)
+
+# Tempo máximo esperando lock durante a migração. Sem isso, o ALTER TABLE fica
+# na fila atrás das transações dos agentes que já estão negociando e acaba em
+# deadlock (incidente 2026-07-25: 5 ocorrências em 24h, todas em deploy).
+SCHEMA_MIGRATION_LOCK_TIMEOUT = os.getenv("BTC_SCHEMA_LOCK_TIMEOUT", "5s")
+SCHEMA_MIGRATION_MAX_ATTEMPTS = int(os.getenv("BTC_SCHEMA_MAX_ATTEMPTS", "5"))
+
+
 # ====================== DATABASE MANAGER ======================
 class TrainingDatabase:
     """Gerenciador do banco de dados de treinamento (PostgreSQL)"""
@@ -211,14 +230,84 @@ class TrainingDatabase:
         finally:
             self._pool.putconn(conn)
 
+    @staticmethod
+    def _profile_migration_applied(cur) -> bool:
+        """True quando PROFILE_MIGRATION_SQL já está aplicado por completo.
+
+        Existe para PULAR a migração no caso comum. Os 13 ALTER TABLE dela
+        pegam AccessExclusiveLock em btc.trades/decisions/ai_plans e os UPDATE
+        varrem a tabela inteira — a cada start de agente. Com 14 agentes, o
+        que reinicia disputa lock com os 13 que já estão negociando nas mesmas
+        tabelas, e o par DDL×DML fecha ciclo: DeadlockDetected.
+
+        O advisory lock acima serializa agentes entre si, mas não protege
+        contra as transações de quem já está rodando — por isso o skip.
+        """
+        tables = tuple({table for table, _, _ in PROFILE_MIGRATION_COLUMNS})
+        cur.execute(
+            """
+            SELECT table_name, column_name, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = ANY(%s)
+            """,
+            (SCHEMA, list(tables)),
+        )
+        found = {
+            (row[0], row[1]): (row[2], row[3])
+            for row in cur.fetchall()
+        }
+
+        for table, column, default in PROFILE_MIGRATION_COLUMNS:
+            state = found.get((table, column))
+            if state is None:
+                return False
+            is_nullable, column_default = state
+            if is_nullable != "NO":
+                return False
+            # Postgres devolve o default como "'default'::text"
+            if not (column_default or "").startswith(f"'{default}'"):
+                return False
+        return True
+
     def _ensure_schema(self):
-        """Garante que o schema e tabelas existem"""
+        """Garante que o schema e tabelas existem.
+
+        Reexecuta em DeadlockDetected/LockNotAvailable: quando a migração é
+        realmente necessária, ela concorre com as transações dos agentes
+        ativos. Falhar aqui mata o agente e o systemd só o traz de volta 30s
+        depois (RestartSec), então vale tentar de novo aqui mesmo.
+        """
+        last_error = None
+        for attempt in range(1, SCHEMA_MIGRATION_MAX_ATTEMPTS + 1):
+            try:
+                self._ensure_schema_once()
+                return
+            except (psycopg2.errors.DeadlockDetected,
+                    psycopg2.errors.LockNotAvailable) as exc:
+                last_error = exc
+                if attempt == SCHEMA_MIGRATION_MAX_ATTEMPTS:
+                    break
+                backoff = min(2 ** (attempt - 1), 8)
+                logger.warning(
+                    "⏳ Schema migration disputando lock (tentativa %d/%d): %s — "
+                    "repetindo em %ds",
+                    attempt, SCHEMA_MIGRATION_MAX_ATTEMPTS,
+                    type(exc).__name__, backoff,
+                )
+                time.sleep(backoff)
+        raise last_error
+
+    def _ensure_schema_once(self):
+        """Uma passada de criação/migração do schema."""
         with self._get_conn() as conn:
             cur = conn.cursor()
             # Serializa a migração entre agentes que sobem simultaneamente
             # (deploy reinicia os 3 profiles juntos → DeadlockDetected nos
             # ALTER TABLE concorrentes). Lock liberado no commit/rollback.
             cur.execute("SELECT pg_advisory_xact_lock(hashtext('btc_ensure_schema'))")
+            # Não ficar na fila atrás das transações dos agentes ativos: falhar
+            # rápido e repetir é melhor que segurar AccessExclusiveLock.
+            cur.execute("SET LOCAL lock_timeout = %s", (SCHEMA_MIGRATION_LOCK_TIMEOUT,))
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
 
             cur.execute(f"""
@@ -367,7 +456,12 @@ class TrainingDatabase:
 
             # Compatibilidade: releases recentes passaram a usar colunas/tabelas
             # com "profile"; manter isso aqui evita depender de migration manual.
-            cur.execute(PROFILE_MIGRATION_SQL)
+            # Só roda se ainda não estiver aplicada — ver _profile_migration_applied().
+            if self._profile_migration_applied(cur):
+                logger.debug("↩️ PROFILE_MIGRATION_SQL já aplicada — pulando DDL")
+            else:
+                logger.info("🔧 Aplicando PROFILE_MIGRATION_SQL (schema desatualizado)")
+                cur.execute(PROFILE_MIGRATION_SQL)
 
             # Conversão intermoedas (owner USDT_BRL)
             cur.execute(f"""

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T21:57:32.092023+00:00",
+  "generated_at": "2026-07-25T23:03:11.232636+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/7f40a52f-d0fb-4e79-95e1-fa52123595d6/scratchpad/wt-dropins",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T21:57:32.092023+00:00`
+- Generated at: `2026-07-25T23:03:11.232636+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/docs/variables-taxonomy/TRADING_DB_SCHEMA.md
+++ b/docs/variables-taxonomy/TRADING_DB_SCHEMA.md
@@ -1,0 +1,37 @@
+# Migração de schema do trading — variáveis
+
+Variáveis de `btc_trading_agent/training_db.py` que controlam a migração de
+schema executada no start de cada `crypto-agent@*`.
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `BTC_SCHEMA_LOCK_TIMEOUT` | `5s` | `SET LOCAL lock_timeout` da transação de migração. Sem ele, o `ALTER TABLE` entra na fila atrás das transações dos agentes que já estão negociando e o par DDL×DML fecha ciclo de deadlock. Falhar rápido e repetir é melhor que segurar `AccessExclusiveLock`. Aceita qualquer literal de intervalo do Postgres. |
+| `BTC_SCHEMA_MAX_ATTEMPTS` | `5` | Tentativas de `_ensure_schema()` antes de propagar o erro. Só repete em `DeadlockDetected`/`LockNotAvailable`; qualquer outra exceção sobe na primeira. Backoff 1s→2s→4s→8s. |
+
+## Por que existem
+
+Incidente de 2026-07-25 (deploy run 30177183701): dois agentes que subiram com
+1s de diferença morreram com `psycopg2.errors.DeadlockDetected` em
+`_ensure_schema()`. 5 ocorrências em 24h, 12 das 14 instâncias atingidas em
+algum momento — sempre em deploy.
+
+`PROFILE_MIGRATION_SQL` rodava **a cada start**: 13 `ALTER TABLE`
+(`AccessExclusiveLock` em `btc.trades`, `btc.decisions`, `btc.ai_plans`) mais
+`UPDATE ... WHERE profile IS NULL` varrendo a tabela inteira. Enquanto isso, os
+outros 13 agentes negociavam nessas mesmas tabelas.
+
+O `pg_advisory_xact_lock('btc_ensure_schema')` que já existia serializa os
+agentes **entre si**, mas não protege contra as transações de quem já está
+rodando. Daí o ciclo DDL×DML.
+
+## A correção principal não é uma variável
+
+É o skip: `_profile_migration_applied()` consulta `information_schema.columns`
+e pula `PROFILE_MIGRATION_SQL` quando o schema já está no estado final. No caso
+comum — todo restart depois do primeiro — não há DDL nenhum, então não há
+`AccessExclusiveLock` a disputar. As duas variáveis acima cobrem o caso em que
+a migração é de fato necessária.
+
+`PROFILE_MIGRATION_COLUMNS` declara o estado final esperado (tabela, coluna,
+default). `tests/test_training_db_schema_migration.py` falha se ela divergir do
+SQL — sem isso, um `ALTER TABLE` novo passaria a ser pulado silenciosamente.

--- a/tests/test_training_db_schema_migration.py
+++ b/tests/test_training_db_schema_migration.py
@@ -1,0 +1,194 @@
+"""Regressão do deadlock de migração de schema dos crypto-agent.
+
+Incidente 2026-07-25 (deploy run 30177183701): dois agentes que subiram com 1s
+de diferença morreram com `psycopg2.errors.DeadlockDetected` em
+`_ensure_schema()`. 5 ocorrências em 24h, 12 das 14 instâncias atingidas.
+
+Causa: `PROFILE_MIGRATION_SQL` rodava a cada start, com 13 `ALTER TABLE`
+(AccessExclusiveLock em btc.trades/decisions/ai_plans) e `UPDATE` de tabela
+inteira — enquanto os outros 13 agentes negociavam nessas mesmas tabelas.
+O `pg_advisory_xact_lock` serializa agentes entre si, mas não protege contra
+as transações de quem já está rodando: o par DDL×DML fecha o ciclo.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE = (REPO_ROOT / "btc_trading_agent" / "training_db.py").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Paridade entre o SQL e a lista usada para pular a migração
+# --------------------------------------------------------------------------
+
+def _migration_sql() -> str:
+    start = SOURCE.index('PROFILE_MIGRATION_SQL = f"""')
+    return SOURCE[start:SOURCE.index('"""', start + 30)]
+
+
+def _declared_columns() -> set[tuple[str, str, str]]:
+    body = re.search(r"PROFILE_MIGRATION_COLUMNS = \((.*?)\n\)", SOURCE, re.S).group(1)
+    return set(ast.literal_eval("[" + body.strip().rstrip(",") + "]"))
+
+
+def test_declared_columns_match_the_migration_sql() -> None:
+    """Se alguém adicionar um ALTER TABLE sem atualizar a lista, o skip passaria
+    a pular uma migração ainda necessária — silenciosamente."""
+    in_sql = {
+        (table, column)
+        for table, column in re.findall(
+            r"ALTER TABLE \{SCHEMA\}\.(\w+)\s+ADD COLUMN IF NOT EXISTS (\w+)",
+            _migration_sql(),
+        )
+    }
+    declared = {(table, column) for table, column, _ in _declared_columns()}
+    assert declared == in_sql, (
+        "PROFILE_MIGRATION_COLUMNS fora de paridade com PROFILE_MIGRATION_SQL. "
+        f"Só no SQL: {in_sql - declared} | só na lista: {declared - in_sql}"
+    )
+
+
+def test_declared_defaults_match_the_migration_sql() -> None:
+    sql = _migration_sql()
+    for table, column, default in _declared_columns():
+        assert re.search(
+            rf"ALTER TABLE \{{SCHEMA\}}\.{table}\s+ALTER COLUMN {column} SET DEFAULT '{default}'",
+            sql,
+        ), f"{table}.{column} declarado com default '{default}', ausente no SQL"
+
+
+# --------------------------------------------------------------------------
+# Comportamento de _profile_migration_applied / _ensure_schema
+# --------------------------------------------------------------------------
+
+# psycopg2 e numpy sao reais no ambiente de teste; so o secrets_helper precisa
+# de DATABASE_URL para nao tentar falar com o Secrets Agent no import.
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+sys.path.insert(0, str(REPO_ROOT / "btc_trading_agent"))
+
+import training_db as db_module  # noqa: E402
+
+
+class FakeCursor:
+    """Cursor que devolve o estado de information_schema.columns."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.executed: list[str] = []
+
+    def execute(self, sql, params=None):
+        self.executed.append(sql)
+
+    def fetchall(self):
+        return self._rows
+
+
+def _rows_from(columns, *, nullable="NO", default_suffix="::text"):
+    return [
+        (table, column, nullable, f"'{default}'{default_suffix}")
+        for table, column, default in columns
+    ]
+
+
+def test_skips_migration_when_already_applied() -> None:
+    db = db_module.TrainingDatabase
+    cur = FakeCursor(_rows_from(db_module.PROFILE_MIGRATION_COLUMNS))
+    assert db._profile_migration_applied(cur) is True
+
+
+def test_runs_migration_when_a_column_is_missing() -> None:
+    db = db_module.TrainingDatabase
+    partial = list(db_module.PROFILE_MIGRATION_COLUMNS)[:-1]
+    cur = FakeCursor(_rows_from(partial))
+    assert db._profile_migration_applied(cur) is False
+
+
+def test_runs_migration_when_column_still_nullable() -> None:
+    """Schema meio migrado (coluna criada, SET NOT NULL não aplicado)."""
+    db = db_module.TrainingDatabase
+    cur = FakeCursor(_rows_from(db_module.PROFILE_MIGRATION_COLUMNS, nullable="YES"))
+    assert db._profile_migration_applied(cur) is False
+
+
+def test_runs_migration_when_default_is_missing() -> None:
+    db = db_module.TrainingDatabase
+    rows = [
+        (table, column, "NO", None)
+        for table, column, _ in db_module.PROFILE_MIGRATION_COLUMNS
+    ]
+    assert db._profile_migration_applied(FakeCursor(rows)) is False
+
+
+def test_runs_migration_when_default_differs() -> None:
+    """Default presente mas com outro valor — não pode contar como aplicado."""
+    db = db_module.TrainingDatabase
+    rows = [
+        (table, column, "NO", "'outro'::text")
+        for table, column, _ in db_module.PROFILE_MIGRATION_COLUMNS
+    ]
+    assert db._profile_migration_applied(FakeCursor(rows)) is False
+
+
+# --------------------------------------------------------------------------
+# Retry
+# --------------------------------------------------------------------------
+
+def test_ensure_schema_retries_on_deadlock(monkeypatch) -> None:
+    db = db_module.TrainingDatabase.__new__(db_module.TrainingDatabase)
+    monkeypatch.setattr(db_module.time, "sleep", lambda _s: None)
+
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise db_module.psycopg2.errors.DeadlockDetected("deadlock detected")
+
+    monkeypatch.setattr(db, "_ensure_schema_once", flaky)
+    db._ensure_schema()
+    assert calls["n"] == 3
+
+
+def test_ensure_schema_reraises_after_max_attempts(monkeypatch) -> None:
+    db = db_module.TrainingDatabase.__new__(db_module.TrainingDatabase)
+    monkeypatch.setattr(db_module.time, "sleep", lambda _s: None)
+
+    def always_deadlock():
+        raise db_module.psycopg2.errors.DeadlockDetected("deadlock detected")
+
+    monkeypatch.setattr(db, "_ensure_schema_once", always_deadlock)
+    with pytest.raises(db_module.psycopg2.errors.DeadlockDetected):
+        db._ensure_schema()
+
+
+def test_ensure_schema_does_not_retry_other_errors(monkeypatch) -> None:
+    """Erro de programação tem que aparecer na hora, não virar 5 tentativas."""
+    db = db_module.TrainingDatabase.__new__(db_module.TrainingDatabase)
+    monkeypatch.setattr(db_module.time, "sleep", lambda _s: None)
+
+    calls = {"n": 0}
+
+    def boom():
+        calls["n"] += 1
+        raise ValueError("erro de programação")
+
+    monkeypatch.setattr(db, "_ensure_schema_once", boom)
+    with pytest.raises(ValueError):
+        db._ensure_schema()
+    assert calls["n"] == 1
+
+
+def test_migration_runs_under_lock_timeout() -> None:
+    """Sem lock_timeout o ALTER TABLE fica na fila atrás dos agentes ativos."""
+    assert "SET LOCAL lock_timeout" in SOURCE
+    assert "pg_advisory_xact_lock" in SOURCE
+    # o timeout precisa ser aplicado ANTES do DDL
+    assert SOURCE.index("SET LOCAL lock_timeout") < SOURCE.index("cur.execute(PROFILE_MIGRATION_SQL)")


### PR DESCRIPTION
## Sintoma

Durante o deploy de 2026-07-25 ([run 30177183701](https://github.com/eddiejdi/eddie-auto-dev/actions/runs/30177183701)), dois crypto-agent que subiram com 1s de diferença morreram com:

```
File "/apps/crypto-trader/trading/btc_trading_agent/training_db.py", line 193, in __init__
  self._ensure_schema()
File ".../training_db.py", line 370, in _ensure_schema
  cur.execute(PROFILE_MIGRATION_SQL)
psycopg2.errors.DeadlockDetected: deadlock detected
DETAIL: Process 4033124 waits for AccessExclusiveLock on relation 16502; blocked by process 4032404.
```

Escopo medido no homelab: **5 ocorrências em 24h**, todas em deploy, **12 das 14 instâncias** atingidas em algum momento. Não derruba serviço — `Restart=always` + `RestartSec=30` recupera — mas custa ~30s de agent fora do ar por ocorrência e polui a triagem de incidentes reais com traceback.

## Causa

`PROFILE_MIGRATION_SQL` rodava **a cada start**:

- 13 `ALTER TABLE` → `AccessExclusiveLock` em `btc.trades`, `btc.decisions`, `btc.ai_plans`
- `UPDATE {tabela} SET profile='default' WHERE profile IS NULL` → varredura da tabela inteira

Enquanto isso, os outros 13 agentes negociavam nessas mesmas tabelas.

O `pg_advisory_xact_lock('btc_ensure_schema')` que já existia serializa os agentes **entre si** — mas não protege contra as transações de quem já está rodando. O par DDL×DML fecha o ciclo. Por isso o lock não bastava, e por isso o problema só aparece em deploy.

## Correção

**1. Pular a migração quando já aplicada** — é o que remove a causa.

`_profile_migration_applied()` consulta `information_schema.columns` e compara com `PROFILE_MIGRATION_COLUMNS`. No caso comum (todo restart depois do primeiro) não há DDL nenhum, logo não há `AccessExclusiveLock` a disputar com os agentes ativos. Confere existência **+ `NOT NULL` + default**, para não pular um schema meio migrado.

**2. `SET LOCAL lock_timeout`** (`BTC_SCHEMA_LOCK_TIMEOUT`, default `5s`) quando a migração é de fato necessária — falhar rápido em vez de segurar `AccessExclusiveLock` atrás da fila.

**3. Retry com backoff** (`BTC_SCHEMA_MAX_ATTEMPTS`, default `5`, 1s→2s→4s→8s) só em `DeadlockDetected`/`LockNotAvailable`. Qualquer outra exceção sobe na primeira tentativa — erro de programação não vira 5 tentativas.

## A guarda que importa

`PROFILE_MIGRATION_COLUMNS` declara o estado final esperado. `test_declared_columns_match_the_migration_sql` falha se ela divergir do SQL — sem isso, um `ALTER TABLE` novo passaria a ser **pulado em silêncio**, que seria pior que o deadlock original.

## Testes

```
python3 -m pytest tests/test_training_db_schema_migration.py -q
# 11 passed
```

Cobrem: paridade lista↔SQL (colunas e defaults), skip quando aplicada, execução quando falta coluna / está nullable / falta default / default diverge, retry em deadlock, propagação após esgotar tentativas, não-retry de outros erros, e ordem `lock_timeout` antes do DDL.

Rodei também `tests/test_ai_plan_fallback.py`, `test_ai_trade_window.py`, `test_clear_trading.py` e `tests/unit/` — as 2 falhas em `tests/unit/test_content_automation.py` são pré-existentes (`ModuleNotFoundError` em `content_automation/publisher.py`), confirmado com `git stash`.

## Impacto do deploy

`training_db.py` é runtime compartilhado, então o deploy reinicia os 14 agents (comportamento normal do script). O primeiro start de cada agent após o merge encontra o schema já migrado e passa a pular o DDL.

⚠️ Reinício da frota sob confirmação explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)