### PR TITLE
perf(nas): corta ~28 W da RTX 2060 e contém as quedas por pico de corrente

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -16681,6 +16681,16 @@
         "contexts": [
           "authentik-http"
         ]
+      },
+      "OLLAMA_COORD_HOST": {
+        "name": "OLLAMA_COORD_HOST",
+        "type": "string",
+        "source": "systemd",
+        "value": null,
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Endpoint do ollama-gpu-coordinator (:11437) usado por nas-ollama-load.service para rotear a inferencia a GPU correta."
       }
     },
     "authentication": {

--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -19152,6 +19152,16 @@
         "contexts": [
           "config"
         ]
+      },
+      "GPU_CLOCK_MAX": {
+        "name": "GPU_CLOCK_MAX",
+        "type": "string",
+        "source": "systemd",
+        "value": "900",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Teto de clock grafico (MHz) da RTX 2060 SUPER da NAS, aplicado por nvidia-clock-limit.service para cortar o pico de corrente numa fonte marginal. Remover quando a fonte nova for instalada."
       }
     },
     "monitoring": {

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-26T03:13:55.667725+00:00",
-  "repo_root": "/workspace/eddie-auto-dev/.claude/worktrees/trusting-chatelet-ffb338",
+  "generated_at": "2026-07-27T12:29:30.648750+00:00",
+  "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 183,
+    "repo_services": 184,
     "trading_instances": 12,
     "critical_services": 70,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 20,
-      "operations": 102,
+      "operations": 103,
       "storage": 32,
       "trading": 11
     }
@@ -1074,6 +1074,14 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/meeting-translator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nas-ollama-load.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nas-ollama-load.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-27T12:29:30.648750+00:00",
+  "generated_at": "2026-07-27T13:38:13.082158+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 184,
+    "repo_services": 185,
     "trading_instances": 12,
     "critical_services": 70,
     "domains": {
       "identity": 4,
       "monitoring": 14,
       "network": 20,
-      "operations": 103,
+      "operations": 104,
       "storage": 32,
       "trading": 11
     }
@@ -1090,6 +1090,14 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nvidia-clock-limit.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nvidia-clock-limit.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T12:29:30.648750+00:00`
+- Generated at: `2026-07-27T13:38:13.082158+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `184`
+- Repo services discovered: `185`
 - Critical services flagged for MVP: `70`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 20
-- `operations`: 103
+- `operations`: 104
 - `storage`: 32
 - `trading`: 11
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-26T03:13:55.667725+00:00`
+- Generated at: `2026-07-27T12:29:30.648750+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `183`
+- Repo services discovered: `184`
 - Critical services flagged for MVP: `70`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 14
 - `network`: 20
-- `operations`: 102
+- `operations`: 103
 - `storage`: 32
 - `trading`: 11
 

--- a/systemd/nas-ai-assessor.timer.d/10-power.conf
+++ b/systemd/nas-ai-assessor.timer.d/10-power.conf
@@ -1,0 +1,8 @@
+# Reducao de consumo (2026-07-27): cada execucao acorda a RTX 2060 da NAS
+# (19,5 W ocioso -> ~46 W). Com OLLAMA_KEEP_ALIVE=15m no ollama-nas, rodar
+# de 5 em 5 min mantinha a GPU quente 100% do tempo.
+# De hora em hora -> ~25% do tempo quente. O painel e narrativo (HTML no
+# Grafana); os alertas de LTO usam as metricas do Prometheus, nao este texto.
+[Timer]
+OnUnitActiveSec=
+OnUnitActiveSec=1h

