### PR TITLE
fix(ci): gatilho do deploy cobre todo arquivo que o deploy sincroniza

### DIFF
--- a/.github/workflows/deploy-btc-trading-profiles.yml
+++ b/.github/workflows/deploy-btc-trading-profiles.yml
@@ -18,6 +18,8 @@ on:
       - 'btc_trading_agent/fast_model.py'
       - 'btc_trading_agent/market_rag.py'
       - 'btc_trading_agent/prometheus_exporter.py'
+      - 'btc_trading_agent/training_db.py'
+      - 'btc_trading_agent/secrets_helper.py'
       - 'btc_trading_agent/config_BTC_USDT_*.json'
       - 'btc_trading_agent/config_ETH_USDT_*.json'
       - 'btc_trading_agent/config_SOL_USDT_*.json'
@@ -33,7 +35,9 @@ on:
       - 'scripts/ollama_finetune_batch.py'
       - 'systemd/crypto-agent@.service'
       - 'systemd/validate_btc_config.py'
-      - 'systemd/trading-svc-ollama.sudoers'
+      # O deploy REMOVE /etc/sudoers.d/trading-svc-ollama e instala o canônico;
+      # o path antigo aqui era gatilho para um arquivo que não existe mais.
+      - 'systemd/btc-trading-ollama.sudoers'
       - 'grafana/exporters/rss_sentiment_exporter.py'
       - 'grafana/exporters/requirements.txt'
       - 'grafana/btc_trading_dashboard_v3_prometheus.json'

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T23:03:11.232636+00:00",
+  "generated_at": "2026-07-25T23:24:58.675221+00:00",
   "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/7f40a52f-d0fb-4e79-95e1-fa52123595d6/scratchpad/wt-dropins",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T23:03:11.232636+00:00`
+- Generated at: `2026-07-25T23:24:58.675221+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -140,3 +140,67 @@ def test_script_syncs_market_rag_runtime() -> None:
     content = _load_script()
     assert "btc_trading_agent/market_rag.py" in content
     assert '${TARGET_DIR}/market_rag.py' in content
+
+
+def test_every_file_the_deploy_syncs_also_triggers_the_deploy() -> None:
+    """Arquivo sincronizado mas fora dos `paths` = correção que nunca chega ao host.
+
+    Foi assim que o `OLLAMA_PLAN_MODEL` dos drop-ins sobreviveu errado por três
+    PRs (#246→#249), e de novo com `training_db.py` no #251: o merge entrou no
+    main e nenhum deploy disparou.
+
+    Este teste fecha a classe inteira, não um caso: extrai de
+    deploy_btc_trading_profiles.sh todo `${REPO_ROOT}/<arquivo>` e exige que o
+    gatilho do workflow o cubra.
+    """
+    import fnmatch
+    import re
+
+    import yaml
+
+    workflow_path = (
+        SCRIPT_PATH.parent.parent / ".github" / "workflows" / "deploy-btc-trading-profiles.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    # `on:` vira True no YAML 1.1
+    triggers = workflow[True] if True in workflow else workflow["on"]
+    paths = triggers["push"]["paths"]
+
+    synced = sorted(set(re.findall(
+        r"\$\{REPO_ROOT\}/([A-Za-z0-9_./@-]+\.(?:py|txt|json|sudoers|service))",
+        _load_script(),
+    )))
+    assert synced, "nenhum arquivo sincronizado encontrado — regex quebrada?"
+
+    def covered(rel_path: str) -> bool:
+        return any(fnmatch.fnmatch(rel_path, p.replace("**", "*")) for p in paths)
+
+    missing = [f for f in synced if not covered(f)]
+    assert not missing, (
+        "o deploy sincroniza estes arquivos, mas mudá-los NÃO dispara o "
+        "workflow — a correção ficaria só no repo: " + ", ".join(missing)
+    )
+
+
+def test_trigger_paths_do_not_reference_removed_files() -> None:
+    """Path de gatilho apontando para arquivo inexistente é ruído que esconde
+    a ausência do path certo (era o caso de systemd/trading-svc-ollama.sudoers,
+    que o próprio deploy remove do host)."""
+    import glob
+
+    import yaml
+
+    repo_root = SCRIPT_PATH.parent.parent
+    workflow = yaml.safe_load(
+        (repo_root / ".github" / "workflows" / "deploy-btc-trading-profiles.yml")
+        .read_text(encoding="utf-8")
+    )
+    triggers = workflow[True] if True in workflow else workflow["on"]
+
+    dangling = [
+        p for p in triggers["push"]["paths"]
+        if not glob.glob(str(repo_root / p), recursive=True)
+    ]
+    assert not dangling, (
+        "paths do gatilho sem arquivo correspondente no repo: " + ", ".join(dangling)
+    )


### PR DESCRIPTION
## Como isto apareceu

O [#251](https://github.com/eddiejdi/eddie-auto-dev/pull/251) mergeou no main às 23:22Z e **nenhum deploy disparou**. `btc_trading_agent/training_db.py` não estava nos `paths` do gatilho — mesmo o `sync_trading_runtime()` sincronizando esse arquivo para o host desde sempre.

É a mesma classe de bug que o [#249](https://github.com/eddiejdi/eddie-auto-dev/pull/249) consertou para os drop-ins systemd: correção mergeada que nunca chega em produção, em silêncio. Só que aqui em código Python de trading, não em config.

## Varredura sistemática

Comparei os 24 arquivos que o `deploy_btc_trading_profiles.sh` sincroniza contra os `paths` do workflow. Três buracos:

| Arquivo | O que faz |
|---|---|
| `btc_trading_agent/training_db.py` | Persistência de trades/decisões/planos — o do #251 |
| `btc_trading_agent/secrets_helper.py` | Resolução de credenciais via Secrets Agent |
| `systemd/btc-trading-ollama.sudoers` | Sudoers instalado em `/etc/sudoers.d/` |

E um path **obsoleto**: `systemd/trading-svc-ollama.sudoers` — arquivo que o próprio deploy remove do host (`rm -f /etc/sudoers.d/trading-svc-ollama`). Gatilho apontando para arquivo inexistente é ruído que ajuda a esconder a falta do path certo.

## Os testes fecham a classe, não o caso

```python
test_every_file_the_deploy_syncs_also_triggers_the_deploy
```
Extrai do shell todo `${REPO_ROOT}/<arquivo>` e exige que os `paths` do gatilho o cubram. Qualquer arquivo novo que o deploy passe a sincronizar sem entrar no gatilho quebra o CI.

```python
test_trigger_paths_do_not_reference_removed_files
```
Nenhum path pode apontar para arquivo que não existe no repo.

## Efeito

Depois deste merge, o deploy dispara — e leva junto o `training_db.py` do #251, que hoje está mergeado no main mas **não instalado no host**.

```
python3 -m pytest tests/test_deploy_btc_trading_profiles_script.py tests/test_systemd_dropin_parity.py tests/test_training_db_schema_migration.py -q
# 46 passed
```

⚠️ O deploy reinicia os 14 agents (comportamento normal do script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)