### PR TITLE
fix(exporter): TrainingDatabase compartilhada em vez de um pool por scrape

### DIFF
--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -13,6 +13,7 @@ import sys
 import json
 import time
 import subprocess
+import threading
 import urllib.request
 from pathlib import Path
 from datetime import datetime
@@ -52,6 +53,30 @@ def load_config() -> Dict:
             return json.load(f)
     except Exception:
         return {}
+
+
+# Uma única TrainingDatabase por processo (pool interno é thread-safe, então o
+# ThreadingHTTPServer pode compartilhá-la). Construir uma por scrape criava — e
+# descartava sem close() — um ThreadedConnectionPool a cada raspagem: medido em
+# 2026-07-25, ~280 construções/3h por instância × 13 unidades crypto-exporter@*.
+_TRAINING_DB = None
+_TRAINING_DB_LOCK = threading.Lock()
+
+
+def get_training_db():
+    """TrainingDatabase compartilhada, construída sob demanda.
+
+    Propaga a exceção se a construção falhar (DB fora do ar) e mantém o global
+    em None, para que o próximo scrape tente de novo quando o DB voltar.
+    """
+    global _TRAINING_DB
+    if _TRAINING_DB is None:
+        with _TRAINING_DB_LOCK:
+            if _TRAINING_DB is None:
+                from training_db import TrainingDatabase
+
+                _TRAINING_DB = TrainingDatabase()
+    return _TRAINING_DB
 
 
 class MetricsCollector:
@@ -1354,9 +1379,7 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                     "lock_held": 0,
                 }
                 try:
