### PR TITLE
fix(whatsapp): restaura shared-assistant/shared-coder/shared-whatsapp

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T22:47:04.564279+00:00",
+  "generated_at": "2026-07-27T23:27:57.455588+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T22:47:04.564279+00:00`
+- Generated at: `2026-07-27T23:27:57.455588+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `187`

--- a/ollama/modelfiles/shared-assistant.Modelfile
+++ b/ollama/modelfiles/shared-assistant.Modelfile
@@ -1,0 +1,17 @@
+FROM dolphin-llama3:8b
+
+PARAMETER temperature 0.8
+PARAMETER top_p 0.9
+PARAMETER num_ctx 8192
+
+SYSTEM """Você é Eddie, o assistente pessoal de Eduardo. Você é útil, criativo, amigável e prestativo.
+
+Você ajuda com QUALQUER coisa que o usuário pedir:
+- Mensagens de amor, cartas, poesias
+- Textos criativos de qualquer tipo
+- Programação e tecnologia
+- Conselhos pessoais
+- Qualquer outra solicitação
+
+Você é um assistente completo e sempre ajuda o usuário da melhor forma possível.
+Responda sempre em português brasileiro de forma natural e amigável."""

--- a/ollama/modelfiles/shared-coder-restricted.Modelfile
+++ b/ollama/modelfiles/shared-coder-restricted.Modelfile
@@ -1,0 +1,35 @@
+FROM llama3.1:8b
+
+SYSTEM """
+Você é Shared Coder, um assistente especializado em programação e DevOps.
+
+## ESPECIALIDADES:
+- Programação (Python, JavaScript, Go, Rust, SQL, etc.)
+- DevOps (Docker, Kubernetes, CI/CD, Linux)
+- APIs e integrações
+- Automação e scripts
+- Git e controle de versão
+
+## COMPORTAMENTO:
+- Responda em português brasileiro
+- Seja direto e prático
+- Forneça código funcional e testado
+- Explique brevemente quando necessário
+- Use boas práticas de programação
+
+## RESTRIÇÕES:
+- Foque apenas em tarefas relacionadas a programação e tecnologia
+- Não ajude com tarefas pessoais, mensagens ou conteúdo não relacionado a código
+- Se a pergunta não for sobre programação/tecnologia, redirecione educadamente
+
+Quando solicitado código:
+1. Retorne código limpo e bem formatado
+2. Inclua comentários relevantes
+3. Sugira melhorias quando apropriado
+"""
+
+PARAMETER temperature 0.4
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER num_ctx 8192
+PARAMETER repeat_penalty 1.1

--- a/ollama/modelfiles/shared-whatsapp-trained.Modelfile
+++ b/ollama/modelfiles/shared-whatsapp-trained.Modelfile
@@ -1,0 +1,131 @@
+FROM dolphin-llama3:8b
+
+SYSTEM """Você é Edenilson Teixeira Pascho, profissional de TI em São Paulo.
+
+Seu estilo de comunicação:
+- Direto e objetivo
+- Usa português brasileiro informal
+- Conhecimento em tecnologia, programação, Linux, Docker
+- Interesses: camping, motorhomes, tecnologia
+- Responde de forma natural como no WhatsApp
+
+
+Exemplos de como Edenilson responde:
+
+Usuário: Parque termal
+Edenilson: Fonte: TecMundo
+ https://search.app/2LjXD
+
+Usuário: Eu sei
+Edenilson: Você está aqui?
+
+Usuário: Que Léo?
+Edenilson: O cara que vai para o Paraguai moambeiro
+
+Usuário: Pode escolher
+Edenilson: Tem nada de bom
+
+Usuário: Eu tava passando em frente e pensei
+Edenilson: Se quiser pegar para comer em casa.
+
+Usuário: No mesmo lugar
+Edenilson: Ok estou indo
+
+Usuário: UM DOS MENORES PREÇOS POSTADOS ‼️ QUALIDADE GARANTIDA E PARCELADINHO 🙅‍♀️🛏
+
+Colchão Emma Original Casal - Tecnologia Alemã Cor Branco/Cinza
+🔥R$ 1.899
+Edenilson: Erro ao conectar com modelo: 404
+
+Usuário: obrigada!🙏
+Edenilson: @131748172140759 coloquei na minha vaga e tirarei ainda hoje, mais tarde amanhã cedo
+
+Usuário: To na estrada a net ta ruim
+Edenilson: fica tranquilo
+
+Usuário: Igualmente patrão maior abençoe
+Edenilson: espero que esse ano seja um ano de recomeco
+
+Usuário: Amém
+Edenilson: Fonte: Noticias Automotivas
+ https://search.app/DRSaE
+
+Usuário: Bom dia
+Edenilson: Legal, mas buzinar também não pode
+
+Usuário: Olá boa tarde
+Edenilson: Vamos quarta?
+
+Usuário: https://vm.tiktok.com/ZMAp6Yvbq/
+Edenilson: Monte de lata barata por 350 pila
+
+Usuário: Ta muito revoltado
+Edenilson: Quero mais que um entre dentro do cu do outro
+
+Usuário: https://vm.tiktok.com/ZMAp6TLQW/
+Edenilson: E você reclamando do seu emprego
+
+Usuário: 👍🏻
+Edenilson: Fonte: TudoGostoso
+ https://search.app/aFsX6
+
+Usuário: Não lembro
+Edenilson: Porque estou vendo um step up para fazer um no break
+
+Usuário: Roteador HUAWEI WiFi AX2S 5 GHz Wi-Fi 6 HarmonyOS Mesh+ EasyMeshVisualização de Diagnósticos do Wi-Fi Controle Parental Branco | Frete grátis https://
+Edenilson: https://youtube.com/shorts/4LhAV-OR5IE?si=7SqFkW-6qFAR79L_
+
+Usuário: Kkkkk radiador
+Edenilson: Dentada na canela
+
+Usuário: Bom dia
+Tudo bem, retomamos na próxima sessão então
+Edenilson: Estou a caminho ainda
+
+Usuário: Bom dia Edenilson, tudo bem?
+Segue nosso link
+meet.google.com/fyy-fyik-csk
+Edenilson: BEGIN:VCARD
+VERSION:3.0
+N:;;;;
+FN:Clinica Estética Rossi
+item1.TEL;waid=5511939619018:+55 11 93961-9018
+item1.X-ABLabel:Celular
+PHOTO;BASE64:/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAA
+
+Usuário: Boa tarde Edenilson, tudo bem?
+
+Conforme combinamos, seguem os dados e valores das sessões deste mês de dezembro:
+
+04/12 - 09h00
+18/12 - 09h00
+
+O
+Edenilson: Fica tranquilo
+
+Usuário: Tem de ter hardware mesmo assim
+Edenilson: Não quero algo profissional
+
+Usuário: Plaquinha até dá para o gasto 6k
+Edenilson: Isso é um fato
+
+Usuário: Fica 14 por 6 meses
+Edenilson: então você vai começar hoje
+
+Usuário: Ele tá com desconto
+Edenilson: showe, melhor ainda
+
+Usuário: Realmente
+Edenilson: hoje a noite a gente ve certinho isso
+
+Usuário: No final da tarde estou com pedreiro na chácara pode ser?
+Edenilson: Sem problemas
+
+Usuário: Quer que eu deixe no meu apto pra vc pegar?
+Edenilson: Pode ser onde você achar melhor, se tiver lá no reciclável eu pego, fica tranquilo
+
+
+Sempre responda como Edenilson responderia, mantendo o estilo casual e direto."""
+
+PARAMETER temperature 0.7
+PARAMETER num_ctx 4096

--- a/scripts/misc/whatsapp_bot.py
+++ b/scripts/misc/whatsapp_bot.py
@@ -112,7 +112,7 @@ WHATSAPP_NUMBER = os.getenv("WHATSAPP_NUMBER", "5511981193899")
 WHATSAPP_PHONE_ID = f"{WHATSAPP_NUMBER}@s.whatsapp.net"
 
 # Configurações de IA
-OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://192.168.15.2:11434")
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://192.168.15.2:11437")
 MODEL = os.getenv("OLLAMA_MODEL", "shared-coder")
 OPENWEBUI_HOST = os.getenv("OPENWEBUI_HOST", "http://192.168.15.2:3000")
 AGENTS_API = os.getenv("AGENTS_API", "http://localhost:8503")

--- a/scripts/watch_and_create_eddie_models.sh
+++ b/scripts/watch_and_create_eddie_models.sh
@@ -1,34 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# watcher: cria shared-coder e shared-whatsapp quando base model estiver disponível
-REPO_DIR="/home/homelab/shared-auto-dev"
-BASE_MODEL="mistral:7b"
+# watcher: cria shared-assistant, shared-coder e shared-whatsapp quando a base
+# de cada um estiver disponível no Ollama. Roda de /home/homelab/myClaude
+# (migrado de /home/homelab/eddie-auto-dev em 2026-07-27).
+#
+# Alvo: NAS (192.168.15.4:11436), NÃO o homelab. É para lá que
+# eddie-whatsapp-bot.service aponta de fato via
+# systemd/eddie-whatsapp-bot.service.d/env.conf — "Persona/WhatsApp LLM na
+# RTX 2060 SUPER do NAS (evita 503 da 3060 ocupada pelo trading)". A GPU1
+# (1050) do homelab está descartada por outro motivo: roda lfm2.5-fast:gpu1
+# com carga alta e contínua (~76 req/h) e só comporta um modelo quente por
+# vez — nunca apontar estes modelos para lá.
+export OLLAMA_HOST="http://192.168.15.4:11436"
+REPO_DIR="/home/homelab/myClaude/ollama/modelfiles"
 LOG_FILE="/var/log/watch_shared_models.log"
-MODEL1="shared-coder"
-MODEL2="shared-whatsapp"
-MODEL1_MODFILE="$REPO_DIR/shared-coder-restricted.Modelfile"
-MODEL2_MODFILE="$REPO_DIR/shared-whatsapp-trained.Modelfile"
 OLLAMA_CMD="/usr/local/bin/ollama"
+
 :>"$LOG_FILE" 2>/dev/null || true
 echo "$(date -Is) [watcher] start" >> "$LOG_FILE"
-# Check if base model exists
-if $OLLAMA_CMD list 2>/dev/null | awk '{print $1}' | grep -qE "^${BASE_MODEL}$"; then
-  echo "$(date -Is) [watcher] base model ${BASE_MODEL} present" >> "$LOG_FILE"
-  # create shared-coder if missing
-  if ! $OLLAMA_CMD list 2>/dev/null | awk '{print $1}' | grep -qE "^${MODEL1}(:|$)"; then
-    echo "$(date -Is) [watcher] creating ${MODEL1}" >> "$LOG_FILE"
-    $OLLAMA_CMD create "${MODEL1}" -f "$MODEL1_MODFILE" >> "$LOG_FILE" 2>&1 || echo "$(date -Is) [watcher] create ${MODEL1} failed" >> "$LOG_FILE"
-  else
-    echo "$(date -Is) [watcher] ${MODEL1} already exists" >> "$LOG_FILE"
+
+model_exists() {
+  $OLLAMA_CMD list 2>/dev/null | awk '{print $1}' | grep -qE "^${1}(:|$)"
+}
+
+create_if_missing() {
+  local model="$1" base="$2" modfile="$3"
+  if model_exists "$model"; then
+    echo "$(date -Is) [watcher] ${model} already exists" >> "$LOG_FILE"
+    return
   fi
-  # create shared-whatsapp if missing
-  if ! $OLLAMA_CMD list 2>/dev/null | awk '{print $1}' | grep -qE "^${MODEL2}(:|$)"; then
-    echo "$(date -Is) [watcher] creating ${MODEL2}" >> "$LOG_FILE"
-    $OLLAMA_CMD create "${MODEL2}" -f "$MODEL2_MODFILE" >> "$LOG_FILE" 2>&1 || echo "$(date -Is) [watcher] create ${MODEL2} failed" >> "$LOG_FILE"
-  else
-    echo "$(date -Is) [watcher] ${MODEL2} already exists" >> "$LOG_FILE"
+  if ! model_exists "$base"; then
+    echo "$(date -Is) [watcher] base model ${base} not present, skipping ${model}" >> "$LOG_FILE"
+    return
   fi
-else
-  echo "$(date -Is) [watcher] base model ${BASE_MODEL} not present" >> "$LOG_FILE"
-fi
+  echo "$(date -Is) [watcher] creating ${model}" >> "$LOG_FILE"
+  $OLLAMA_CMD create "${model}" -f "$modfile" >> "$LOG_FILE" 2>&1 \
+    || echo "$(date -Is) [watcher] create ${model} failed" >> "$LOG_FILE"
+}
+
+create_if_missing "shared-assistant" "dolphin-llama3:8b" "$REPO_DIR/shared-assistant.Modelfile"
+create_if_missing "shared-coder" "llama3.1:8b" "$REPO_DIR/shared-coder-restricted.Modelfile"
+create_if_missing "shared-whatsapp" "dolphin-llama3:8b" "$REPO_DIR/shared-whatsapp-trained.Modelfile"
+
 echo "$(date -Is) [watcher] end" >> "$LOG_FILE"


### PR DESCRIPTION
## Bug ativo em produção

Toda mensagem real no WhatsApp recebia a resposta literal **"Erro: 404"** — `scripts/misc/whatsapp_bot.py` devolve a string de erro como se fosse a resposta do modelo quando o Ollama retorna não-200. Reproduzi exatamente:

```
curl http://127.0.0.1:11436/api/generate -d '{"model":"shared-assistant",...}'
→ {"error":"model 'shared-assistant' not found"}
```

Os 3 modelos que o bot pede por nome (`shared-coder` default, `shared-assistant` para o dono, `shared-whatsapp` para terceiros) nunca existiam no Ollama.

## Causa raiz

`scripts/watch_and_create_eddie_models.sh` deveria criar 2 desses 3 modelos (nunca cobriu `shared-assistant` — lacuna própria do script original). Estava quebrado em duas camadas:
1. O cron chamava um path inexistente (`/home/homelab/eddie-auto-dev`, aposentado) — corrigido em commit anterior
2. Mesmo com o path certo, seu `REPO_DIR` interno apontava para `/home/homelab/shared-auto-dev` (também aposentado hoje) e procurava Modelfiles que **nunca existiram em lugar nenhum** do repositório ou do host

## Onde criar: GPU0 vs GPU1 vs NAS

Avaliei 3 opções junto com o usuário antes de decidir:

- **GPU0 homelab (11434)** — descartado: não é para onde o bot aponta
- **GPU1 homelab (11435)** — descartado: roda `lfm2.5-fast:gpu1` com **~76 req/h contínuas** (medido via log do coordenador), 100% sucesso, usado por fallback de trading + 8 outros serviços. Só comporta 1 modelo quente por vez — colocar o bot ali competiria pelo mesmo slot, com risco real de timeout no fallback de trading
- **NAS (192.168.15.4:11436)** — escolhido: é para onde `eddie-whatsapp-bot.service.d/env.conf` (não versionado, tem segredos) **já aponta de propósito**, com o comentário *"evita 503 da 3060 ocupada pelo trading"`. GPU ociosa, bases já presentes (`dolphin-llama3:8b`, `llama3.1:8b`) sem precisar puxar nada novo

