### PR TITLE
fix(infra): traz para o git a proteção de tunnel-guardian do exporter

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T14:30:37.428646+00:00",
+  "generated_at": "2026-07-27T16:51:30.741737+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T14:30:37.428646+00:00`
+- Generated at: `2026-07-27T16:51:30.741737+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `185`

--- a/grafana/exporters/tunnel_healthcheck_exporter.py
+++ b/grafana/exporters/tunnel_healthcheck_exporter.py
@@ -68,6 +68,11 @@ CRITICAL_SERVICES = {
     "ufw", "ufw.service",
 }
 
+# Managed by cloudflared-tunnel-guardian — tunnel-heal only reapplies routes.
+NO_RESTART_TUNNELS = {
+    "cloudflared-rpa4all",
+}
+
 # ── Tunnel definitions ─────────────────────────────────────────────────
 
 @dataclass
@@ -195,6 +200,26 @@ class TunnelHealthChecker:
             )
             return result.returncode == 0
         except Exception:
+            return False
+
+    def _routes_only_heal(self, tunnel: TunnelDef, state: TunnelState) -> bool:
+        """Reapply WAN routes without restarting cloudflared (guardian owns restarts)."""
+        cmd = tunnel.restart_command or "/usr/local/sbin/cloudflared-vpn-routes.sh"
+        log.warning("ROUTES-ONLY HEAL: %s via: %s", tunnel.name, cmd)
+        try:
+            result = subprocess.run(
+                shlex.split(cmd), capture_output=True, text=True, timeout=30,
+            )
+            success = result.returncode == 0
+            self._audit("routes_only", tunnel.name, success, result.stderr.strip())
+            if success:
+                log.info("ROUTES-ONLY HEAL: %s routes reapplied", tunnel.name)
+            else:
+                log.error("ROUTES-ONLY HEAL: %s FAILED: %s", tunnel.name, result.stderr)
+            return success
+        except Exception as e:
+            log.error("ROUTES-ONLY HEAL: %s EXCEPTION: %s", tunnel.name, e)
+            self._audit("routes_only", tunnel.name, False, str(e))
             return False
 
     def restart_service(self, tunnel: TunnelDef, state: TunnelState) -> bool:
@@ -326,7 +351,10 @@ class TunnelHealthChecker:
 
             # Self-heal after 2 consecutive failures
             if state.consecutive_failures >= 2:
-                self.restart_service(tunnel, state)
+                if name in NO_RESTART_TUNNELS:
+                    self._routes_only_heal(tunnel, state)
+                else:
+                    self.restart_service(tunnel, state)
 
         return all_ok
 


### PR DESCRIPTION
## Problema

Código crítico de produção rodando no host (`/home/homelab/shared-auto-dev/grafana/exporters/tunnel_healthcheck_exporter.py`) **não estava no repositório**. Quando a manutenção sincronizasse o repo → host, essa proteção desapareceria silenciosamente e o incidente CF 1033 voltaria.

## O que está sendo trazido

30 linhas que implementam a mitigação do **incidente CF 1033 (2026-07-17)**:

### Proteção: `NO_RESTART_TUNNELS` e `_routes_only_heal()`

```python
# Managed by cloudflared-tunnel-guardian — tunnel-heal only reapplies routes.
NO_RESTART_TUNNELS = {"cloudflared-rpa4all"}

def _routes_only_heal(self, tunnel, state):
    """Reapply WAN routes sem reiniciar cloudflared (guardian owns restarts)."""
    cmd = tunnel.restart_command or "/usr/local/sbin/cloudflared-vpn-routes.sh"
    # ... roda o script de rotas isoladamente ...
```

**Lógica:** Quando o healthcheck detecta que o túnel precisa reaplicar routes:
- **Se `cloudflared-rpa4all`** (pinado em `NO_RESTART_TUNNELS`): chama `_routes_only_heal()` que roda um script isolado de setup de WAN routes
- **Se outro túnel**: chama `self.restart_service()` e reinicia o daemon normalmente

## Por que isso importa

No incidente de 17/jul, o watchdog reiniciando cloudflared amplificava um blip do eth-wan e entrava em loop. A mitigação separou os concerns: um serviço paralelo (`cloudflared-tunnel-guardian`) é responsável pelos restarts; o healthcheck só reaplica rotas.

Se essa proteção desaparecer (via deploy copiando uma versão vinha do repo), o loop volta.

## Histórico

- **implantada:** no host em algum momento pós-17/jul
- **nunca commitada:** o `shared-auto-dev` é um diretório **sem `.git`**, cópia solta que nada atualiza
- **descoberta:** 2026-07-27, ao investigar resíduo de modelos banidos — achei que o exporter tinha 5 arquivos `.py`, dos quais 4 idênticos ao repo e 1 divergindo em 30 linhas

## Plano seguinte

Após revisão, repontar os três serviços que rodam de `shared-auto-dev` para o checkout git (`myClaude`):

```
tunnel-healthcheck-exporter  → usar /home/homelab/myClaude/...
grafana-dashboard-sync       → usar /home/homelab/myClaude/...
nas-ai-assessor              → usar /home/homelab/myClaude/...
```

E aposentar `/home/homelab/shared-auto-dev` que é código morto.

## Validação

```
repo antes:   24.089 bytes (sem proteção)
host/prod:    24.385 bytes (com proteção)
repo agora:   24.385 bytes (idêntico ao host)
```

Sintaxe validada: `python3 -m py_compile grafana/exporters/tunnel_healthcheck_exporter.py` ✅

---

**Status:** Bloqueia em revisão. Não mergear até você confirmar que a proteção é a correta (check contra PR #222 / feedback_cf_tunnel_guardian_restart_loop.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)