--- a/systemd/nas-ollama-load.service
+++ b/systemd/nas-ollama-load.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Carga periódica no Ollama NAS (RTX 2060) via coordenador :11437
+After=network-online.target ollama-gpu-coordinator.service
+Wants=ollama-gpu-coordinator.service
+
+[Service]
+Type=oneshot
+User=homelab
+Group=homelab
+WorkingDirectory=/apps/crypto-trader
+Environment=PYTHONUNBUFFERED=1
+Environment=OLLAMA_COORD_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_NAS_HOST=http://192.168.15.4:11436
+# Modelos pinados :nas — garantem GPU da NAS
+ExecStart=/usr/bin/python3 /apps/crypto-trader/scripts/nas_ollama_load.py --loops 1 --workers 2 --timeout 180
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/nvidia-clock-limit.service
+++ b/systemd/nvidia-clock-limit.service
@@ -1,0 +1,22 @@
+# Teto de clock da RTX 2060 SUPER (2026-07-27).
+# A maquina (OptiPlex 7010 MT, fonte de fabrica ~275 W) desliga sozinha ao
+# subir modelo para a GPU: 5 de 6 quedas sujas ocorreram de 0 a 93 s depois de
+# "offloaded NN/NN layers to GPU". O power limit ja esta em 125 W, que e o
+# minimo que a placa aceita, entao a unica alavanca de software restante e
+# limitar o clock para cortar o pico de corrente.
+# Substituir por -rgc quando a fonte nova for instalada.
+[Unit]
+Description=NVIDIA GPU clock ceiling (mitigacao de pico de corrente — fonte marginal)
+After=nvidia-modprobe.service
+Wants=nvidia-modprobe.service
+Before=ollama-nas.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=GPU_CLOCK_MAX=900
+ExecStart=/bin/sh -c "for i in $(seq 1 30); do nvidia-smi -pm 1 >/dev/null 2>&1 && nvidia-smi -lgc 300,${GPU_CLOCK_MAX} >/dev/null 2>&1 && exit 0; sleep 2; done; echo desisti; exit 1"
+ExecStop=-/usr/bin/nvidia-smi -rgc
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ollama-nas.service.d/zzzz-idle-power.conf
+++ b/systemd/ollama-nas.service.d/zzzz-idle-power.conf
@@ -1,0 +1,23 @@
+# Reducao de consumo da RTX 2060 SUPER (2026-07-27) — mesmo padrao ja usado
+# na GPU0 do homelab (ollama.service.d/zzzz-idle-power.conf).
+#
+# Medicoes que motivaram a mudanca:
+#   GPU sem trafego, modelo residente em VRAM .. P8,  300 MHz, 18,0 W
+#   GPU com trafego periodico (1% de uso) ...... P2, 1470 MHz, 45,6 W
+#
+# Ou seja: o custo NAO era manter o modelo em VRAM — era o trafego periodico
+# que impedia o downclock. Tres timers geravam esse trafego sem trabalho real
+# (ollama-warmup-nas.timer, nas-ollama-load.timer e nas-ai-assessor a cada
+# 5 min), mantendo a GPU em P2 24/7.
+#
+# KEEP_ALIVE=10m libera a VRAM quando ocioso; MAX_LOADED_MODELS=1 evita o
+# churn de despejo/recarga ("evicting a model to make space") que em 8 GB de
+# VRAM com modelos de ~4 GB dava respostas de 1m47s — cada recarga e trabalho
+# real de GPU, e portanto consumo.
+#
+# ExecStartPost= limpa o warmup-on-start herdado de zz-warmup-on-start.conf
+# (por isso o nome ordena depois dele).
+[Service]
+Environment=OLLAMA_KEEP_ALIVE=10m
+Environment=OLLAMA_MAX_LOADED_MODELS=1
+ExecStartPost=


### PR DESCRIPTION
Dois commits: o primeiro corta o consumo ocioso da GPU; o segundo contém as quedas da máquina, que apareceram durante a investigação do primeiro.

---

# 1. `8b6e7128` — consumo ocioso: 45,6 W → 18,0 W

A RTX 2060 SUPER ficava presa em **P2 (45,6 W com 1% de utilização)** em vez de P8. Três timers geravam tráfego periódico **sem trabalho real**, e esse tráfego impedia o downclock:

1. `ollama-warmup-nas.timer` (NAS) — re-pinava o phi4-mini a cada 10 min
2. `nas-ollama-load.timer` (homelab) — a cada 10 min mandava prompts descartáveis via `scripts/nas_ollama_load.py` só para gerar carga
3. `nas-ai-assessor.timer` (homelab) — a cada 5 min

