### PR TITLE
fix(whatsapp): adiciona shared-homelab, faltante nas 2 varreduras anteriores

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T23:34:31.964236+00:00",
+  "generated_at": "2026-07-27T23:52:08.197902+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T23:34:31.964236+00:00`
+- Generated at: `2026-07-27T23:52:08.197902+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `187`

--- a/ollama/modelfiles/shared-homelab.Modelfile
+++ b/ollama/modelfiles/shared-homelab.Modelfile
@@ -1,0 +1,57 @@
+FROM llama3.1:8b
+
+SYSTEM """
+Você é Eddie, um assistente de IA pessoal e especializado no homelab do usuário.
+
+## COMPORTAMENTO GERAL:
+- Responda em português brasileiro
+- Seja prestativo, amigável e útil
+- NUNCA recuse pedidos inofensivos (mensagens, textos, poemas, ideias)
+- Ajude com QUALQUER tarefa que não seja ilegal ou prejudicial
+
+## ESPECIALIDADE: HOMELAB (192.168.15.2)
+- Sistema: Ubuntu 24.04.3 LTS
+- Hostname: homelab
+- Memória: 31GB RAM
+- Disk: ~170GB livres
+
+## SERVIÇOS RODANDO:
+1. **Ollama** (porta 11434) - Servidor LLM local
+   - Modelos: eddie-coder, mistral:7b, gemma3:1b, phi4-mini:latest, llama3.1:8b
+   - API: http://192.168.15.2:11434
+
+2. **Open WebUI** (porta 3000) - Interface web para chat
+   - Container Docker: open-webui
+   - Autenticação: Google OAuth
+   - URL externa: (no public exposure configured in repo)
+
+## PROJETOS EM ~/projects/:
+-- (flyio-tunnel removed) - Fly.io tunnel configuration removed from repository
+- github-agent/ - Agente de automação GitHub
+- github-mcp-server/ - MCP Server para GitHub
+- homelab-scripts/ - Scripts de manutenção do servidor
+- rag-dashboard/ - Dashboard Streamlit para RAG
+
+## COMANDOS ÚTEIS:
+- Ollama: systemctl status/restart ollama, ollama list, ollama run <model>
+- Docker: docker ps, docker logs open-webui, docker restart open-webui
+- Túnel: ~/bin/fly-tunnel status|test|logs|restart
+
+# APIs DISPONÍVEIS:
+- Ollama Local: http://192.168.15.2:11434/api/tags, /api/generate, /api/chat
+- Via Tunnel: PUBLIC_TUNNEL_URL/api/ollama/*
+
+Quando o usuário perguntar sobre o servidor, infraestrutura, serviços ou configurações, forneça informações precisas baseadas neste contexto.
+
+## TAMBÉM POSSO AJUDAR COM:
+- Mensagens pessoais (amor, parabéns, agradecimentos)
+- Textos criativos e poemas
+- Ideias e sugestões
+- Qualquer tarefa do dia a dia
+
+Lembre-se: Você é um ASSISTENTE COMPLETO, especializado em homelab mas capaz de ajudar com qualquer coisa!
+"""
+
+PARAMETER temperature 0.7
+PARAMETER num_ctx 8192
+PARAMETER top_p 0.9

--- a/scripts/watch_and_create_eddie_models.sh
+++ b/scripts/watch_and_create_eddie_models.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# watcher: cria shared-assistant, shared-coder e shared-whatsapp quando a base
-# de cada um estiver disponível no Ollama. Roda de /home/homelab/myClaude
-# (migrado de /home/homelab/eddie-auto-dev em 2026-07-27).
+# watcher: cria shared-assistant, shared-coder, shared-homelab e
+# shared-whatsapp quando a base de cada um estiver disponível no Ollama.
+# Roda de /home/homelab/myClaude (migrado de /home/homelab/eddie-auto-dev em
+# 2026-07-27). shared-homelab adicionado 2026-07-27 (2ª rodada): o próprio
+# número do dono está mapeado em PHONE_MODEL_MAPPING (scripts/misc/
+# whatsapp_bot.py) para "shared-homelab", sobrepondo a lógica is_owner ->
+# shared-assistant — faltou nas duas primeiras varreduras.
 #
 # Alvo: NAS (192.168.15.4:11436), NÃO o homelab. É para lá que
 # eddie-whatsapp-bot.service aponta de fato via
@@ -40,6 +44,7 @@ create_if_missing() {
 
 create_if_missing "shared-assistant" "dolphin-llama3:8b" "$REPO_DIR/shared-assistant.Modelfile"
 create_if_missing "shared-coder" "llama3.1:8b" "$REPO_DIR/shared-coder-restricted.Modelfile"
+create_if_missing "shared-homelab" "llama3.1:8b" "$REPO_DIR/shared-homelab.Modelfile"
 create_if_missing "shared-whatsapp" "dolphin-llama3:8b" "$REPO_DIR/shared-whatsapp-trained.Modelfile"
 
 echo "$(date -Is) [watcher] end" >> "$LOG_FILE"


### PR DESCRIPTION
Confirmado por **teste real do usuário** após o #262: mensagem "oi" do próprio dono ainda voltou `Erro: 404`, agora por um motivo diferente.

## Causa

O número do dono está hardcoded em `PHONE_MODEL_MAPPING` (`scripts/misc/whatsapp_bot.py:135-137`) para `shared-homelab` — isso tem **prioridade** sobre a lógica `is_owner → shared-assistant`, então o dono nunca usa `shared-assistant` na prática. Esse modelo faltou nas duas varreduras anteriores (#262 e a checagem de docs/Modelfiles do #261).

## Fix

`shared-homelab.Modelfile` criado espelhando `eddie-homelab.Modelfile` (já corrigido no #261), com `FROM llama3.1:8b` em vez de `mistral:7b` — mesma decisão do `shared-coder`: `llama3.1:8b` já presente na NAS, evita puxar modelo novo num host com PSU marginal.

## Verificação de exaustividade

Chequei se sobrou algum outro nome `shared-*`. `dashboard/config.py` referencia mais alguns (`shared-coder`/`shared-assistant`/`shared-reports` num dict `OLLAMA_MODELS` separado com modelfiles `v2`, base `codestral:22b`; e `shared-telegram-bot`/`shared-whatsapp-bot`/`shared-calendar` como nomes de serviço systemd num registro de controle, não modelos) — mas `dashboard/control_panel.py` **não roda como serviço** no host (confirmado via `ps aux` + `systemctl list-units`), então não há chamada real pendente ali. Fora de escopo.

## Testado end-to-end

Mensagem real "oi" do dono recebeu resposta correta e coerente do `shared-homelab` via WhatsApp:

> *"Olá! O que posso fazer por você hoje? Você precisa de ajuda com algum projeto no seu homelab?"*

Uma resposta de fila logo depois mencionando "problema de conexão com Ollama" **não é bug novo** — é o LLM reagindo ao histórico de conversa, que ainda tinha as mensagens de erro dos testes anteriores a este fix.

## Achado à parte, também resolvido nesta sessão (sem mudança de código)

A sessão do WAHA (gateway WhatsApp) estava presa em loop de reconexão `STARTING` há 30+ min, sem relação com este bug — `POST /api/sessions/default/restart` via API a recuperou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)