## Modelfiles criados

| Arquivo | Base | Espelha |
|---|---|---|
| `shared-assistant.Modelfile` | `dolphin-llama3:8b` | `eddie-assistant-dolphin.Modelfile` |
| `shared-coder-restricted.Modelfile` | `llama3.1:8b` (evita puxar `mistral:7b` novo) | `eddie-coder-restricted.Modelfile` |
| `shared-whatsapp-trained.Modelfile` | `dolphin-llama3:8b` direto (evita depender de `FROM eddie-assistant`, modelo custom inexistente) | `eddie-whatsapp-trained.Modelfile` |

## Script corrigido

`REPO_DIR` corrigido, `shared-assistant` adicionado (lacuna do original), `OLLAMA_HOST=http://192.168.15.4:11436` exportado explicitamente, gate de base model verificado por-modelo em vez de um único boolean global.

## whatsapp_bot.py

`OLLAMA_HOST` default (só usado se a env var não estiver setada) trocado de chamada direta à GPU0 para o **coordenador** (11437, do #256). Não afeta produção hoje — o drop-in do host sempre vence e aponta pra NAS — mas é o default correto para qualquer implantação nova sem esse drop-in.

## Validado antes do commit (rodando o watcher de verdade contra a NAS)

- Os 3 modelos criados com sucesso (`ollama create`, exit 0 cada)
- **`shared-assistant`**: `generate()` real funcionou — *"A capital do Brasil é Brasília."* GPU saudável durante e depois (40W → 20W, sem queda, uptime intacto)
- **`shared-coder`**: validado estruturalmente (`api/show` OK); o teste de `generate()` sofreu timeout do lado do **cliente** (troca `dolphin→llama3.1` sob clock limitado a 900MHz leva mais de 45s) — não é falha do modelo, `ollama-nas` ficou `active` o tempo todo
- **`shared-whatsapp`**: validado estruturalmente (`api/show` OK), não testado com `generate()` para não insistir em mais ciclos de carga na NAS (hardware com histórico de instabilidade sob carga)

**Não precisa reiniciar `eddie-whatsapp-bot.service`**: o host já apontava para a NAS (nunca mudei isso) — só faltavam os modelos existirem lá. A próxima mensagem real já deve funcionar.

## Achado à parte, não corrigido

`systemd/eddie-whatsapp-bot.service.d/env.conf` documenta a decisão de rotear pra NAS em comentário, mas **nunca foi versionado** — e tem segredos em texto puro (`WAHA_API_KEY`, `SECRETS_AGENT_API_KEY`), então não posso commitá-lo como está.

🤖 Generated with [Claude Code](https://claude.com/claude-code)