### PR TITLE
fix(coord): só rotear modelo para endpoint que o possui (elimina 404 silencioso)

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -16681,6 +16681,36 @@
         "contexts": [
           "authentik-http"
         ]
+      },
+      "GPU_COORD_PAYLOAD_LOG_CHARS": {
+        "name": "GPU_COORD_PAYLOAD_LOG_CHARS",
+        "type": "string",
+        "source": "systemd",
+        "value": "32000",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Teto de caracteres de prompt/resposta guardados na auditoria do ollama-gpu-coordinator (ring buffer e painel auth.rpa4all.com/llm-prompts/)."
+      },
+      "GPU_COORD_PG_PROMPT_CHARS": {
+        "name": "GPU_COORD_PG_PROMPT_CHARS",
+        "type": "string",
+        "source": "systemd",
+        "value": "32000",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Teto de caracteres gravados em ollama_payload_log no PostgreSQL; separado de GPU_COORD_PAYLOAD_LOG_CHARS para permitir truncar so no banco."
+      },
+      "GPU_COORD_RING_SIZE": {
+        "name": "GPU_COORD_RING_SIZE",
+        "type": "string",
+        "source": "systemd",
+        "value": "500",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Numero de requisicoes mantidas no ring buffer em memoria do ollama-gpu-coordinator."
       }
     },
     "authentication": {

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T14:07:29.433402+00:00",
+  "generated_at": "2026-07-27T14:25:42.749064+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-26T03:13:55.667725+00:00",
-  "repo_root": "/workspace/eddie-auto-dev/.claude/worktrees/trusting-chatelet-ffb338",
+  "generated_at": "2026-07-27T14:07:29.433402+00:00",
+  "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T14:07:29.433402+00:00`
+- Generated at: `2026-07-27T14:25:42.749064+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-26T03:13:55.667725+00:00`
+- Generated at: `2026-07-27T14:07:29.433402+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `183`

--- a/systemd/ollama-gpu-coordinator.service.d/audit-prompts.conf
+++ b/systemd/ollama-gpu-coordinator.service.d/audit-prompts.conf
@@ -1,0 +1,5 @@
+[Service]
+# Auditoria completa de prompts/respostas (painel auth.rpa4all.com/llm-prompts/)
+Environment=GPU_COORD_PAYLOAD_LOG_CHARS=32000
+Environment=GPU_COORD_PG_PROMPT_CHARS=32000
+Environment=GPU_COORD_RING_SIZE=500

--- a/tests/test_ollama_gpu_coordinator_availability.py
+++ b/tests/test_ollama_gpu_coordinator_availability.py
@@ -1,0 +1,148 @@
+"""Elegibilidade por catálogo de modelos no ollama-gpu-coordinator.
+
+Contexto: o coordenador roteava por score sem saber quais modelos cada endpoint
+POSSUI — só sabia o que estava residente em VRAM (/api/ps). Resultado medido em
+2026-07-27: 116 requisições de `trading-analyst` em 2 dias foram roteadas para a
+NAS, que não tem esse modelo, e morreram com 404 (2,6% do tráfego do modelo).
+
+Estes testes fixam as duas metades do contrato:
+  - filtrar quando se SABE que o endpoint não tem o modelo;
+  - não filtrar quando o catálogo é desconhecido (fail-open), para que um
+    /api/tags intermitente nunca tire uma GPU do pool.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import ollama_gpu_coordinator as coord  # noqa: E402
+
+
+def _endpoint(name="gpu-test", host="http://127.0.0.1:9", vram=8192, priority=0):
+    return coord.EndpointState(name=name, host=host, vram_total_mb=vram, priority=priority)
+
+
+def _make_healthy(ep, available=None, loaded=None):
+    """Coloca o endpoint em estado saudável sem tocar a rede."""
+    import time
+
+    ep._healthy = True
+    ep._last_ok_poll = time.monotonic()
+    ep._loaded = dict(loaded or {})
+    if available is not None:
+        ep._available = set(available)
+        ep._available_known = True
+    return ep
+
+
+# ── fail-open ────────────────────────────────────────────────────────────────
+
+def test_catalogo_desconhecido_nao_filtra():
+    """Sem catálogo, tudo é elegível — não podemos quebrar roteamento que funciona."""
+    ep = _make_healthy(_endpoint())
+    assert ep._available_known is False
+    assert ep.has_model_available("trading-analyst") is True
+    assert ep.score("trading-analyst") < float("inf")
+
+
+def test_tags_falhando_preserva_catalogo_anterior():
+    ep = _make_healthy(_endpoint(), available={"trading-analyst:latest"})
+    ep.host = "http://127.0.0.1:1"  # porta fechada → urlopen falha
+    ep._poll_tags()
+    assert ep._available_known is True
+    assert ep.has_model_available("trading-analyst") is True
+
+
+def test_tags_vazio_preserva_catalogo_anterior(monkeypatch):
+    ep = _make_healthy(_endpoint(), available={"trading-analyst:latest"})
+
+    class _Resp:
+        def read(self):
+            return b'{"models": []}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(coord.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    ep._poll_tags()
+    assert ep.has_model_available("trading-analyst") is True
+
+
+# ── filtragem com conhecimento positivo ──────────────────────────────────────
+
+def test_modelo_ausente_do_catalogo_e_inelegivel():
+    """O caso real: NAS sem trading-analyst."""
+    ep = _make_healthy(_endpoint("nas-rtx2060"), available={"phi4-mini:latest"})
+    assert ep.has_model_available("trading-analyst") is False
+    assert ep.score("trading-analyst") == float("inf")
+
+
+def test_modelo_presente_no_catalogo_e_elegivel():
+    ep = _make_healthy(_endpoint(), available={"trading-analyst:latest"})
+    assert ep.has_model_available("trading-analyst") is True
+    assert ep.score("trading-analyst") < float("inf")
+
+
+@pytest.mark.parametrize(
+    "consulta, catalogo, esperado",
+    [
+        ("trading-analyst", {"trading-analyst:latest"}, True),
+        ("trading-analyst:latest", {"trading-analyst:latest"}, True),
+        ("phi4-mini:nas", {"phi4-mini:nas"}, True),
+        ("trading-analyst", {"phi4-mini:latest"}, False),
+        ("gemma3:1b", {"phi4-mini:latest"}, False),
+    ],
+)
+def test_normalizacao_de_tag(consulta, catalogo, esperado):
+    ep = _make_healthy(_endpoint(), available=catalogo)
+    assert ep.has_model_available(consulta) is esperado
+
+
+def test_modelo_residente_conta_como_disponivel():
+    """Se está em VRAM, existe — mesmo que o catálogo esteja desatualizado."""
+    ep = _make_healthy(_endpoint(), available={"outro:latest"}, loaded={"recem-baixado:latest": 100.0})
+    assert ep.has_model_available("recem-baixado") is True
+
+
+# ── roteamento no cluster ────────────────────────────────────────────────────
+
+def test_pick_evita_endpoint_sem_o_modelo():
+    """Reproduz o bug: sem o filtro, a NAS vencia por ter mais VRAM livre."""
+    gpu0 = _make_healthy(
+        _endpoint("gpu0-rtx3060", vram=12288, priority=0),
+        available={"trading-analyst:latest"},
+        loaded={"trading-analyst:latest": 6000.0},
+    )
+    nas = _make_healthy(
+        _endpoint("nas-rtx2060", vram=8192, priority=1),
+        available={"phi4-mini:latest"},
+    )
+    nas._active = 0
+    gpu0._active = 5  # GPU0 ocupada — antes isso bastava para desviar para a NAS
+
+    cluster = coord.GPUCluster([gpu0, nas])
+    assert cluster.pick("trading-analyst") is gpu0
+
+
+def test_pick_retorna_none_quando_ninguem_tem_o_modelo():
+    """Melhor um 503 explícito do coordenador que um 404 silencioso do endpoint."""
+    gpu0 = _make_healthy(_endpoint("gpu0-rtx3060"), available={"phi4-mini:latest"})
+    nas = _make_healthy(_endpoint("nas-rtx2060"), available={"phi4-mini:latest"})
+    cluster = coord.GPUCluster([gpu0, nas])
+    assert cluster.pick("modelo-inexistente") is None
+
+
+def test_pin_por_sufixo_continua_mandando_para_o_endpoint_pinado():
+    """O pin é intenção explícita: avisa no log, mas não desvia."""
+    nas = _make_healthy(_endpoint("nas-rtx2060"), available={"phi4-mini:nas"})
+    gpu0 = _make_healthy(_endpoint("gpu0-rtx3060"), available={"tudo:latest"})
+    cluster = coord.GPUCluster([gpu0, nas])
+    assert cluster.pick("phi4-mini:nas") is nas

--- a/tools/ollama_gpu_coordinator.py
+++ b/tools/ollama_gpu_coordinator.py
@@ -222,7 +222,9 @@ class EndpointState:
 
         self._lock = threading.Lock()
         self._active: int = 0
-        self._loaded: dict[str, float] = {}        # model_name → vram_mb
+        self._loaded: dict[str, float] = {}        # model_name → vram_mb (residente, /api/ps)
+        self._available: set[str] = set()          # modelos que o endpoint POSSUI (/api/tags)
+        self._available_known: bool = False        # False = catálogo desconhecido → fail-open
         self._model_active: dict[str, int] = {}    # model_name → requests ativas
         self._model_last_used: dict[str, float] = {}  # model_name → monotonic timestamp
         self._healthy: bool = False
@@ -253,8 +255,25 @@ class EndpointState:
         return max(0.0, self.vram_total_mb - self.vram_used_mb)
 
     def has_model(self, model: str) -> bool:
+        """O modelo está carregado em VRAM agora? (afinidade — evita reload)"""
         m = model if ":" in model else model + ":latest"
         return model in self._loaded or m in self._loaded
+
+    def has_model_available(self, model: str) -> bool:
+        """O endpoint POSSUI este modelo? (elegibilidade — evita 404)
+
+        Fail-open deliberado: enquanto o catálogo for desconhecido (endpoint
+        novo, /api/tags falhando), retorna True para não bloquear roteamento
+        que hoje funciona. Só filtra com conhecimento positivo da ausência.
+        """
+        with self._lock:
+            if not self._available_known:
+                return True
+            avail = self._available
+            loaded = set(self._loaded)
+        m = model if ":" in model else model + ":latest"
+        # Um modelo residente está, por definição, disponível.
+        return bool({model, m} & (avail | loaded))
 
     # ── mutação ───────────────────────────────────────────────────────────────
 
@@ -322,6 +341,34 @@ class EndpointState:
             log.warning("poll %s falhou (%d/%d): %s",
                         self.name, self._consec_fails, FAIL_THRESHOLD, exc)
 
+        if self._healthy:
+            self._poll_tags()
+
+    def _poll_tags(self) -> None:
+        """Atualiza o catálogo de modelos que o endpoint possui (/api/tags).
+
+        Falha aqui NÃO marca o endpoint unhealthy nem invalida o catálogo
+        anterior: um /api/tags intermitente não pode tirar uma GPU do pool.
+        """
+        try:
+            req = urllib.request.Request(
+                f"{self.host}/api/tags",
+                headers={"User-Agent": "gpu-coordinator/2.0"},
+            )
+            with urllib.request.urlopen(req, timeout=HEALTH_TIMEOUT_SEC) as resp:
+                data = json.loads(resp.read())
+            names = {m.get("name", "") for m in data.get("models", [])}
+            names.discard("")
+            if not names:
+                return  # resposta vazia/inesperada — preserva o catálogo anterior
+            with self._lock:
+                if names != self._available:
+                    log.info("catálogo de %s atualizado: %d modelos", self.name, len(names))
+                self._available = names
+                self._available_known = True
+        except Exception as exc:
+            log.debug("tags %s falhou (catálogo anterior preservado): %s", self.name, exc)
+
     def mark_unhealthy(self, reason: str = "") -> None:
         """Marca imediatamente como unhealthy (ex.: falha de conexão no forward)."""
         with self._lock:
@@ -338,6 +385,12 @@ class EndpointState:
         Retorna float('inf') se o endpoint não é elegível.
         """
         if not self.healthy:
+            return float("inf")
+
+        # Endpoint não possui o modelo — encaminhar para cá devolve 404.
+        # Era a causa de 116 requisições de trading-analyst perdidas em 2 dias
+        # (roteadas para a NAS, que não tem esse modelo).
+        if not self.has_model_available(model):
             return float("inf")
 
         needed_mb = _estimate_vram_mb(model)
@@ -373,6 +426,8 @@ class EndpointState:
             "vram_used_mb": round(self.vram_used_mb, 1),
             "vram_free_mb": round(self.vram_free_mb, 1),
             "loaded_models": list(self._loaded.keys()),
+            "available_models_known": self._available_known,
+            "available_models_count": len(self._available),
         }
 
 
@@ -504,6 +559,11 @@ class GPUCluster:
             if model.endswith(suffix):
                 pinned = next((ep for ep in self._endpoints if ep.name == ep_name), None)
                 if pinned and pinned.healthy and pinned.name not in exclude:
+                    if not pinned.has_model_available(model):
+                        # Não desvia (o pin é intenção explícita), mas avisa —
+                        # senão a falha vira um 404 silencioso no endpoint.
+                        log.warning("model=%s pinado em %s, mas o endpoint não o possui — vai 404",
+                                    model, pinned.name)
                     log.info("roteando model=%s → %s [pinned] (active=%d vram_free=%.0fMB)",
                              model, pinned.name, pinned.active_requests, pinned.vram_free_mb)
                     return pinned

--- a/tools/ollama_gpu_coordinator.py
+++ b/tools/ollama_gpu_coordinator.py
@@ -108,8 +108,11 @@ def _record_duration(model: str, elapsed_s: float) -> None:
 
 # ── Ring buffer de requisições ────────────────────────────────────────────────
 
-_PAYLOAD_LOG_CHARS = int(os.environ.get("GPU_COORD_PAYLOAD_LOG_CHARS", "500"))
-_RING_SIZE = int(os.environ.get("GPU_COORD_RING_SIZE", "100"))
+# Auditoria: por padrão guarda prompt/resposta quase inteiros (32k chars).
+# Override via GPU_COORD_PAYLOAD_LOG_CHARS se precisar reduzir memória.
+_PAYLOAD_LOG_CHARS = int(os.environ.get("GPU_COORD_PAYLOAD_LOG_CHARS", "32000"))
+_RING_SIZE = int(os.environ.get("GPU_COORD_RING_SIZE", "500"))
+_PG_PROMPT_CHARS = int(os.environ.get("GPU_COORD_PG_PROMPT_CHARS", str(_PAYLOAD_LOG_CHARS)))
 
 _ring_lock = threading.Lock()
 _ring: collections.deque = collections.deque(maxlen=_RING_SIZE)
@@ -161,8 +164,8 @@ def _start_pg_writer() -> None:
                             entry.get("ts"), entry.get("model"), entry.get("endpoint"),
                             entry.get("path"), entry.get("status"), entry.get("elapsed_s"),
                             bool(entry.get("streaming")),
-                            (entry.get("prompt") or "")[:2000],
-                            (entry.get("response") or "")[:2000],
+                            (entry.get("prompt") or "")[:_PG_PROMPT_CHARS],
+                            (entry.get("response") or "")[:_PG_PROMPT_CHARS],
                         ),
                     )
             except Exception as exc:
@@ -732,7 +735,7 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
         host = parsed.hostname
         port = parsed.port or 80
 
-        # Extrai prompt para o ring buffer
+        # Extrai prompt completo para auditoria (ring + PG + painel).
         prompt_preview = ""
         model_name = ""
         try:
@@ -740,8 +743,24 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
             model_name = req_data.get("model", "")
             raw_prompt = req_data.get("prompt") or ""
             if not raw_prompt:
-                msgs = req_data.get("messages", [])
-                raw_prompt = " | ".join(m.get("content", "")[:200] for m in msgs[-3:])
+                msgs = req_data.get("messages") or []
+                parts: list[str] = []
+                for m in msgs:
+                    if not isinstance(m, dict):
+                        continue
+                    role = (m.get("role") or "user").strip()
+                    content = m.get("content") or ""
+                    if isinstance(content, list):
+                        # multimodal: junta textos
+                        content = " ".join(
+                            (c.get("text") or "") if isinstance(c, dict) else str(c)
+                            for c in content
+                        )
+                    parts.append(f"[{role}] {content}")
+                raw_prompt = "\n\n".join(parts)
+            # system separado (algumas APIs)
+            if req_data.get("system") and "system" not in raw_prompt[:80].lower():
+                raw_prompt = f"[system] {req_data['system']}\n\n{raw_prompt}"
             prompt_preview = _clean_text(raw_prompt)
         except Exception:
             pass


### PR DESCRIPTION
Dois commits: o fix de roteamento, e a versionagem da auditoria de prompts que já rodava em produção (necessária para que o deploy não a destrua).

---

# 1. `3af895b1` — só rotear modelo para endpoint que o possui

## Problema

O coordenador escolhia endpoint por score **sem saber quais modelos cada um possui**. O `has_model()` consultava `_loaded`, que vem de `/api/ps` — modelos *residentes em VRAM*. O docstring do `poll()` prometia *"via /api/ps e /api/tags"*, mas **`/api/tags` nunca foi implementado**.

## Impacto medido (2 dias de log)

```
trading-analyst → nas-rtx2060   116x   status=404
gemma3:1b       → nas-rtx2060     2x   status=404
llama3.2:1b     → nas-rtx2060     1x   status=404
```

| `trading-analyst` | |
|---|---|
| roteadas | 4.544 |
| OK | 4.425 |
| **404** | **116 (2,6%)** |

A NAS não tem o `trading-analyst`. Com a GPU0 ocupada, o score mandava para a NAS — mais VRAM livre, menos requisições ativas — e a requisição morria com 404, **silenciosamente do ponto de vista do agente de trading**.

## Mudanças

- **`_poll_tags()`** busca `/api/tags` e mantém o catálogo de modelos disponíveis
- **`has_model_available()`** decide *elegibilidade*; `has_model()` continua sendo *afinidade de VRAM*. Eram duas coisas distintas coladas numa só
- **`score()`** devolve `inf` quando o endpoint comprovadamente não tem o modelo
- **`info()`** expõe `available_models_known` / `available_models_count`

**Fail-open deliberado:** com catálogo desconhecido (endpoint novo, `/api/tags` falhando), tudo é elegível. Um `/api/tags` intermitente **nunca** pode tirar uma GPU do pool. Falha no poll **preserva o catálogo anterior**; resposta vazia é ignorada. Modelo residente conta como disponível.

**Pin por sufixo** continua mandando para o endpoint pinado — é intenção explícita — mas agora loga `WARNING` se o endpoint não tiver o modelo.

Quando ninguém tem o modelo: **503 `nenhum GPU disponível para model=X`** em vez de 404 silencioso.

## Testes

14 testes novos. Verificado que o teste falha sem o fix:

```
COM o fix   -> gpu0-rtx3060
SEM o fix   -> nas-rtx2060   <- reproduz o 404
```

121 testes de `ollama/coord/gpu` passam. Duas falhas em `test_ollama_gpu_selfheal_script.py` são ambientais e pré-existentes (`/var/lib/ollama-selfheal` não existe na máquina de dev); esse arquivo não importa o código alterado.

## Verificado em produção

```
gpu0-rtx3060     healthy=True catalogo_conhecido=True modelos=20
nas-rtx2060      healthy=True catalogo_conhecido=True modelos=11
gpu1-gtx1050     healthy=True catalogo_conhecido=True modelos=20
```

3 min de tráfego real: **14 `trading-analyst` → gpu0, 2 pinados → gpu1, 0 em 404, 0 em 503.**

---

# 2. `e4c6382d` — versiona a auditoria de prompts

**Estas 26 linhas não são minhas e não mudam nada em runtime.** São exatamente o que já roda em `/apps/crypto-trader/tools/ollama_gpu_coordinator.py`, implantado à mão e nunca commitado.

Trago para o git porque **o deploy é destrutivo**: `deploy-btc-trading-profiles.yml` dispara em `tools/ollama_gpu_coordinator.py` e faz `sudo install ${REPO_ROOT}/tools/... ${TOOLS_DIR}/...`. Enquanto essas linhas ficassem só no host, qualquer PR que tocasse esses paths as apagaria em silêncio — inclusive este.

O que a auditoria faz (painel `auth.rpa4all.com/llm-prompts/`):
- `_PAYLOAD_LOG_CHARS` 500 → 32000 e `_RING_SIZE` 100 → 500
- `_PG_PROMPT_CHARS` separa o truncamento do PostgreSQL, que estava fixo em 2000 chars e cortava prompt/resposta antes de chegar ao painel
- extração de prompt completo: percorre todas as mensagens (não só as 3 últimas truncadas em 200 chars), trata `content` multimodal em lista, concatena por papel; `system` entra separado

Também versiona `ollama-gpu-coordinator.service.d/audit-prompts.conf`, que define as três variáveis no host e também estava fora do git. **Deliberadamente fora** de `deploy/systemd-dropins-sync.allowlist` — o arquivo já existe no host e a instalação de drop-ins é opt-in por arquivo.

---

## Segurança do deploy

- `tools/ollama_gpu_coordinator.py` no repo é **byte-a-byte igual** ao que roda no host. O deploy reinstala os mesmos bytes: no-op de conteúdo, só reinicia o serviço.
- Sync de drop-ins é **aditivo, sem `--delete`** — nada no host é removido.
- Drift dos 13 drop-ins da allowlist conferido contra o host: **zero**, então `check_systemd_dropin_drift.py --strict` passa.
- `--strict` falha em `drift`, não em `host_only` (isso exigiria `--fail-on-host-only`, que o workflow não passa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)