### PR TITLE
docs(whatsapp): versiona template do env.conf com placeholders

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -16771,6 +16771,86 @@
           "systemd"
         ],
         "description": "Endpoint da API de RAG consultado pelo eddie-whatsapp-exporter para metricas de contexto."
+      },
+      "WAHA_API_KEY": {
+        "name": "WAHA_API_KEY",
+        "type": "string",
+        "source": "systemd",
+        "value": "<from_bitwarden>",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Chave de API da instancia WAHA (WhatsApp HTTP API) usada pelo eddie-whatsapp-bot para enviar/receber mensagens."
+      },
+      "OLLAMA_HTTP_RETRIES": {
+        "name": "OLLAMA_HTTP_RETRIES",
+        "type": "string",
+        "source": "systemd",
+        "value": "5",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Numero de tentativas de retry do eddie-whatsapp-bot ao chamar o Ollama antes de desistir."
+      },
+      "PERSONA_MODE": {
+        "name": "PERSONA_MODE",
+        "type": "string",
+        "source": "systemd",
+        "value": "auto",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Config legada do eddie-whatsapp-bot, nao lida pelo codigo atual (o modelo e decidido por PHONE_MODEL_MAPPING/is_owner). Mantida so para nao divergir do env.conf real do host."
+      },
+      "PERSONA_MODEL_SAFE": {
+        "name": "PERSONA_MODEL_SAFE",
+        "type": "string",
+        "source": "systemd",
+        "value": "eddie-persona-safe",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Config legada do eddie-whatsapp-bot, nao lida pelo codigo atual. Ver PERSONA_MODE."
+      },
+      "PERSONA_MODEL_FREE": {
+        "name": "PERSONA_MODEL_FREE",
+        "type": "string",
+        "source": "systemd",
+        "value": "eddie-persona-free",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Config legada do eddie-whatsapp-bot, nao lida pelo codigo atual. Ver PERSONA_MODE."
+      },
+      "NSFW_FREE_CONTACTS": {
+        "name": "NSFW_FREE_CONTACTS",
+        "type": "string",
+        "source": "systemd",
+        "value": "<phone_number_1>,<phone_number_2>,...",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Lista de numeros de telefone (dados pessoais) com acesso ao modelo sem filtro no eddie-whatsapp-bot."
+      },
+      "ALLOWED_NUMBERS": {
+        "name": "ALLOWED_NUMBERS",
+        "type": "string",
+        "source": "systemd",
+        "value": "<phone_number_1>,<phone_number_2>,...",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Whitelist de numeros de telefone autorizados a usar o eddie-whatsapp-bot quando OWNER_ONLY=true."
+      },
+      "OWNER_ONLY": {
+        "name": "OWNER_ONLY",
+        "type": "string",
+        "source": "systemd",
+        "value": "true",
+        "contexts": [
+          "systemd"
+        ],
+        "description": "Quando true, so OWNER_NUMBER + ALLOWED_NUMBERS podem usar o eddie-whatsapp-bot."
       }
     },
     "authentication": {

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T23:27:57.455588+00:00",
+  "generated_at": "2026-07-27T23:34:31.964236+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T23:27:57.455588+00:00`
+- Generated at: `2026-07-27T23:34:31.964236+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `187`

--- a/systemd/eddie-whatsapp-bot.service.d/env.conf
+++ b/systemd/eddie-whatsapp-bot.service.d/env.conf
@@ -1,0 +1,39 @@
+[Service]
+# TEMPLATE — este arquivo NÃO é instalado por nenhum deploy automático
+# (não está em deploy/systemd-dropins-sync.allowlist). Contém placeholders de
+# segredo; existe só como documentação de recuperação — o arquivo real vive
+# só no host, criado à mão em algum momento e nunca commitado até hoje.
+#
+# Descoberto 2026-07-27 investigando por que o bot respondia "Erro: 404" a
+# mensagens reais (ver PR #262): OLLAMA_HOST aqui é quem decide para onde o
+# bot chama, sobrescrevendo o default do código (scripts/misc/whatsapp_bot.py).
+Environment=WAHA_URL=http://localhost:3001
+Environment=WAHA_API_KEY=<from_bitwarden>
+
+# Persona/WhatsApp LLM na RTX 2060 SUPER do NAS (evita 503 da 3060 ocupada
+# pelo trading) — decisão deliberada, não mudar sem avaliar contenção de GPU.
+Environment=OLLAMA_HOST=http://192.168.15.4:11436
+
+# OLLAMA_MODEL e as 3 variáveis PERSONA_* abaixo NÃO são lidas pelo código
+# atual de scripts/misc/whatsapp_bot.py — o modelo de fato usado é decidido em
+# runtime por PHONE_MODEL_MAPPING / is_owner (shared-assistant, shared-coder,
+# shared-whatsapp; ver PR #262). Config morta, mantida aqui só para não
+# divergir do env.conf real do host até alguém limpar os dois juntos.
+Environment=OLLAMA_MODEL=eddie-persona-safe
+Environment=PERSONA_MODEL_SAFE=eddie-persona-safe
+Environment=PERSONA_MODEL_FREE=eddie-persona-free
+Environment=PERSONA_MODE=auto
+
+Environment=OLLAMA_HTTP_RETRIES=5
+Environment=OLLAMA_KEEP_ALIVE=15m
+
+# Números de contato — dados pessoais, nunca reais aqui.
+Environment="NSFW_FREE_CONTACTS=<phone_number_1>,<phone_number_2>,..."
+Environment=ALLOWED_NUMBERS=<phone_number_1>,<phone_number_2>,...
+Environment=OWNER_ONLY=true
+
+Environment=SECRETS_AGENT_URL=http://localhost:8088
+Environment=SECRETS_AGENT_API_KEY=<from_bitwarden>
+# DSN completo resolvido via Secrets Agent (schema btc, host localhost,
+# porta 5433) — nunca escrever usuário/senha diretamente neste arquivo.
+Environment=DATABASE_URL=<from_secrets_agent>


### PR DESCRIPTION
Continuação do [#262](https://github.com/eddiejdi/eddie-auto-dev/pull/262). `systemd/eddie-whatsapp-bot.service.d/env.conf` existia só no host — criado à mão em algum momento, nunca commitado. É **este** arquivo que decide para onde o bot chama (`OLLAMA_HOST` → NAS); sem lê-lo eu teria criado os modelos `shared-*` no lugar errado no #262.

## Padrão seguido

Mesmo usado em `systemd/crypto-agent@.service.d/common.conf`: arquivo no mesmo nome/local do drop-in real, placeholders `<from_bitwarden>` para segredos, banner "TEMPLATE — não instalado por deploy automático". **Não está** em `deploy/systemd-dropins-sync.allowlist`, então não há risco de `check_systemd_dropin_drift.py` compará-lo com o host, nem de qualquer workflow sincronizá-lo por cima do arquivo real.

## Redigido

- `WAHA_API_KEY`, `SECRETS_AGENT_API_KEY` — placeholders `<from_bitwarden>`
- `DATABASE_URL` — o hook de guardrail bloqueou minha primeira tentativa com `postgresql://<user>:<password>@...`: o regex de detecção de DSN não distingue placeholder de segredo real. Reescrito como `DATABASE_URL=<from_secrets_agent>`
- Números de telefone em `NSFW_FREE_CONTACTS`/`ALLOWED_NUMBERS` — dados pessoais, nunca reais aqui

## Achado documentado no próprio arquivo

`OLLAMA_MODEL` e as 3 variáveis `PERSONA_*` são **config morta** — o código atual de `whatsapp_bot.py` não as lê, decide o modelo via `PHONE_MODEL_MAPPING`/`is_owner` (achado durante a investigação do #262). Deixei isso documentado para quem for limpar os dois lados (código + drop-in real) no futuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)