### PR TITLE
fix(hooks): wiki-sync usa git-common-dir, não quebra em worktrees

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -7,6 +7,10 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Em worktrees, .git é um arquivo (não diretório) apontando para o gitdir
+# privado do worktree — usar --git-common-dir para achar o .git compartilhado
+# de verdade, senão "$REPO_ROOT/.git/wiki_sync.log" falha com ENOTDIR.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 
 # ─── Memory ingestor (git → Chroma) ───────────────────────────────────────────
 INGESTOR="tools/memory_ingestors/git_ingestor.py"
@@ -60,7 +64,7 @@ PY_BIN="$(dirname "$0")/../.venv/bin/python"
 WIKI_SYNC="$(dirname "$0")/../tools/hooks/wiki_sync.py"
 
 for f in $TO_SEND; do
-    "$PY_BIN" "$WIKI_SYNC" "$f" >>"$REPO_ROOT/.git/wiki_sync.log" 2>&1 &
+    "$PY_BIN" "$WIKI_SYNC" "$f" >>"$GIT_COMMON_DIR/wiki_sync.log" 2>&1 &
 done
 
 exit 0

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-26T03:13:55.667725+00:00",
+  "generated_at": "2026-07-26T04:29:53.719167+00:00",
   "repo_root": "/workspace/eddie-auto-dev/.claude/worktrees/trusting-chatelet-ffb338",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-26T03:13:55.667725+00:00`
+- Generated at: `2026-07-26T04:29:53.719167+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/tools/hooks/wiki_sync.py
+++ b/tools/hooks/wiki_sync.py
@@ -20,7 +20,20 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from specialized_agents.wiki_client import WikiJsClient  # noqa: E402
 
-LOG_FILE = REPO_ROOT / ".git" / "wiki_sync.log"
+# Em worktrees, REPO_ROOT/.git é um arquivo (não diretório) — usar
+# --git-common-dir para achar o .git compartilhado de verdade.
+try:
+    _GIT_COMMON_DIR = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"], cwd=REPO_ROOT, text=True
+        ).strip()
+    )
+    if not _GIT_COMMON_DIR.is_absolute():
+        _GIT_COMMON_DIR = REPO_ROOT / _GIT_COMMON_DIR
+except Exception:
+    _GIT_COMMON_DIR = REPO_ROOT / ".git"
+
+LOG_FILE = _GIT_COMMON_DIR / "wiki_sync.log"
 WIKI_GQL = "http://192.168.15.2:3009/graphql"
 
 PATH_HINTS = {


### PR DESCRIPTION
## Problema

`.githooks/post-commit` e `tools/hooks/wiki_sync.py` escreviam o log em `"$REPO_ROOT/.git/wiki_sync.log"`. Em worktree, `.git` é um **arquivo** (aponta para `.git/worktrees/<nome>`), não diretório — abrir esse caminho falha com `ENOTDIR`, e a publicação na Wiki silenciosamente não roda (o post-commit dispara o `wiki_sync.py` em background, então o erro nunca aparece no terminal do usuário).

Confirmado no commit 410f6da4 (#253): o hook chegou a imprimir `📚 [wiki-sync] Publicando .md na Wiki RPA4All...` mas o `wiki_sync.py` nunca escreveu — rodava em worktree.

## Correção

`git rev-parse --git-common-dir` resolve para o `.git` compartilhado de verdade nos dois casos — caminho absoluto quando é worktree, relativo ao cwd quando é repo normal. Validado manualmente nos dois cenários (worktree real e um repo `git init` limpo).

## Observação para quem for revisar (não corrigido neste PR)

`core.hooksPath` está configurado como caminho **absoluto** (`/workspace/eddie-auto-dev/.githooks`), compartilhado entre todos os worktrees. Isso significa que o hook que roda de fato, em qualquer worktree, é sempre a cópia física naquele diretório — não a versão da branch do worktree onde o commit está sendo feito. No momento em que este PR foi aberto, aquele diretório estava checkado em `feat/taxonomy-tables-apis-expansion`, então esta correção só passa a valer depois que esse checkout específico for atualizado (merge + checkout/pull de `main` lá, ou trocar `core.hooksPath` para algo que sempre resolva a branch corrente). Sinalizando para não ficar surpreso se o hook continuar com o bug antigo por mais um tempo após o merge.

## Testes

Sem suíte dedicada a `wiki_sync.py`. Rodei `pytest -k "wiki_sync or wiki_agent"` — as falhas em `test_wiki_agent.py` são pré-existentes (mesma lista de 84 falhas de ambiente já documentada no PR #253, nenhuma relacionada a este arquivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)