-                    from training_db import TrainingDatabase
-
-                    snap = TrainingDatabase().conversion_metrics_snapshot(profile=_profile) or snap
+                    snap = get_training_db().conversion_metrics_snapshot(profile=_profile) or snap
                 except Exception:
                     pass
                 output.append("# HELP btc_conversion_enabled Conversion owner enabled (1=yes)")

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-25T23:24:58.675221+00:00",
-  "repo_root": "/tmp/claude-1000/-workspace-eddie-auto-dev/7f40a52f-d0fb-4e79-95e1-fa52123595d6/scratchpad/wt-dropins",
+  "generated_at": "2026-07-26T03:13:55.667725+00:00",
+  "repo_root": "/workspace/eddie-auto-dev/.claude/worktrees/trusting-chatelet-ffb338",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-25T23:24:58.675221+00:00`
+- Generated at: `2026-07-26T03:13:55.667725+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -3,6 +3,8 @@ Testes unitários para prometheus_exporter.py
 Foco: cálculo correto de total_trades e win_rate incluindo sell_reconciled
 """
 import sys
+import threading
+import time
 import types
 from unittest.mock import MagicMock, patch, call
 from pathlib import Path
@@ -172,3 +174,114 @@ class TestEquityDailyChanges:
         assert result["equity_change_today_pct"] == 10.0
         assert result["equity_change_yesterday_usdt"] == -10.0
         assert result["equity_change_yesterday_pct"] == -5.0
+
+
+# ---------------------------------------------------------------------------
+# Testes: TrainingDatabase compartilhada (um pool por processo, não por scrape)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def pe_module():
+    """prometheus_exporter com o singleton de TrainingDatabase zerado."""
+    sys.path.insert(0, str(Path(__file__).parent.parent / "btc_trading_agent"))
+    import prometheus_exporter as pe
+    saved = pe._TRAINING_DB
+    pe._TRAINING_DB = None
+    try:
+        yield pe
+    finally:
+        pe._TRAINING_DB = saved
+
+
+def _fake_training_db_module(cls):
+    """Módulo training_db falso, para não construir pool psycopg2 de verdade."""
+    mod = types.ModuleType("training_db")
+    mod.TrainingDatabase = cls
+    return mod
+
+
+class TestSharedTrainingDatabase:
+    """get_training_db() deve reaproveitar a instância entre scrapes."""
+
+    def test_constructs_only_once_across_calls(self, pe_module):
+        """Chamadas repetidas retornam a mesma instância e não abrem novo pool."""
+        constructions = []
+
+        class FakeDB:
+            def __init__(self):
+                constructions.append(self)
+
+        with patch.dict(sys.modules, {"training_db": _fake_training_db_module(FakeDB)}):
+            first = pe_module.get_training_db()
+            second = pe_module.get_training_db()
+            third = pe_module.get_training_db()
+
+        assert first is second is third
+        assert len(constructions) == 1, (
+            f"TrainingDatabase deve ser construída 1x, foi {len(constructions)}x "
+            "(um ThreadedConnectionPool vazando por scrape)"
+        )
+
+    def test_concurrent_scrapes_share_one_instance(self, pe_module):
+        """ThreadingHTTPServer: threads simultâneas não podem criar pools extras."""
+        constructions = []
+        barrier = threading.Barrier(8)
+
+        class SlowFakeDB:
+            def __init__(self):
+                # Amplia a janela de corrida entre os threads
+                time.sleep(0.01)
+                constructions.append(self)
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            barrier.wait()
+            db = pe_module.get_training_db()
+            with results_lock:
+                results.append(db)
+
+        with patch.dict(sys.modules, {"training_db": _fake_training_db_module(SlowFakeDB)}):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(constructions) == 1, (
+            f"8 scrapes concorrentes construíram {len(constructions)} instâncias"
+        )
+        assert len(results) == 8
+        assert all(r is results[0] for r in results)
+
+    def test_construction_failure_is_not_cached(self, pe_module):
+        """DB fora do ar: falha propaga e o próximo scrape tenta de novo."""
+        attempts = []
+
+        class FlakyDB:
+            def __init__(self):
+                attempts.append(1)
+                if len(attempts) == 1:
+                    raise RuntimeError("db down")
+
+        with patch.dict(sys.modules, {"training_db": _fake_training_db_module(FlakyDB)}):
+            with pytest.raises(RuntimeError):
+                pe_module.get_training_db()
+            assert pe_module._TRAINING_DB is None
+            db = pe_module.get_training_db()
+
+        assert db is not None
+        assert len(attempts) == 2
+
+    def test_metrics_snapshot_uses_shared_instance(self, pe_module):
+        """A métrica de conversão deve ler pelo singleton, não construir por scrape."""
+        import inspect
+        source = inspect.getsource(pe_module.PrometheusHandler.send_metrics)
+        assert "get_training_db().conversion_metrics_snapshot(" in source, (
+            "send_metrics deve usar get_training_db()"
+        )
+        assert "TrainingDatabase()" not in source, (
+            "send_metrics não pode construir TrainingDatabase por scrape "
+            "(cada construção abre um ThreadedConnectionPool que nunca é fechado)"
+        )


### PR DESCRIPTION
## Problema

O bloco de métricas de conversão em `btc_trading_agent/prometheus_exporter.py` construía `TrainingDatabase()` **a cada scrape do Prometheus**:

```python
from training_db import TrainingDatabase
snap = TrainingDatabase().conversion_metrics_snapshot(profile=_profile) or snap
```

Cada construção abre um `psycopg2.pool.ThreadedConnectionPool` (minconn=1) e roda os 4 SELECTs de catálogo do `_ensure_schema` — e nada chamava `.close()`. Medido em 2026-07-25 no homelab (192.168.15.2): **~280 construções por instância a cada 3h, em 13 unidades `crypto-exporter@*`** — milhares de pools abertos e descartados por hora.

Esse mesmo padrão era o que alimentava a tempestade de deadlocks de migração de schema, já corrigida em #251 (o DDL agora só roda quando o catálogo mostra que falta algo). O que sobrava era o desperdício de conexões.

## Correção

Instância guardada em módulo (lazy), como `scripts/llm_log_panel_server.py` já faz com o global `_DB`. Duas diferenças em relação àquele:

- **lock com double-check** — o exporter roda em `ThreadingHTTPServer`, então dois scrapes concorrentes poderiam criar dois pools. O pool interno do psycopg2 é thread-safe, então compartilhar a instância entre threads é seguro.
- **falha de construção não é cacheada** — se o DB estiver fora, a exceção propaga (o call site já a engole) e o global fica em `None`, para o próximo scrape tentar de novo quando o DB voltar.

Pool de vida longa se auto-cura de restart do Postgres: `putconn` descarta conexão com `transaction_status` UNKNOWN e `getconn` abre outra. É o mesmo regime que `trading_agent.py:332` e `telegram_trading.py:158` já usam em produção.

Era o único ponto do exporter que construía por scrape. `clear_trading_agent/prometheus_exporter.py` não usa `TrainingDatabase`.

## Testes

`TestSharedTrainingDatabase` em `tests/test_prometheus_exporter.py`:

- construção única entre chamadas repetidas
- 8 scrapes concorrentes (barrier) compartilhando uma instância
- falha de construção não cacheada — próxima chamada tenta de novo
- guarda de fonte: `send_metrics` usa `get_training_db()` e não constrói `TrainingDatabase()`

Usam `patch.dict(sys.modules, ...)` com um `training_db` falso — sem pool real e sem resíduo em `sys.modules` para os outros testes.

**Validados por mutação:** restaurar o `TrainingDatabase()` por scrape quebra o guarda de fonte; remover o lock quebra o teste de concorrência (8 construções em vez de 1).

## Regressão

Suíte completa antes e depois: **84 falhas idênticas, lista byte a byte igual**. Todas pré-existentes e de ambiente (sem Postgres em localhost:5432 no sandbox, `scripts.kwai` ausente, wiki agent, docs de fita). Nenhuma regressão.

Três arquivos precisam ser excluídos da coleta local porque fazem `sys.exit()` no import e abortam o pytest inteiro com INTERNALERROR — também pré-existente, confirmado com a árvore limpa: `test_rss_llm_trainer.py`, `test_selenium_grafana_action.py`, `test_fast_model.py`.

## Deploy

O ganho só aparece depois de sincronizar o arquivo para 192.168.15.2 e **reiniciar as 13 unidades `crypto-exporter@*`** — código de trading com dinheiro real, restart pendente de confirmação explícita do usuário. Nada foi reiniciado.

Os arquivos em `deploy/cmdb/bootstrap/generated/` foram regerados e staged automaticamente pelo hook de pre-commit; o diff é só timestamp e `repo_root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)