| Estado | Potência |
|---|---|
| CPU package (i3-3220) | **4,0 W** |
| GPU **sem tráfego**, modelo residente em VRAM | **18,0 W** (P8, 300 MHz) |
| GPU **com tráfego periódico**, 1% de utilização | **45,6 W** (P2, 1470 MHz) |

**O custo não era manter o modelo em VRAM** — com o phi4-mini totalmente residente (4 GB, confirmado no `size_vram`) e sem tráfego, a GPU fica em P8 a 18 W. O que custava era o tráfego periódico.

Em 2026-07-26, **12 das 24 horas** só tiveram o piso de 6 req/h gerado pelos próprios timers — zero trabalho real.

**Mudanças:** `ollama-nas.service.d/zzzz-idle-power.conf` (`KEEP_ALIVE=10m`, `MAX_LOADED_MODELS=1`, `ExecStartPost=` limpo — mesmo padrão da GPU0); `nas-ai-assessor.timer.d/10-power.conf` (5 min → 1 h); `nas-ollama-load.timer` removido.

Estimativa: **~20 kWh/mês (~R$ 19/mês)**.

---

# 2. `470ead75` — a máquina desligava ao carregar modelo na GPU

Correlacionando o fim de cada boot com a última carga de modelo:

| boot | fim | estado | última carga | Δ |
|---|---|---|---|---|
| -6 | 22:07:24 | **sujo** | 22:05:51 | 93 s |
| -5 | 22:19:57 | **sujo** | 22:19:46 | 11 s |
| -4 | 22:24:32 | **sujo** | 22:24:32 | 0 s |
| -3 | 08:32:25 | limpo | — | *reboot deliberado* |
| -2 | 09:14:28 | **sujo** | 09:13:04 | 84 s |
| -1 | 10:19:09 | **sujo** | 10:19:08 | 1 s |

Todas as quedas sujas de 0 a 93 s depois de `offloaded NN/NN layers to GPU`. A placa está **sã** — sem Xid, sem páginas retiradas, sem linhas remapeadas, sem erros de ECC, 38-43 °C. A máquina é um **OptiPlex 7010 MT** (fonte de fábrica ~275 W) com uma placa de 175 W.

O power limit já estava em 125 W, o `power.min_limit` da placa — alavanca esgotada. Sobrava o clock.

**`nvidia-clock-limit.service`** aplica `nvidia-smi -lgc 300,900` no boot, antes do `ollama-nas` (o `-lgc` não persiste entre reboots nem recargas do driver).

Medido com a trava:
- `clocks.sm` nunca passou de **900 MHz** (antes 1470)
- pico sob 90% de utilização: **81 W** (não encosta nos 125 W)
- **6/6** ciclos de carga a frio sem queda
- **6/6** gerações de 400 tokens (2 em paralelo, 3 rodadas)
- throughput preservado: **58 tok/s** no phi4-mini

⚠️ **Não é prova definitiva.** As quedas eram intermitentes — a máquina já tinha ficado 10 h de pé entre elas. Fonte nova já encomendada; quando instalada, remover a unit ou elevar `GPU_CLOCK_MAX`. Se voltar a cair antes disso, o plano é suspender a 2060 do pool do coordenador.

---

## Descoberta lateral

A lentidão histórica (cargas de 40-50 s, timeouts de 1m47s e 3m) era **pressão de RAM** — 8 GB com 6,2 GB em uso — não a GPU. Com memória livre, carga a frio leva 3-4 s.

## Verificação

- Aplicado em `192.168.15.4` e `192.168.15.2`; env conferido via `/proc/PID/environ` (não via `systemctl show`, que engana com drop-ins).
- Drop-ins do repo conferidos byte-a-byte contra os hosts.
- Persistência: `/etc` na NAS é dataset ZFS; config sobreviveu ao reboot das 10:20.
- `pytest tests/test_systemd_dropin_parity.py tests/test_nas_ai_assessor_html.py tests/test_ollama_warmup.py tests/test_ollama_num_ctx_consistency.py` → **57 passed**.

## Pendência

`ollama-nas.service`, `ollama-warmup-nas.service/.timer`, `nvidia-power-limit.service` e o `warmup-phi4-mini.sh` existem só no host, fora do git. Um upgrade do TrueNAS cria um novo boot environment e pode levá-los junto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)