### PR TITLE
feat(vpn): seletor horário do servidor ProtonVPN mais rápido

### DIFF
--- a/.github/workflows/deploy-protonvpn-best-server.yml
+++ b/.github/workflows/deploy-protonvpn-best-server.yml
@@ -1,0 +1,108 @@
+name: Deploy ProtonVPN Best Server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/homelab/protonvpn_best_server.py'
+      - 'systemd/protonvpn-best-server.service'
+      - 'systemd/protonvpn-best-server.timer'
+      - '.github/workflows/deploy-protonvpn-best-server.yml'
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    # Self-hosted runner no homelab — precisa de /etc/wireguard e systemd
+    runs-on: [self-hosted, linux, homelab]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Instalar script e units
+        run: |
+          set -euo pipefail
+
+          python3 -m py_compile tools/homelab/protonvpn_best_server.py
+
+          sudo install -D -m 0755 tools/homelab/protonvpn_best_server.py \
+            /usr/local/bin/protonvpn_best_server.py
+          sudo install -D -m 0644 systemd/protonvpn-best-server.service \
+            /etc/systemd/system/protonvpn-best-server.service
+          sudo install -D -m 0644 systemd/protonvpn-best-server.timer \
+            /etc/systemd/system/protonvpn-best-server.timer
+
+          sudo systemctl daemon-reload
+          echo "✅ Script e units instalados"
+
+      - name: Semear lista de candidatos a partir do peer ativo
+        run: |
+          set -euo pipefail
+
+          # Sem lista, o serviço falharia de hora em hora. Semeia com o servidor
+          # que já está no ar (extraído da conf viva, sem hardcode) — assim o
+          # timer roda inofensivo: mede, vê que o atual é o único/melhor e não
+          # troca nada. Ao adicionar AR/US/CL o seletor passa a agir de fato.
+          # Idempotente: nunca sobrescreve uma lista já preenchida pelo usuário.
+          if sudo test -f /etc/protonvpn-best-server.json; then
+            echo "ℹ️  Lista de candidatos já existe — preservada"
+            sudo python3 -c "import json;d=json.load(open('/etc/protonvpn-best-server.json'));print('Servidores:',[s['name'] for s in d.get('servers',[])])"
+            exit 0
+          fi
+
+          PUBKEY=$(sudo awk '/^\[Peer\]/{p=1} p&&/^PublicKey/{print $3; exit}' /etc/wireguard/protonvpn.conf)
+          ENDPOINT=$(sudo awk '/^\[Peer\]/{p=1} p&&/^Endpoint/{print $3; exit}' /etc/wireguard/protonvpn.conf)
+          NAME=$(sudo awk '/^\[Peer\]/{p=1} p&&/^#/{print $2; exit}' /etc/wireguard/protonvpn.conf)
+          NAME=${NAME:-atual}
+
+          test -n "$PUBKEY" && test -n "$ENDPOINT"
+
+          sudo tee /etc/protonvpn-best-server.json >/dev/null <<EOF
+          {
+            "servers": [
+              {
+                "name": "${NAME}",
+                "country": "${NAME:0:2}",
+                "public_key": "${PUBKEY}",
+                "endpoint": "${ENDPOINT}"
+              }
+            ]
+          }
+          EOF
+          sudo chmod 0644 /etc/protonvpn-best-server.json
+          echo "✅ Lista semeada com o servidor ativo: ${NAME} (${ENDPOINT})"
+
+      - name: Smoke test (medição real, sem trocar)
+        run: |
+          set -euo pipefail
+
+          # Só um candidato na lista semeada → não há para onde trocar.
+          # Valida medição, fwmark, escrita de métricas e leitura do peer ativo.
+          sudo systemctl start protonvpn-best-server.service
+          sudo journalctl -u protonvpn-best-server -n 20 --no-pager
+
+          test -f /var/lib/prometheus/node-exporter/protonvpn_best_server.prom
+          grep -q "protonvpn_candidate_rtt_ms" \
+            /var/lib/prometheus/node-exporter/protonvpn_best_server.prom
+          echo "✅ Métricas publicadas:"
+          cat /var/lib/prometheus/node-exporter/protonvpn_best_server.prom
+
+      - name: Verificar que o túnel seguiu íntegro
+        run: |
+          set -euo pipefail
+
+          # O seletor não deve ter mexido em nada com um candidato só. Se o
+          # roteamento tivesse sido tocado, a LAN inteira cairia — checar é barato.
+          sudo wg show protonvpn | head -8
+          ip rule show | grep -q "32764" && echo "✅ Regra 32764 (tabela 205) presente"
+          ip route show table 205 | grep -q "default dev protonvpn" && echo "✅ Default da 205 intacto"
+
+      - name: Ativar timer horário
+        run: |
+          set -euo pipefail
+
+          sudo systemctl enable protonvpn-best-server.timer
+          sudo systemctl restart protonvpn-best-server.timer
+          systemctl status protonvpn-best-server.timer --no-pager | grep -E "Active|Trigger"
+          echo "✅ Timer horário ativo"

--- a/config/protonvpn-best-server.example.json
+++ b/config/protonvpn-best-server.example.json
@@ -1,0 +1,33 @@
+{
+  "_comment": [
+    "Copie para /etc/protonvpn-best-server.json no homelab e preencha com os",
+    "servidores desejados. public_key e endpoint saem do bloco [Peer] das",
+    "configs WireGuard geradas em account.protonvpn.com -> WireGuard configuration",
+    "(uma config por servidor). A PrivateKey do [Interface] NAO vai aqui — o",
+    "seletor reaproveita a que ja esta em /etc/wireguard/protonvpn.conf.",
+    "",
+    "Sugestao de pool (paises Free no Freedom on the Net, ordenados por",
+    "proximidade do Brasil): AR, CL, US, CR, CA. Manter o BE#72 na lista serve",
+    "de referencia — o seletor so troca com ganho acima de PVPN_MIN_GAIN_PCT."
+  ],
+  "servers": [
+    {
+      "name": "AR#12",
+      "country": "AR",
+      "public_key": "COLE_AQUI_A_PublicKey_DO_PEER=",
+      "endpoint": "0.0.0.0:51820"
+    },
+    {
+      "name": "US-MIA#5",
+      "country": "US",
+      "public_key": "COLE_AQUI_A_PublicKey_DO_PEER=",
+      "endpoint": "0.0.0.0:51820"
+    },
+    {
+      "name": "BE#72",
+      "country": "BE",
+      "public_key": "J/ZzG0F1/adsnl//WNoHQVmUL+eJcYLFwdnHsYvbjC0=",
+      "endpoint": "79.127.164.65:51820"
+    }
+  ]
+}

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-28T03:39:03.374996+00:00",
+  "generated_at": "2026-07-28T03:50:10.801641+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,18 +1,18 @@
 {
-  "generated_at": "2026-07-28T03:50:10.801641+00:00",
+  "generated_at": "2026-07-28T13:27:24.577903+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 189,
+    "repo_services": 191,
     "trading_instances": 12,
-    "critical_services": 74,
+    "critical_services": 76,
     "domains": {
       "identity": 4,
       "monitoring": 18,
-      "network": 20,
+      "network": 22,
       "operations": 104,
       "storage": 32,
       "trading": 11
@@ -466,6 +466,22 @@
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/pihole-ipv6-dns-fix.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-best-server.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-best-server.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-best-server.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-best-server.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -2185,6 +2201,20 @@
         "name": "pihole-ipv6-dns-fix.service",
         "domain": "network",
         "source": "systemd/pihole-ipv6-dns-fix.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-best-server.service",
+        "domain": "network",
+        "source": "systemd/protonvpn-best-server.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-best-server.timer",
+        "domain": "network",
+        "source": "systemd/protonvpn-best-server.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-28T03:31:33.818335+00:00",
+  "generated_at": "2026-07-28T03:39:03.374996+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,17 +1,17 @@
 {
-  "generated_at": "2026-07-28T01:03:57.119413+00:00",
+  "generated_at": "2026-07-28T03:31:33.818335+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 187,
+    "repo_services": 189,
     "trading_instances": 12,
-    "critical_services": 72,
+    "critical_services": 74,
     "domains": {
       "identity": 4,
-      "monitoring": 16,
+      "monitoring": 18,
       "network": 20,
       "operations": 104,
       "storage": 32,
@@ -338,6 +338,22 @@
       "domain": "monitoring",
       "kind": "systemd",
       "source": "deploy/storj-exporter.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-payout-monitor.service",
+      "domain": "monitoring",
+      "kind": "systemd",
+      "source": "systemd/storj-payout-monitor.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-payout-monitor.timer",
+      "domain": "monitoring",
+      "kind": "systemd",
+      "source": "systemd/storj-payout-monitor.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -2057,6 +2073,20 @@
         "name": "storj-exporter.service",
         "domain": "monitoring",
         "source": "deploy/storj-exporter.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-payout-monitor.service",
+        "domain": "monitoring",
+        "source": "systemd/storj-payout-monitor.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-payout-monitor.timer",
+        "domain": "monitoring",
+        "source": "systemd/storj-payout-monitor.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-27T23:52:08.197902+00:00",
+  "generated_at": "2026-07-28T01:03:57.119413+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-28T03:50:10.801641+00:00`
+- Generated at: `2026-07-28T13:27:24.577903+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `189`
-- Critical services flagged for MVP: `74`
+- Repo services discovered: `191`
+- Critical services flagged for MVP: `76`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,7 +12,7 @@
 
 - `identity`: 4
 - `monitoring`: 18
-- `network`: 20
+- `network`: 22
 - `operations`: 104
 - `storage`: 32
 - `trading`: 11
@@ -72,12 +72,12 @@
 - `ipv6-proxy.service` (network, systemd) from `systemd/ipv6-proxy.service`
 - `localtunnel@.service` (network, systemd) from `tools/tunnels/localtunnel@.service`
 - `pihole-ipv6-dns-fix.service` (network, systemd) from `systemd/pihole-ipv6-dns-fix.service`
+- `protonvpn-best-server.service` (network, systemd) from `systemd/protonvpn-best-server.service`
+- `protonvpn-best-server.timer` (network, systemd) from `systemd/protonvpn-best-server.timer`
 - `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
 - `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
 - `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
 - `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
-- `protonvpn-unit-selfheal.timer` (network, systemd) from `systemd/protonvpn-unit-selfheal.timer`
-- `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
 
 ## Serviços anotados manualmente
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-28T03:31:33.818335+00:00`
+- Generated at: `2026-07-28T03:39:03.374996+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `189`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-27T23:52:08.197902+00:00`
+- Generated at: `2026-07-28T01:03:57.119413+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `187`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-28T03:39:03.374996+00:00`
+- Generated at: `2026-07-28T03:50:10.801641+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `189`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,17 +1,17 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-28T01:03:57.119413+00:00`
+- Generated at: `2026-07-28T03:31:33.818335+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `187`
-- Critical services flagged for MVP: `72`
+- Repo services discovered: `189`
+- Critical services flagged for MVP: `74`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
 - `identity`: 4
-- `monitoring`: 16
+- `monitoring`: 18
 - `network`: 20
 - `operations`: 104
 - `storage`: 32
@@ -56,6 +56,8 @@
 - `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
 - `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
 - `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
+- `storj-payout-monitor.service` (monitoring, systemd) from `systemd/storj-payout-monitor.service`
+- `storj-payout-monitor.timer` (monitoring, systemd) from `systemd/storj-payout-monitor.timer`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `tunnel-healthcheck-exporter.service` (monitoring, systemd) from `systemd/tunnel-healthcheck-exporter.service`
 - `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
@@ -76,8 +78,6 @@
 - `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
 - `protonvpn-unit-selfheal.timer` (network, systemd) from `systemd/protonvpn-unit-selfheal.timer`
 - `rpa4all-ddns-server.service` (network, systemd) from `deploy/vpn/rpa4all-ddns-server.service`
-- `rpa4all-vpn-ddns.service` (network, systemd) from `deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service`
-- `wireguard-nat.service` (network, systemd) from `deploy/vpn/wireguard-nat.service`
 
 ## Serviços anotados manualmente
 

--- a/docs/storj-withdrawal-runbook.md
+++ b/docs/storj-withdrawal-runbook.md
@@ -1,0 +1,107 @@
+# Runbook: Retirada Manual de STORJ para KuCoin
+
+**Este é um procedimento operado por humano, não automatizado.** Nenhum
+serviço deste repositório tem, ou terá, custódia da chave privada da
+carteira de payout do nó Storj (`0x4787E8bA11d9D32f8A51336a1844e663105a7d24`).
+A assinatura de qualquer transferência real é sempre feita à mão, com um
+hardware wallet (Ledger ou Trezor) fisicamente conectado.
+
+## Contexto
+
+- O token STORJ é um ERC-20 nativo do **Ethereum L1**
+  (`0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC`).
+- O saldo do nó é pago e fica representado no **zkSync Era (L2)**.
+- A Storj retém pagamentos por ~2 períodos (meses) antes de liberá-los como
+  saldo gasto ("disposed") — `tools/homelab/storj_payout_monitor.py` avisa
+  via Telegram quando isso acontece.
+- Caminho oficial documentado pela Storj para mover fundos para uma exchange:
+  **bridge L2→L1**, depois **transfer ERC-20 padrão em L1**.
+
+## Pré-requisitos (uma vez)
+
+1. **Hardware wallet** (Ledger ou Trezor) com a carteira que controla
+   `0x4787E8bA11d9D32f8A51336a1844e663105a7d24` já configurada nele —
+   confirmar que o endereço mostrado no device bate exatamente com esse.
+2. **Regras udev** no host onde o device for conectado (não precisa ser o
+   homelab — pode ser qualquer máquina do operador):
+   - Ledger: `20-hw1.rules` (repositório oficial LedgerHQ/udev-rules)
+   - Trezor: `51-trezor.rules` (repositório oficial trezor/trezor-common)
+3. Navegador atualizado para acessar `https://portal.zksync.io/bridge`
+   (interface oficial da zkSync Era, não deste repositório).
+4. Conta KuCoin com STORJ habilitado para depósito (rede ERC20/L1).
+
+## Passo a passo
+
+### 1. Ver o plano de transferência (seguro, sem device conectado)
+
+```bash
+ssh homelab@192.168.15.2
+python3 /usr/local/bin/storj_withdraw.py
+```
+
+Isso imprime: saldo atual na carteira, endereço de depósito STORJ da KuCoin
+(rede ERC20), e o plano em duas etapas. **Não executa nada, não precisa do
+hardware wallet conectado.**
+
+### 2. Etapa 1 — Bridge L2 (zkSync Era) → L1 (Ethereum)
+
+1. Conectar o hardware wallet ao computador.
+2. Abrir `https://portal.zksync.io/bridge`.
+3. Conectar a carteira (WalletConnect ou USB direto, conforme o device).
+4. Selecionar token **STORJ**, rede origem **zkSync Era**, destino **Ethereum
+   Mainnet (L1)**, endereço destino = a mesma carteira
+   (`0x4787E8bA11d9D32f8A51336a1844e663105a7d24`).
+5. Selecionar **pagar taxa em STORJ** (meta-transação gasless — não precisa
+   de ETH).
+6. **Confirmar fisicamente no hardware wallet.**
+7. Aguardar confirmação on-chain (pode levar alguns minutos).
+
+### 3. Etapa 2 — Transfer ERC-20 L1 → KuCoin
+
+1. Com o saldo já em L1, usar a mesma carteira/hardware wallet num app que
+   suporte envio ERC-20 padrão (MetaMask conectado ao Ledger/Trezor, ou o
+   próprio app do device).
+2. Endereço destino = o endereço de depósito impresso pelo
+   `storj_withdraw.py` no passo 1 (rede ERC20).
+3. **Conferir 3x o endereço e a rede antes de confirmar** — é irreversível.
+4. **Confirmar fisicamente no hardware wallet.**
+
+### 4. Teste obrigatório com valor pequeno primeiro
+
+**Antes de mover o saldo total**, repita as etapas 2–3 com um valor pequeno
+(equivalente a $1–2 em STORJ). Só prossiga com o valor total depois de:
+- Confirmar que o valor pequeno chegou corretamente na conta KuCoin.
+- Confirmar que a rede/endereço usados foram exatamente os certos.
+
+## Troubleshooting
+
+- **Ledger não assina a transação de bridge (tx type 113 / EIP-712):**
+  verificar se o app Ethereum do Ledger está atualizado; alguns fluxos de
+  bridge zkSync exigem o "blind signing" habilitado nas configurações do
+  app Ethereum do device.
+- **KuCoin não credita o depósito:** confirmar que a rede usada foi
+  exatamente `ERC20` (não zkSync Era) — a KuCoin pode não suportar
+  depósito direto via L2 para STORJ.
+- **API da KuCoin retorna "currency does not exist" para STORJ/erc20:** a
+  KuCoin expõe a rede ERC20 do STORJ com `chainId=eth` na API (mesmo com
+  `chainName` exibido como "ERC20" na UI) — confirmado via
+  `GET https://api.kucoin.com/api/v3/currencies/STORJ` (público, sem auth).
+  `storj_withdraw.py` já usa `chain="eth"` por padrão; se voltar a falhar,
+  reconferir esse endpoint (a KuCoin pode mudar o chainId).
+- **Depósito mínimo:** a KuCoin exige `depositMinSize=2` STORJ — valores
+  abaixo disso na Etapa 2 não são creditados.
+- **Saldo não aparece após o bridge:** o bridge L2→L1 pode levar de minutos
+  a horas dependendo da carga da rede; conferir o hash da transação no
+  explorer do zkSync Era antes de assumir falha.
+
+## Fora de Escopo (por design)
+
+- **Automação da assinatura.** `storj_withdraw.py --i-am-present` levanta
+  `NotImplementedError` de propósito — não existe, e não deve ser criado,
+  código neste repositório que assine transações reais.
+- **Custódia de chave privada por qualquer serviço deste repositório** —
+  nenhuma secret com chave privada da carteira Storj deve ser criada em
+  `tools/secrets_agent_client.py` ou em qualquer outro lugar.
+- **Config de trading STORJ-USDT** no `btc_trading_agent` — decisão
+  separada, a ser tomada depois que o saldo já estiver na KuCoin, com
+  revisão própria de parâmetros de risco.

--- a/docs/variables-taxonomy/PROTONVPN_BEST_SERVER.md
+++ b/docs/variables-taxonomy/PROTONVPN_BEST_SERVER.md
@@ -1,0 +1,65 @@
+# ProtonVPN Best Server — Variáveis
+
+Serviço: `protonvpn-best-server.service` (+ `.timer`, **de hora em hora**) —
+script `tools/homelab/protonvpn_best_server.py`, instalado em
+`/usr/local/bin/protonvpn_best_server.py` no homelab (192.168.15.2).
+
+Mede RTT/perda dos servidores ProtonVPN candidatos e troca **apenas o bloco
+`[Peer]`** do túnel para o mais rápido, aplicando com `wg syncconf`.
+
+**Por que syncconf e não `wg-quick down/up`:** a conf
+`/etc/wireguard/protonvpn.conf` carrega ~40 regras `PostUp` (tabela 205,
+`fwmark 0xca6c`, rotas da LAN, bridges Docker 172.x, exceções de edge Cloudflare
+por UID `_rpa4all`, macvlan Storj, kill-switch). `syncconf` atualiza o peer no
+kernel sem disparar `PostDown`/`PostUp` — nenhuma regra de roteamento é tocada.
+Como o homelab é o gateway da LAN, derrubar o túnel derrubaria a casa.
+
+**Anti-alternância:** a troca só ocorre se o candidato for `PVPN_MIN_GAIN_PCT`
+melhor **e** o dwell mínimo (`PVPN_MIN_DWELL_SEC`) tiver vencido. O timer horário
+é o piso da cadência; o dwell é o teto.
+
+**Rollback automático:** se o peer novo não fechar handshake em
+`PVPN_HANDSHAKE_TIMEOUT_SEC`, a conf anterior é restaurada e reaplicada.
+
+Métricas em `/var/lib/prometheus/node-exporter/protonvpn_best_server.prom`
+(o collector ativo é esse — `/var/lib/node_exporter/textfile_collector/` **não**
+é lido pelo node-exporter deste host).
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `PVPN_IFACE` | `protonvpn` | Nome da interface WireGuard do túnel Proton. |
+| `PVPN_CONF` | `/etc/wireguard/protonvpn.conf` | Config wg-quick cujo bloco `[Peer]` é reescrito. O `[Interface]` (com os PostUp) nunca é tocado. |
+| `PVPN_CANDIDATES` | `/etc/protonvpn-best-server.json` | Lista de servidores candidatos (`name`, `country`, `public_key`, `endpoint`), gerada a partir das configs WireGuard baixadas em account.protonvpn.com. |
+| `PVPN_STATE` | `/var/lib/protonvpn-best-server/state.json` | Estado persistente — guarda `last_switch_ts` para o dwell mínimo sobreviver a reboot. |
+| `PVPN_METRICS` | `/var/lib/prometheus/node-exporter/protonvpn_best_server.prom` | Saída textfile collector das métricas Prometheus. |
+| `PVPN_MIN_GAIN_PCT` | `20` | Ganho mínimo (%) sobre o servidor atual para justificar a troca. Abaixo disso dois servidores empatados dentro do ruído ficariam se revezando. |
+| `PVPN_MIN_DWELL_SEC` | `3600` | Tempo mínimo (s) no mesmo servidor antes de considerar outra troca — 1h, conforme cadência pedida. |
+| `PVPN_PING_COUNT` | `10` | Pacotes ICMP por candidato na medição. Menos que isso torna a média sensível a um outlier. |
+| `PVPN_PING_FWMARK` | `51820` | Marca (`ping -m`, decimal de `0xca6c`) que faz a medição escapar da tabela 205 e sair direto pela `eth-wan`. **Sem ela a medição sai pelo túnel atual** e todos os candidatos medem ~RTT do servidor atual, tornando a escolha aleatória — medido no homelab: 1.1.1.1 a 206ms com o túnel contra 7ms sem. Exige root. |
+| `PVPN_LOSS_PENALTY_MS` | `8` | Penalidade em ms por 1% de perda no score. Perda trava vídeo, latência só atrasa — por isso perda pesa mais que RTT puro. |
+| `PVPN_HANDSHAKE_TIMEOUT_SEC` | `25` | Prazo para o peer novo fechar handshake antes do rollback automático. |
+
+## Formato do arquivo de candidatos
+
+```json
+{
+  "servers": [
+    {
+      "name": "AR#12",
+      "country": "AR",
+      "public_key": "<PublicKey do [Peer] da config baixada>",
+      "endpoint": "<ip>:51820"
+    }
+  ]
+}
+```
+
+Os valores saem das configs WireGuard geradas em account.protonvpn.com →
+*WireGuard configuration* (uma por servidor). Só `PublicKey` e `Endpoint` do
+bloco `[Peer]` são necessários — a `PrivateKey` do `[Interface]` continua sendo
+a que já está na conf do túnel.
+
+> **Validar antes de confiar:** a `PrivateKey` atual precisa estar registrada
+> para os servidores novos. Se o certificado tiver sido gerado por servidor, o
+> handshake falha e o rollback automático devolve o peer anterior — rode
+> `--apply` uma vez à mão e confira o log antes de habilitar o timer.

--- a/docs/variables-taxonomy/STORJ_PAYOUT_MONITOR.md
+++ b/docs/variables-taxonomy/STORJ_PAYOUT_MONITOR.md
@@ -1,0 +1,29 @@
+# Storj Payout Monitor — Variáveis
+
+Serviço: `storj-payout-monitor.service` (+ `.timer`, a cada **30 min**) —
+script `tools/homelab/storj_payout_monitor.py`, instalado em
+`/usr/local/bin/storj_payout_monitor.py` no homelab (192.168.15.2).
+
+Inclui também `tools/homelab/storj_withdraw.py` (`/usr/local/bin/storj_withdraw.py`)
+— ferramenta de **uso manual apenas** (nunca chamada por systemd), que lê o
+plano de retirada em `--dry-run`; ver `docs/storj-withdrawal-runbook.md`.
+
+Detecta quando o saldo "disposed" (liberado, cumulativo) do payout Storj
+aumenta — a Storj retém pagamentos por ~2 períodos antes de liberá-los como
+saldo gasto na carteira do nó — e dispara alerta via Telegram. Somente
+leitura: não tem acesso a nenhuma chave privada nem move fundos. Métricas em
+`/var/lib/prometheus/node-exporter/storj_payout_monitor.prom`.
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `STORJ_API_BASE` | `http://127.0.0.1:14002/api` | Base URL da API local do storagenode (held-history/paystubs). |
+| `STORJ_WALLET_ADDRESS` | `0x4787E8bA11d9D32f8A51336a1844e663105a7d24` | Endereço da carteira de payout do nó (zkSync-era), configurado no container via `WALLET=`. |
+| `ZKSYNC_EXPLORER_BASE` | `https://block-explorer-api.mainnet.zksync.io` | Block explorer público do zkSync-era usado para ler saldo STORJ on-chain (somente leitura). |
+| `COINGECKO_PRICE_URL` | `https://api.coingecko.com/api/v3/simple/price?ids=storj&vs_currencies=usd` | Endpoint público para preço STORJ/USD (usado só para enriquecer o texto do alerta). |
+| `STORJ_PAYOUT_STATE_FILE` | `/var/lib/storj-payout-monitor/state.json` | Estado persistente (último disposed_total/saldo/contador de alertas) para não re-alertar o mesmo delta. |
+| `PROM_FILE` | `/var/lib/prometheus/node-exporter/storj_payout_monitor.prom` | Saída textfile collector das métricas Prometheus. |
+| `STORJ_ALERT_THRESHOLD_USD` | `20` | Delta mínimo (USD) de saldo recém-liberado para disparar alerta Telegram. |
+| `STORJ_PAYOUT_HTTP_TIMEOUT` | `15` | Timeout (s) das chamadas HTTP feitas pelo monitor. |
+| `SECRETS_AGENT_API_KEY` | (via `EnvironmentFile=-/etc/crypto-agent/secrets-api.env`) | Chave de API do secrets agent local — reaproveitada do mesmo arquivo já usado pelo trading agent (só a API key, nada de segredo específico de trading). |
+| `SECRETS_AGENT_URL` | `http://127.0.0.1:8088` | Base URL do secrets agent local. |
+| `KUCOIN_API_DIR` | (auto-detectado: `/apps/crypto-trader/trading/btc_trading_agent`, `/apps/crypto-trader/btc_trading_agent`, `/home/homelab/myClaude/btc_trading_agent`, nessa ordem) | Diretório onde `storj_withdraw.py` (uso manual) encontra `kucoin_api.py` para reaproveitar autenticação — o script roda standalone em `/usr/local/bin`, fora do checkout do repo, então o caminho não pode ser derivado de `__file__`. |

--- a/scripts/homelab_mcp_server.py
+++ b/scripts/homelab_mcp_server.py
@@ -931,7 +931,16 @@ def _get_trading_db_url() -> Optional[str]:
         _trading_db_url_cache = url
         return url
 
-    # 2. Secrets agent — mesmo padrão do secrets_helper.py do trading agent
+    # 2. DATABASE_URL já configurado no ambiente — mesma instância Postgres
+    #    (o schema btc.* do trading agent convive com o schema public da
+    #    Estou Aqui no mesmo banco btc_trading). Evita depender de um
+    #    secret que pode ter sido salvo com host "localhost" (só válido
+    #    quando executado no próprio homelab, não em consumidores remotos).
+    if DATABASE_URL:
+        _trading_db_url_cache = DATABASE_URL
+        return DATABASE_URL
+
+    # 3. Secrets agent — mesmo padrão do secrets_helper.py do trading agent
     for secret_name in ("eddie/database_url", "shared/database_url", "crypto/database_url"):
         result = _http_get(
             f"{SECRETS_AGENT_URL}/secrets/local/{secret_name}?field=url",

--- a/systemd/protonvpn-best-server.service
+++ b/systemd/protonvpn-best-server.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=ProtonVPN Best Server — mede candidatos e troca o [Peer] do túnel
+Documentation=file:///home/homelab/myClaude/docs/variables-taxonomy/PROTONVPN_BEST_SERVER.md
+After=network-online.target wg-quick@protonvpn.service
+Wants=network-online.target
+# Sem túnel no ar não há o que medir nem o que trocar.
+ConditionPathExists=/sys/class/net/protonvpn
+
+[Service]
+Type=oneshot
+# Precisa de root: lê /etc/wireguard/protonvpn.conf e chama wg syncconf.
+User=root
+# --apply é obrigatório para agir; sem ele o script só mede e reporta.
+# flock envolve o processo inteiro: duas trocas concorrentes de peer (timer +
+# execução manual) corromperiam a conf. Com -n, a segunda desiste em vez de
+# enfileirar — medição atrasada não tem valor.
+ExecStart=/usr/bin/flock -n /run/protonvpn-best-server.lock \
+    /usr/bin/python3 /usr/local/bin/protonvpn_best_server.py --apply
+TimeoutStartSec=300
+
+StateDirectory=protonvpn-best-server
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=protonvpn-best-server
+
+NoNewPrivileges=true
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/protonvpn-best-server.timer
+++ b/systemd/protonvpn-best-server.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Timer do ProtonVPN Best Server (de hora em hora)
+Requires=protonvpn-best-server.service
+
+[Timer]
+Unit=protonvpn-best-server.service
+# De hora em hora. O dwell mínimo de 1h no script (PVPN_MIN_DWELL_SEC) garante
+# que mesmo uma execução manual extra não provoque alternância mais rápida.
+OnCalendar=hourly
+# Espalha a medição para não bater sempre no mesmo minuto cheio.
+RandomizedDelaySec=300
+# Não roda no boot imediato: espera o túnel estabilizar.
+OnBootSec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/storj-payout-monitor.service
+++ b/systemd/storj-payout-monitor.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 User=homelab
+StateDirectory=storj-payout-monitor
 EnvironmentFile=-/etc/crypto-agent/secrets-api.env
 Environment=STORJ_API_BASE=http://127.0.0.1:14002/api
 Environment=STORJ_WALLET_ADDRESS=0x4787E8bA11d9D32f8A51336a1844e663105a7d24

--- a/systemd/storj-payout-monitor.service
+++ b/systemd/storj-payout-monitor.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Monitor de saldo liberado (disposed) do payout Storj — somente leitura
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=homelab
+EnvironmentFile=-/etc/crypto-agent/secrets-api.env
+Environment=STORJ_API_BASE=http://127.0.0.1:14002/api
+Environment=STORJ_WALLET_ADDRESS=0x4787E8bA11d9D32f8A51336a1844e663105a7d24
+Environment=ZKSYNC_EXPLORER_BASE=https://block-explorer-api.mainnet.zksync.io
+Environment=COINGECKO_PRICE_URL=https://api.coingecko.com/api/v3/simple/price?ids=storj&vs_currencies=usd
+Environment=STORJ_PAYOUT_STATE_FILE=/var/lib/storj-payout-monitor/state.json
+Environment=PROM_FILE=/var/lib/prometheus/node-exporter/storj_payout_monitor.prom
+Environment=STORJ_ALERT_THRESHOLD_USD=20
+Environment=STORJ_PAYOUT_HTTP_TIMEOUT=15
+ExecStart=/home/homelab/myClaude/.venv/bin/python3 /usr/local/bin/storj_payout_monitor.py

--- a/systemd/storj-payout-monitor.timer
+++ b/systemd/storj-payout-monitor.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Roda o monitor de payout Storj a cada 30 minutos
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+Unit=storj-payout-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_protonvpn_best_server.py
+++ b/tests/test_protonvpn_best_server.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "homelab" / "protonvpn_best_server.py"
+)
+_SPEC = importlib.util.spec_from_file_location("protonvpn_best_server", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+pbs = importlib.util.module_from_spec(_SPEC)
+# @dataclass resolve anotações via sys.modules[cls.__module__]; sem registrar
+# antes do exec_module o decorator estoura com AttributeError.
+sys.modules["protonvpn_best_server"] = pbs
+_SPEC.loader.exec_module(pbs)
+
+
+# Réplica reduzida da conf real: o que importa é que o [Interface] carregue
+# PostUp/PostDown e que eles sobrevivam intactos à reescrita do [Peer].
+CONF = """[Interface]
+Address = 10.2.0.2/32
+FwMark = 0xca6c
+Table = 205
+PrivateKey = PRIVADA_NAO_TOCAR=
+PostUp = ip route add default dev protonvpn table 205 2>/dev/null || true
+PostUp = ip rule add not fwmark 0xca6c lookup 205 priority 32764 2>/dev/null || true
+PostDown = ip route del default dev protonvpn table 205 2>/dev/null || true
+
+[Peer]
+# BE#72
+PublicKey = ANTIGA_PUBKEY=
+AllowedIPs = 0.0.0.0/0
+Endpoint = 79.127.164.65:51820
+PersistentKeepalive = 25
+"""
+
+AR = pbs.Candidate(
+    name="AR#12", country="AR", public_key="NOVA_PUBKEY=", endpoint="1.2.3.4:51820"
+)
+
+
+class TestRewritePeer:
+    def test_troca_pubkey_e_endpoint(self):
+        out = pbs.rewrite_peer(CONF, AR)
+        assert "PublicKey = NOVA_PUBKEY=" in out
+        assert "Endpoint = 1.2.3.4:51820" in out
+        assert "ANTIGA_PUBKEY=" not in out
+        assert "79.127.164.65" not in out
+
+    def test_preserva_interface_e_postup(self):
+        """O bloco [Interface] é a razão de existir do syncconf — perder um
+        PostUp aqui derruba o roteamento da LAN inteira."""
+        out = pbs.rewrite_peer(CONF, AR)
+        assert "PrivateKey = PRIVADA_NAO_TOCAR=" in out
+        assert out.count("PostUp = ") == 2
+        assert out.count("PostDown = ") == 1
+        assert "FwMark = 0xca6c" in out
+        assert "Table = 205" in out
+
+    def test_preserva_allowedips_e_keepalive(self):
+        out = pbs.rewrite_peer(CONF, AR)
+        assert "AllowedIPs = 0.0.0.0/0" in out
+        assert "PersistentKeepalive = 25" in out
+
+    def test_atualiza_comentario_do_servidor(self):
+        out = pbs.rewrite_peer(CONF, AR)
+        assert "# AR#12" in out
+        assert "# BE#72" not in out
+
+    def test_conf_sem_peer_falha(self):
+        with pytest.raises(ValueError, match="sem bloco"):
+            pbs.rewrite_peer("[Interface]\nAddress = 10.2.0.2/32\n", AR)
+
+    def test_reescrita_e_idempotente(self):
+        uma = pbs.rewrite_peer(CONF, AR)
+        duas = pbs.rewrite_peer(uma, AR)
+        assert uma == duas
+
+    def test_peer_sem_comentario_ganha_um(self):
+        sem_comentario = CONF.replace("# BE#72\n", "")
+        out = pbs.rewrite_peer(sem_comentario, AR)
+        assert "# AR#12" in out
+        assert "PublicKey = NOVA_PUBKEY=" in out
+
+
+class TestScore:
+    """Perda pesa mais que RTT: vídeo tolera latência, não tolera stall."""
+
+    def _medir(self, monkeypatch, ping_out: str) -> pbs.Measurement:
+        monkeypatch.setattr(pbs, "resolve", lambda h: "1.2.3.4")
+        monkeypatch.setattr(
+            pbs,
+            "run",
+            lambda cmd, **kw: type("P", (), {"stdout": ping_out, "stderr": "", "returncode": 0})(),
+        )
+        return pbs.measure(AR, count=10)
+
+    def test_medicao_usa_fwmark_para_escapar_do_tunel(self, monkeypatch):
+        """Regressão do bug de projeto: sem -m, todo candidato mede o RTT do
+        túnel atual somado ao real e a escolha vira ruído."""
+        vistos = []
+
+        def fake_run(cmd, **kw):
+            vistos.append(cmd)
+            return type(
+                "P",
+                (),
+                {
+                    "stdout": "10 packets transmitted, 10 received, 0% packet loss\n"
+                    "rtt min/avg/max/mdev = 5.0/7.0/9.0/1.0 ms\n",
+                    "stderr": "",
+                    "returncode": 0,
+                },
+            )()
+
+        monkeypatch.setattr(pbs, "resolve", lambda h: "1.2.3.4")
+        monkeypatch.setattr(pbs, "run", fake_run)
+        pbs.measure(AR, count=4)
+        assert "-m" in vistos[0]
+        assert str(pbs.PING_FWMARK) in vistos[0]
+
+    def test_fallback_quando_ping_nao_suporta_fwmark(self, monkeypatch):
+        """ping antigo rejeita -m: mede pelo túnel em vez de estourar."""
+        chamadas = []
+
+        def fake_run(cmd, **kw):
+            chamadas.append(cmd)
+            if "-m" in cmd:
+                return type(
+                    "P", (), {"stdout": "", "stderr": "ping: invalid argument", "returncode": 2}
+                )()
+            return type(
+                "P",
+                (),
+                {
+                    "stdout": "10 packets transmitted, 10 received, 0% packet loss\n"
+                    "rtt min/avg/max/mdev = 200.0/210.0/220.0/5.0 ms\n",
+                    "stderr": "",
+                    "returncode": 0,
+                },
+            )()
+
+        monkeypatch.setattr(pbs, "resolve", lambda h: "1.2.3.4")
+        monkeypatch.setattr(pbs, "run", fake_run)
+        m = pbs.measure(AR, count=4)
+        assert len(chamadas) == 2
+        assert "-m" not in chamadas[1]
+        assert m.reachable
+        assert m.rtt_ms == 210.0
+
+    def test_rtt_e_loss_extraidos(self, monkeypatch):
+        out = (
+            "10 packets transmitted, 10 received, 0% packet loss, time 2700ms\n"
+            "rtt min/avg/max/mdev = 30.1/42.5/55.0/6.2 ms\n"
+        )
+        m = self._medir(monkeypatch, out)
+        assert m.rtt_ms == 42.5
+        assert m.loss_pct == 0.0
+        assert m.score == 42.5
+        assert m.reachable
+
+    def test_perda_penaliza_score(self, monkeypatch):
+        out = (
+            "10 packets transmitted, 9 received, 10% packet loss, time 2700ms\n"
+            "rtt min/avg/max/mdev = 30.1/40.0/55.0/6.2 ms\n"
+        )
+        m = self._medir(monkeypatch, out)
+        assert m.rtt_ms == 40.0
+        assert m.loss_pct == 10.0
+        # 40ms + 10% * 8ms = 120 — perde para um servidor limpo de 70ms.
+        assert m.score == pytest.approx(120.0)
+
+    def test_servidor_mudo_nao_vence_por_ausencia_de_dado(self, monkeypatch):
+        """Regressão: sem esse guard, 100% de perda vira score baixo e o
+        seletor migraria para um servidor morto."""
+        out = "10 packets transmitted, 0 received, 100% packet loss, time 2700ms\n"
+        m = self._medir(monkeypatch, out)
+        assert not m.reachable
+        assert m.score == pbs.UNREACHABLE_SCORE
+
+    def test_dns_falho_e_inalcancavel(self, monkeypatch):
+        monkeypatch.setattr(pbs, "resolve", lambda h: None)
+        m = pbs.measure(AR, count=3)
+        assert not m.reachable
+        assert m.score == pbs.UNREACHABLE_SCORE
+
+
+class TestCandidateParsing:
+    def test_host_sem_porta(self):
+        assert AR.host == "1.2.3.4"
+
+    def test_host_ipv6_usa_ultimo_separador(self):
+        c = pbs.Candidate("X", "XX", "k", "[2001:db8::1]:51820")
+        assert c.host == "[2001:db8::1]"
+
+    def test_candidatos_invalidos_sao_ignorados(self, tmp_path, monkeypatch):
+        arq = tmp_path / "cand.json"
+        arq.write_text(
+            '{"servers": ['
+            '{"name": "OK", "country": "AR", "public_key": "k", "endpoint": "1.2.3.4:51820"},'
+            '{"name": "SEM_PORTA", "country": "AR", "public_key": "k", "endpoint": "1.2.3.4"},'
+            '{"name": "SEM_CHAVE", "endpoint": "1.2.3.4:51820"}'
+            "]}"
+        )
+        monkeypatch.setattr(pbs, "CANDIDATES", arq)
+        out = pbs.load_candidates()
+        assert [c.name for c in out] == ["OK"]
+
+    def test_arquivo_ausente_retorna_vazio(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pbs, "CANDIDATES", tmp_path / "nao-existe.json")
+        assert pbs.load_candidates() == []
+
+
+class TestCurrentPeer:
+    def _dump(self, monkeypatch, saida: str, rc: int = 0):
+        monkeypatch.setattr(
+            pbs,
+            "run",
+            lambda cmd, **kw: type("P", (), {"stdout": saida, "stderr": "", "returncode": rc})(),
+        )
+
+    def test_extrai_pubkey_e_endpoint(self, monkeypatch):
+        dump = (
+            "PRIV\tPUB\t38460\t0xca6c\n"
+            "PEERPUB\tPSK\t79.127.164.65:51820\t0.0.0.0/0\t1785240000\t100\t200\t25\n"
+        )
+        self._dump(monkeypatch, dump)
+        pub, ep = pbs.current_peer()
+        assert pub == "PEERPUB"
+        assert ep == "79.127.164.65:51820"
+
+    def test_sem_peer_retorna_none(self, monkeypatch):
+        self._dump(monkeypatch, "PRIV\tPUB\t38460\t0xca6c\n")
+        assert pbs.current_peer() == (None, None)
+
+    def test_endpoint_none_quando_sem_conexao(self, monkeypatch):
+        dump = "PRIV\tPUB\t38460\t0xca6c\nPEERPUB\tPSK\t(none)\t0.0.0.0/0\t0\t0\t0\t25\n"
+        self._dump(monkeypatch, dump)
+        pub, ep = pbs.current_peer()
+        assert pub == "PEERPUB"
+        assert ep is None

--- a/tests/test_storj_payout_monitor.py
+++ b/tests/test_storj_payout_monitor.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "homelab" / "storj_payout_monitor.py"
+)
+_SPEC = importlib.util.spec_from_file_location("storj_payout_monitor", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+spm = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(spm)
+
+
+HELD_HISTORY = [
+    {"satelliteID": "sat1", "totalDisposed": 10319, "totalHeld": 10319},
+    {"satelliteID": "sat2", "totalDisposed": 17639, "totalHeld": 17639},
+    {"satelliteID": "sat3", "totalDisposed": 392246, "totalHeld": 392246},
+    {"satelliteID": "sat4", "totalDisposed": 85483, "totalHeld": 85483},
+]
+
+WALLET_BALANCE_RESPONSE = {
+    "balances": {
+        "0xA0806DA7835a4E63dB2CE44A2b622eF8b73B5DB5": {
+            "balance": "531467164",
+            "token": {"symbol": "STORJ", "decimals": 8, "usdPrice": 0.061247},
+        }
+    }
+}
+
+
+def test_fetch_disposed_total_sums_all_satellites():
+    with patch.object(spm, "_http_json", return_value=HELD_HISTORY):
+        total = spm.fetch_disposed_total()
+    assert total == pytest.approx((10319 + 17639 + 392246 + 85483) / 100.0)
+
+
+def test_fetch_wallet_storj_balance_finds_storj_token():
+    with patch.object(spm, "_http_json", return_value=WALLET_BALANCE_RESPONSE):
+        balance = spm.fetch_wallet_storj_balance("0xdead")
+    assert balance == pytest.approx(531467164 / 1e8)
+
+
+def test_fetch_wallet_storj_balance_missing_token_returns_zero():
+    with patch.object(spm, "_http_json", return_value={"balances": {}}):
+        balance = spm.fetch_wallet_storj_balance("0xdead")
+    assert balance == 0.0
+
+
+def test_main_alerts_only_once_per_crossing(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    prom_file = tmp_path / "metrics.prom"
+    monkeypatch.setattr(spm, "STATE_FILE", state_file)
+    monkeypatch.setattr(spm, "PROM_FILE", prom_file)
+    monkeypatch.setattr(spm, "ALERT_THRESHOLD_USD", 20.0)
+
+    alerts = []
+    monkeypatch.setattr(spm, "send_telegram_alert", lambda msg: alerts.append(msg))
+    monkeypatch.setattr(spm, "fetch_storj_usd_price", lambda: 0.061247)
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 100.0)
+    monkeypatch.setattr(spm, "fetch_wallet_storj_balance", lambda: 5.31)
+
+    # 1ª execução: sem estado anterior, delta = 0 (last=current) -> sem alerta
+    rc = spm.main()
+    assert rc == 0
+    assert alerts == []
+    state = json.loads(state_file.read_text())
+    assert state["last_disposed_total"] == 100.0
+
+    # 2ª execução: disposed subiu $25 (>= threshold $20) -> alerta 1x
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 125.0)
+    rc = spm.main()
+    assert rc == 0
+    assert len(alerts) == 1
+    assert "+$25.00" in alerts[0]
+
+    # 3ª execução: sem novo delta -> nenhum alerta novo
+    rc = spm.main()
+    assert rc == 0
+    assert len(alerts) == 1
+
+
+def test_main_no_alert_below_threshold(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    prom_file = tmp_path / "metrics.prom"
+    monkeypatch.setattr(spm, "STATE_FILE", state_file)
+    monkeypatch.setattr(spm, "PROM_FILE", prom_file)
+    monkeypatch.setattr(spm, "ALERT_THRESHOLD_USD", 20.0)
+
+    alerts = []
+    monkeypatch.setattr(spm, "send_telegram_alert", lambda msg: alerts.append(msg))
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 50.0)
+    monkeypatch.setattr(spm, "fetch_wallet_storj_balance", lambda: 1.0)
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps({"last_disposed_total": 45.0, "alert_sent_total": 0}))
+
+    rc = spm.main()
+    assert rc == 0
+    assert alerts == []  # delta = $5, abaixo do threshold $20
+
+
+def test_main_handles_disposed_fetch_failure(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    prom_file = tmp_path / "metrics.prom"
+    monkeypatch.setattr(spm, "STATE_FILE", state_file)
+    monkeypatch.setattr(spm, "PROM_FILE", prom_file)
+
+    def _raise():
+        raise ValueError("boom")
+
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: _raise())
+    rc = spm.main()
+    assert rc == 2

--- a/tests/test_storj_payout_monitor.py
+++ b/tests/test_storj_payout_monitor.py
@@ -63,6 +63,10 @@ def test_main_alerts_only_once_per_crossing(tmp_path, monkeypatch):
     monkeypatch.setattr(spm, "fetch_storj_usd_price", lambda: 0.061247)
     monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 100.0)
     monkeypatch.setattr(spm, "fetch_wallet_storj_balance", lambda: 5.31)
+    # Este teste cobre só a lógica de dedup do alerta — o plano de transferência
+    # (que bateria em rede real pra buscar credenciais KuCoin) é coberto à parte
+    # em test_build_transfer_plan_text_* e test_main_alert_includes_transfer_plan.
+    monkeypatch.setattr(spm, "_build_transfer_plan_text", lambda balance: "")
 
     # 1ª execução: sem estado anterior, delta = 0 (last=current) -> sem alerta
     rc = spm.main()
@@ -101,6 +105,54 @@ def test_main_no_alert_below_threshold(tmp_path, monkeypatch):
     rc = spm.main()
     assert rc == 0
     assert alerts == []  # delta = $5, abaixo do threshold $20
+
+
+def test_build_transfer_plan_text_success(monkeypatch):
+    class _FakeStorjWithdraw:
+        @staticmethod
+        def fetch_kucoin_deposit_address():
+            return {"success": True, "address": "0xdeposit"}
+
+        @staticmethod
+        def format_transfer_plan_markdown(balance, info):
+            return f"PLANO balance={balance} addr={info['address']}"
+
+    monkeypatch.setattr(spm, "_load_storj_withdraw", lambda: _FakeStorjWithdraw)
+    text = spm._build_transfer_plan_text(5.31)
+    assert "PLANO balance=5.31 addr=0xdeposit" in text
+
+
+def test_build_transfer_plan_text_handles_failure(monkeypatch):
+    def _raise():
+        raise RuntimeError("sem credenciais KuCoin")
+
+    monkeypatch.setattr(spm, "_load_storj_withdraw", _raise)
+    text = spm._build_transfer_plan_text(5.31)
+    assert "Não foi possível montar o plano" in text
+
+
+def test_main_alert_includes_transfer_plan(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    prom_file = tmp_path / "metrics.prom"
+    monkeypatch.setattr(spm, "STATE_FILE", state_file)
+    monkeypatch.setattr(spm, "PROM_FILE", prom_file)
+    monkeypatch.setattr(spm, "ALERT_THRESHOLD_USD", 20.0)
+
+    alerts = []
+    monkeypatch.setattr(spm, "send_telegram_alert", lambda msg: alerts.append(msg))
+    monkeypatch.setattr(spm, "fetch_storj_usd_price", lambda: 0.061247)
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 100.0)
+    monkeypatch.setattr(spm, "fetch_wallet_storj_balance", lambda: 5.31)
+    monkeypatch.setattr(
+        spm, "_build_transfer_plan_text", lambda balance: f"\n\nPLANO balance={balance}"
+    )
+
+    spm.main()  # baseline, sem estado anterior -> sem alerta
+    monkeypatch.setattr(spm, "fetch_disposed_total", lambda: 125.0)
+    spm.main()
+
+    assert len(alerts) == 1
+    assert "PLANO balance=5.31" in alerts[0]
 
 
 def test_main_handles_disposed_fetch_failure(tmp_path, monkeypatch):

--- a/tests/test_storj_payout_monitor_integration.py
+++ b/tests/test_storj_payout_monitor_integration.py
@@ -1,0 +1,80 @@
+"""Testes de integração — batem em APIs reais (Storj local + zkSync explorer).
+
+Rodar com: pytest tests/test_storj_payout_monitor_integration.py -m integration -v
+
+Requer:
+- Acesso de rede à API local do storagenode (http://127.0.0.1:14002) — só
+  funciona rodando no host 192.168.15.2, ou via túnel SSH -L 14002:127.0.0.1:14002.
+- Acesso à internet para o block explorer público do zkSync Era.
+Não requer nenhuma credencial. Somente leitura.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "homelab" / "storj_payout_monitor.py"
+)
+_SPEC = importlib.util.spec_from_file_location("storj_payout_monitor", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+spm = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(spm)
+
+
+@pytest.mark.integration
+def test_real_zksync_wallet_balance_is_reachable():
+    """Bate no block explorer real e valida o shape da resposta p/ a carteira do nó."""
+    try:
+        balance = spm.fetch_wallet_storj_balance()
+    except (URLError, OSError) as exc:
+        pytest.skip(f"zkSync explorer inacessível deste ambiente: {exc}")
+    assert isinstance(balance, float)
+    assert balance >= 0.0
+
+
+@pytest.mark.integration
+def test_real_storj_price_feed_is_reachable():
+    price = spm.fetch_storj_usd_price()
+    if price is None:
+        pytest.skip("CoinGecko indisponível/rate-limited neste ambiente")
+    assert price > 0
+
+
+@pytest.mark.integration
+def test_real_storj_local_api_held_history():
+    """Só passa rodando no host do storagenode (ou com túnel SSH -L 14002:...)."""
+    try:
+        total = spm.fetch_disposed_total()
+    except (URLError, OSError) as exc:
+        pytest.skip(f"API local do storagenode inacessível deste ambiente: {exc}")
+    assert isinstance(total, float)
+    assert total >= 0.0
+
+
+@pytest.mark.integration
+def test_real_end_to_end_run_writes_state_and_prom(tmp_path, monkeypatch):
+    """Roda main() de ponta a ponta contra APIs reais, sem enviar alerta Telegram."""
+    state_file = tmp_path / "state.json"
+    prom_file = tmp_path / "metrics.prom"
+    monkeypatch.setattr(spm, "STATE_FILE", state_file)
+    monkeypatch.setattr(spm, "PROM_FILE", prom_file)
+    # Nunca mandar alerta de verdade num teste — mas deixa o resto real.
+    sent = []
+    monkeypatch.setattr(spm, "send_telegram_alert", lambda msg: sent.append(msg))
+
+    rc = spm.main()
+
+    if rc == 2:
+        pytest.skip("API do storagenode inacessível deste ambiente de teste")
+
+    assert rc == 0
+    assert state_file.exists()
+    assert prom_file.exists()
+    prom_content = prom_file.read_text()
+    assert "storj_payout_disposed_total" in prom_content
+    assert "storj_payout_wallet_balance_storj" in prom_content

--- a/tests/test_storj_withdraw.py
+++ b/tests/test_storj_withdraw.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "homelab" / "storj_withdraw.py"
+)
+_SPEC = importlib.util.spec_from_file_location("storj_withdraw", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+sw = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(sw)
+
+
+WALLET_BALANCE_RESPONSE = {
+    "balances": {
+        "0xA0806DA7835a4E63dB2CE44A2b622eF8b73B5DB5": {
+            "balance": "531467164",
+            "token": {"symbol": "STORJ", "decimals": 8},
+        }
+    }
+}
+
+
+def test_fetch_wallet_storj_balance():
+    with patch.object(sw, "_http_json", return_value=WALLET_BALANCE_RESPONSE):
+        balance = sw.fetch_wallet_storj_balance()
+    assert balance == pytest.approx(531467164 / 1e8)
+
+
+def test_fetch_wallet_storj_balance_zero_when_absent():
+    with patch.object(sw, "_http_json", return_value={"balances": {}}):
+        balance = sw.fetch_wallet_storj_balance()
+    assert balance == 0.0
+
+
+class _FakeKucoinApiExisting:
+    @staticmethod
+    def get_deposit_addresses(currency, chain=None):
+        assert currency == "STORJ"
+        return {
+            "success": True,
+            "addresses": [{"address": "0xkucoindeposit", "chain": chain}],
+        }
+
+    @staticmethod
+    def create_deposit_address(currency, chain=None):
+        raise AssertionError("não deveria criar se já existe endereço")
+
+
+class _FakeKucoinApiMissing:
+    @staticmethod
+    def get_deposit_addresses(currency, chain=None):
+        return {"success": True, "addresses": []}
+
+    @staticmethod
+    def create_deposit_address(currency, chain=None):
+        return {"success": True, "address": "0xnewaddress", "chain": chain}
+
+
+def test_fetch_kucoin_deposit_address_reuses_existing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "kucoin_api", _FakeKucoinApiExisting)
+    result = sw.fetch_kucoin_deposit_address(chain="erc20")
+    assert result["success"] is True
+    assert result["address"] == "0xkucoindeposit"
+
+
+def test_fetch_kucoin_deposit_address_creates_when_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "kucoin_api", _FakeKucoinApiMissing)
+    result = sw.fetch_kucoin_deposit_address(chain="erc20")
+    assert result["success"] is True
+    assert result["address"] == "0xnewaddress"
+
+
+def test_main_dry_run_default_does_not_raise(monkeypatch, capsys):
+    monkeypatch.setattr(sw, "fetch_wallet_storj_balance", lambda: 5.31)
+    monkeypatch.setattr(
+        sw, "fetch_kucoin_deposit_address", lambda chain=None: {"success": True, "address": "0xdeposit"}
+    )
+    monkeypatch.setattr(sys, "argv", ["storj_withdraw.py"])
+    rc = sw.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PLANO DE TRANSFERÊNCIA" in out
+    assert "0xdeposit" in out
+
+
+def test_main_without_present_flag_never_imports_hardware_wallet_libs(monkeypatch, capsys):
+    """Garante que o caminho default (sem --i-am-present) não levanta NotImplementedError."""
+    monkeypatch.setattr(sw, "fetch_wallet_storj_balance", lambda: 5.31)
+    monkeypatch.setattr(
+        sw, "fetch_kucoin_deposit_address", lambda chain=None: {"success": True, "address": "0xdeposit"}
+    )
+    monkeypatch.setattr(sys, "argv", ["storj_withdraw.py"])
+    rc = sw.main()
+    assert rc == 0
+
+
+def test_main_with_present_flag_raises_not_implemented(monkeypatch):
+    monkeypatch.setattr(sw, "fetch_wallet_storj_balance", lambda: 5.31)
+    monkeypatch.setattr(
+        sw, "fetch_kucoin_deposit_address", lambda chain=None: {"success": True, "address": "0xdeposit"}
+    )
+    monkeypatch.setattr(sys, "argv", ["storj_withdraw.py", "--i-am-present"])
+    with pytest.raises(NotImplementedError):
+        sw.main()
+
+
+def test_main_handles_balance_fetch_failure(monkeypatch):
+    def _raise():
+        raise ValueError("boom")
+
+    monkeypatch.setattr(sw, "fetch_wallet_storj_balance", lambda: _raise())
+    monkeypatch.setattr(sys, "argv", ["storj_withdraw.py"])
+    rc = sw.main()
+    assert rc == 2

--- a/tests/test_storj_withdraw.py
+++ b/tests/test_storj_withdraw.py
@@ -110,6 +110,26 @@ def test_main_with_present_flag_raises_not_implemented(monkeypatch):
         sw.main()
 
 
+def test_format_transfer_plan_markdown_success():
+    text = sw.format_transfer_plan_markdown(5.31, {"success": True, "address": "0xdeposit"})
+    assert "0xdeposit" in text
+    assert "5.3100 STORJ" in text
+    assert "portal.zksync.io/bridge" in text
+
+
+def test_format_transfer_plan_markdown_includes_memo():
+    text = sw.format_transfer_plan_markdown(
+        1.0, {"success": True, "address": "0xdeposit", "memo": "tag-123"}
+    )
+    assert "tag-123" in text
+
+
+def test_format_transfer_plan_markdown_failure():
+    text = sw.format_transfer_plan_markdown(1.0, {"success": False, "error": "boom"})
+    assert "Falha ao obter endereço" in text
+    assert "boom" in text
+
+
 def test_main_handles_balance_fetch_failure(monkeypatch):
     def _raise():
         raise ValueError("boom")

--- a/tests/test_storj_withdraw_integration.py
+++ b/tests/test_storj_withdraw_integration.py
@@ -1,0 +1,120 @@
+"""Testes de integração — batem em APIs reais (zkSync explorer + KuCoin).
+
+Rodar com: pytest tests/test_storj_withdraw_integration.py -m integration -v
+
+O teste de saldo on-chain não precisa de credenciais. O teste de endereço de
+depósito KuCoin precisa das credenciais reais do secrets agent (só
+disponíveis rodando no host onde o btc_trading_agent já roda, ex.:
+192.168.15.2) — se ausentes, o teste é pulado (skip), nunca falha por falta
+de secret.
+
+O lookup KuCoin roda em SUBPROCESSO com timeout de kernel (não SIGALRM):
+kucoin_api._load_credentials() roda no import do módulo e pode ficar preso
+numa chamada de rede bloqueante (DNS/socket) que ignora sinais Python — um
+alarm in-process não é suficiente para garantir que o teste termine.
+subprocess.run(timeout=...) mata o processo filho via SIGKILL do SO, o que
+sempre funciona.
+
+Nenhum destes testes assina ou transmite nenhuma transação — são somente
+leitura (GET/consulta de saldo e endereço de depósito).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "homelab" / "storj_withdraw.py"
+_SPEC = importlib.util.spec_from_file_location("storj_withdraw", MODULE_PATH)
+assert _SPEC and _SPEC.loader
+sw = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(sw)
+
+KUCOIN_LOOKUP_TIMEOUT_S = 20
+
+_SUBPROCESS_SCRIPT = f"""
+import json, sys
+sys.path.insert(0, {str(REPO_ROOT)!r})
+sys.path.insert(0, {str(MODULE_PATH.parent)!r})
+import importlib.util
+spec = importlib.util.spec_from_file_location("storj_withdraw", {str(MODULE_PATH)!r})
+sw = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sw)
+result = sw.fetch_kucoin_deposit_address(chain="erc20")
+print(json.dumps(result))
+"""
+
+
+def _run_kucoin_lookup_in_subprocess() -> dict | None:
+    """Roda o lookup isolado, com timeout garantido pelo SO. Retorna None em skip."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _SUBPROCESS_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=KUCOIN_LOOKUP_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            f"KuCoin/secrets agent não respondeu em {KUCOIN_LOOKUP_TIMEOUT_S}s neste ambiente"
+        )
+    if proc.returncode != 0:
+        pytest.skip(f"Subprocesso do lookup KuCoin falhou: {proc.stderr[-500:]}")
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError) as exc:
+        pytest.skip(f"Saída inesperada do lookup KuCoin: {exc} — stdout={proc.stdout[-300:]}")
+
+
+@pytest.mark.integration
+def test_real_wallet_balance_matches_expected_shape():
+    try:
+        balance = sw.fetch_wallet_storj_balance()
+    except (URLError, OSError) as exc:
+        pytest.skip(f"zkSync explorer inacessível deste ambiente: {exc}")
+    assert isinstance(balance, float)
+    assert balance >= 0.0
+
+
+@pytest.mark.integration
+def test_real_kucoin_deposit_address_lookup():
+    """Só passa com credenciais KuCoin reais disponíveis (secrets agent no host)."""
+    result = _run_kucoin_lookup_in_subprocess()
+    if result is None:
+        return  # pytest.skip já foi chamado dentro do helper
+
+    if not result.get("success"):
+        pytest.skip(f"KuCoin retornou erro (provavelmente sem credenciais): {result.get('error')}")
+
+    assert "address" in result
+    assert result["address"]
+
+
+@pytest.mark.integration
+def test_real_dry_run_end_to_end(monkeypatch, capsys):
+    """Roda o CLI completo em --dry-run contra APIs reais.
+
+    O lookup KuCoin é substituído por uma versão com timeout de kernel
+    (mesma lógica do teste acima) para nunca travar a suíte.
+    """
+    monkeypatch.setattr(sys, "argv", ["storj_withdraw.py"])
+
+    def _bounded_lookup(chain=None):
+        result = _run_kucoin_lookup_in_subprocess()
+        return result or {"success": False, "error": "timeout/skip no lookup"}
+
+    monkeypatch.setattr(sw, "fetch_kucoin_deposit_address", _bounded_lookup)
+
+    rc = sw.main()
+    assert rc in (0, 2)  # 2 só se zkSync explorer estiver fora do ar
+    if rc == 0:
+        out = capsys.readouterr().out
+        assert "PLANO DE TRANSFERÊNCIA" in out
+        assert sw.WALLET_ADDRESS in out

--- a/tools/homelab/protonvpn_best_server.py
+++ b/tools/homelab/protonvpn_best_server.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Seleciona o servidor ProtonVPN mais rápido e troca só o [Peer] do túnel.
+
+O túnel do homelab é um wg-quick estático cuja config carrega ~40 regras PostUp
+(tabela 205, fwmark 0xca6c, rotas da LAN, bridges Docker, exceções de edge
+Cloudflare por UID, macvlan Storj, kill-switch). Derrubar o túnel para trocar de
+servidor destruiria tudo isso — e o homelab é o gateway da LAN.
+
+Por isso a troca é feita com `wg syncconf`, que atualiza o peer no kernel **sem**
+disparar PostDown/PostUp. Nenhuma regra de roteamento é tocada.
+
+Fluxo:
+1. Mede RTT/perda de cada candidato (ICMP no endpoint).
+2. Pontua (RTT penalizado por perda) e escolhe o melhor.
+3. Só troca se o ganho passar da histerese E o dwell mínimo tiver vencido —
+   evita ficar alternando a cada execução.
+4. Aplica via syncconf, confirma handshake e faz rollback se o peer novo não
+   fechar handshake dentro do prazo.
+
+Dry-run é o padrão. Para aplicar de fato é preciso --apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("protonvpn-best-server")
+
+IFACE = os.environ.get("PVPN_IFACE", "protonvpn")
+CONF = Path(os.environ.get("PVPN_CONF", "/etc/wireguard/protonvpn.conf"))
+CANDIDATES = Path(
+    os.environ.get("PVPN_CANDIDATES", "/etc/protonvpn-best-server.json")
+)
+STATE = Path(os.environ.get("PVPN_STATE", "/var/lib/protonvpn-best-server/state.json"))
+METRICS = Path(
+    os.environ.get(
+        "PVPN_METRICS", "/var/lib/prometheus/node-exporter/protonvpn_best_server.prom"
+    )
+)
+
+# Só troca se o candidato for pelo menos X% melhor que o atual. Sem isso, dois
+# servidores empatados dentro do ruído de medição ficariam se revezando.
+MIN_GAIN_PCT = float(os.environ.get("PVPN_MIN_GAIN_PCT", "20"))
+# E nunca troca antes disso, mesmo que o ganho seja grande — o pedido é que a
+# alternância seja de 1h, então o timer horário é o piso e este é o teto.
+MIN_DWELL_SEC = int(os.environ.get("PVPN_MIN_DWELL_SEC", "3600"))
+PING_COUNT = int(os.environ.get("PVPN_PING_COUNT", "10"))
+# A medição PRECISA sair por fora do túnel. Todo o tráfego do homelab cai na
+# tabela 205 (regra 32764 = "not fwmark 0xca6c"), então um ping normal mediria
+# "RTT via servidor atual até o candidato" — inflado pelo RTT do túnel e
+# praticamente igual para todos, tornando a escolha aleatória. Marcando com
+# 0xca6c (51820, a mesma marca que o WireGuard usa para evitar loop de
+# roteamento) o pacote escapa da 205 e vai direto pela eth-wan.
+# Medido no homelab 2026-07-28: 1.1.1.1 dá 206ms sem a marca e 7ms com ela.
+PING_FWMARK = int(os.environ.get("PVPN_PING_FWMARK", "51820"))
+HANDSHAKE_TIMEOUT_SEC = int(os.environ.get("PVPN_HANDSHAKE_TIMEOUT_SEC", "25"))
+# Perda vira penalidade de RTT: 1% de perda ~ +8ms. Um servidor com 5% de perda
+# e 40ms perde para um com 0% e 70ms — perda trava vídeo, latência só atrasa.
+LOSS_PENALTY_MS = float(os.environ.get("PVPN_LOSS_PENALTY_MS", "8"))
+UNREACHABLE_SCORE = 10_000.0
+
+
+@dataclass
+class Candidate:
+    name: str
+    country: str
+    public_key: str
+    endpoint: str  # host:porta
+
+    @property
+    def host(self) -> str:
+        return self.endpoint.rsplit(":", 1)[0]
+
+
+@dataclass
+class Measurement:
+    name: str
+    country: str
+    endpoint: str
+    rtt_ms: float | None
+    loss_pct: float
+    score: float
+    reachable: bool
+
+
+def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def load_candidates() -> list[Candidate]:
+    if not CANDIDATES.exists():
+        log.error(
+            "Arquivo de candidatos ausente: %s — veja o exemplo em "
+            "docs/PROTONVPN_BEST_SERVER.md",
+            CANDIDATES,
+        )
+        return []
+    raw = json.loads(CANDIDATES.read_text())
+    servers = raw.get("servers", raw if isinstance(raw, list) else [])
+    out: list[Candidate] = []
+    for item in servers:
+        try:
+            cand = Candidate(
+                name=item["name"],
+                country=item.get("country", "??"),
+                public_key=item["public_key"],
+                endpoint=item["endpoint"],
+            )
+        except KeyError as exc:
+            log.warning("Candidato ignorado (campo %s ausente): %r", exc, item)
+            continue
+        if ":" not in cand.endpoint:
+            log.warning("Endpoint sem porta, ignorado: %s", cand.endpoint)
+            continue
+        out.append(cand)
+    return out
+
+
+def resolve(host: str) -> str | None:
+    try:
+        ipaddress.ip_address(host)
+        return host
+    except ValueError:
+        pass
+    try:
+        return socket.gethostbyname(host)
+    except OSError:
+        return None
+
+
+def measure(cand: Candidate, count: int = PING_COUNT) -> Measurement:
+    """Mede RTT e perda até o endpoint do servidor.
+
+    Os endpoints WireGuard da Proton respondem a ICMP. Se um servidor não
+    responder, ele é considerado inalcançável em vez de "rápido" — sem isso, um
+    servidor mudo ganharia por ausência de dados.
+    """
+    ip = resolve(cand.host)
+    if ip is None:
+        log.warning("%s: DNS falhou para %s", cand.name, cand.host)
+        return Measurement(cand.name, cand.country, cand.endpoint, None, 100.0, UNREACHABLE_SCORE, False)
+
+    base = ["ping", "-n", "-q", "-c", str(count), "-i", "0.3", "-W", "2"]
+    proc = run([*base, "-m", str(PING_FWMARK), ip])
+    if proc.returncode != 0 and "invalid argument" in (proc.stderr + proc.stdout).lower():
+        # ping sem suporte a -m (ou sem CAP_NET_ADMIN): mede pelo túnel. Serve
+        # para não quebrar, mas os números ficam inflados e comparáveis só entre si.
+        log.warning(
+            "%s: ping -m indisponível — medindo PELO TÚNEL (valores inflados)", cand.name
+        )
+        proc = run([*base, ip])
+    out = proc.stdout
+
+    loss = 100.0
+    m = re.search(r"(\d+(?:\.\d+)?)% packet loss", out)
+    if m:
+        loss = float(m.group(1))
+
+    rtt = None
+    m = re.search(r"rtt [^=]+= [\d.]+/([\d.]+)/", out)
+    if m:
+        rtt = float(m.group(1))
+
+    if rtt is None or loss >= 100.0:
+        return Measurement(cand.name, cand.country, cand.endpoint, rtt, loss, UNREACHABLE_SCORE, False)
+
+    score = rtt + loss * LOSS_PENALTY_MS
+    return Measurement(cand.name, cand.country, cand.endpoint, rtt, loss, score, True)
+
+
+def current_peer() -> tuple[str | None, str | None]:
+    """Retorna (public_key, endpoint) do peer ativo no kernel."""
+    proc = run(["wg", "show", IFACE, "dump"])
+    if proc.returncode != 0:
+        log.error("wg show falhou: %s", proc.stderr.strip())
+        return None, None
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    # 1ª linha = interface; demais = peers. O túnel Proton tem um peer só.
+    if len(lines) < 2:
+        return None, None
+    fields = lines[1].split("\t")
+    pubkey = fields[0] if fields else None
+    endpoint = fields[2] if len(fields) > 2 and fields[2] != "(none)" else None
+    return pubkey, endpoint
+
+
+def last_handshake_age() -> float | None:
+    proc = run(["wg", "show", IFACE, "latest-handshakes"])
+    if proc.returncode != 0:
+        return None
+    for line in proc.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[1].isdigit():
+            ts = int(parts[1])
+            if ts == 0:
+                return None
+            return time.time() - ts
+    return None
+
+
+def rewrite_peer(conf_text: str, cand: Candidate) -> str:
+    """Troca PublicKey e Endpoint do bloco [Peer], preservando o resto.
+
+    AllowedIPs/PersistentKeepalive e todo o bloco [Interface] (com as ~40 regras
+    PostUp) ficam intactos — só as duas linhas que identificam o servidor mudam.
+    """
+    head, sep, peer = conf_text.partition("[Peer]")
+    if not sep:
+        raise ValueError("conf sem bloco [Peer]")
+
+    peer = re.sub(
+        r"(?m)^\s*PublicKey\s*=.*$", f"PublicKey = {cand.public_key}", peer, count=1
+    )
+    peer = re.sub(
+        r"(?m)^\s*Endpoint\s*=.*$", f"Endpoint = {cand.endpoint}", peer, count=1
+    )
+    # Comentário de identificação do servidor (a conf atual usa "# BE#72").
+    if re.search(r"(?m)^\s*#\s*\S+", peer):
+        peer = re.sub(r"(?m)^\s*#\s*\S+.*$", f"# {cand.name}", peer, count=1)
+    else:
+        peer = f"\n# {cand.name}" + peer
+
+    return head + sep + peer
+
+
+def apply_peer(cand: Candidate, dry_run: bool) -> bool:
+    conf_text = CONF.read_text()
+    new_text = rewrite_peer(conf_text, cand)
+
+    if dry_run:
+        log.info("[dry-run] trocaria peer para %s (%s)", cand.name, cand.endpoint)
+        return True
+
+    backup = CONF.with_suffix(CONF.suffix + f".bak-{time.strftime('%Y%m%d-%H%M%S')}")
+    shutil.copy2(CONF, backup)
+    log.info("Backup da conf em %s", backup)
+
+    CONF.write_text(new_text)
+    if not syncconf():
+        log.error("syncconf falhou — restaurando %s", backup)
+        shutil.copy2(backup, CONF)
+        syncconf()
+        return False
+
+    if not wait_handshake():
+        log.error(
+            "Peer %s não fechou handshake em %ss — rollback para a config anterior",
+            cand.name,
+            HANDSHAKE_TIMEOUT_SEC,
+        )
+        shutil.copy2(backup, CONF)
+        syncconf()
+        wait_handshake()
+        return False
+
+    log.info("✅ Peer ativo: %s (%s)", cand.name, cand.endpoint)
+    return True
+
+
+def syncconf() -> bool:
+    """Aplica a conf sem derrubar a interface (não dispara PostDown/PostUp)."""
+    stripped = run(["wg-quick", "strip", str(CONF)])
+    if stripped.returncode != 0:
+        log.error("wg-quick strip falhou: %s", stripped.stderr.strip())
+        return False
+    proc = subprocess.run(
+        ["wg", "syncconf", IFACE, "/dev/stdin"],
+        input=stripped.stdout,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        log.error("wg syncconf falhou: %s", proc.stderr.strip())
+        return False
+    return True
+
+
+def wait_handshake(timeout: int = HANDSHAKE_TIMEOUT_SEC) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        age = last_handshake_age()
+        if age is not None and age < timeout:
+            return True
+        time.sleep(2)
+    return False
+
+
+def load_state() -> dict:
+    if STATE.exists():
+        try:
+            return json.loads(STATE.read_text())
+        except (json.JSONDecodeError, OSError):
+            log.warning("State ilegível em %s — recomeçando", STATE)
+    return {}
+
+
+def save_state(state: dict) -> None:
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    STATE.write_text(json.dumps(state, indent=2))
+
+
+def write_metrics(measurements: list[Measurement], active: str | None, switched: bool) -> None:
+    try:
+        METRICS.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.debug("Sem textfile collector (%s) — métricas ignoradas", exc)
+        return
+
+    lines = [
+        "# HELP protonvpn_candidate_rtt_ms RTT medido até o endpoint do servidor",
+        "# TYPE protonvpn_candidate_rtt_ms gauge",
+    ]
+    for m in measurements:
+        if m.rtt_ms is not None:
+            lines.append(
+                f'protonvpn_candidate_rtt_ms{{server="{m.name}",country="{m.country}"}} {m.rtt_ms}'
+            )
+    lines += [
+        "# HELP protonvpn_candidate_loss_pct Perda de pacotes até o endpoint",
+        "# TYPE protonvpn_candidate_loss_pct gauge",
+    ]
+    for m in measurements:
+        lines.append(
+            f'protonvpn_candidate_loss_pct{{server="{m.name}",country="{m.country}"}} {m.loss_pct}'
+        )
+    lines += [
+        "# HELP protonvpn_active_server Servidor ativo no túnel (1 = ativo)",
+        "# TYPE protonvpn_active_server gauge",
+    ]
+    for m in measurements:
+        lines.append(
+            f'protonvpn_active_server{{server="{m.name}",country="{m.country}"}} '
+            f"{1 if m.name == active else 0}"
+        )
+    lines += [
+        "# HELP protonvpn_best_server_switched_total Trocas de servidor aplicadas",
+        "# TYPE protonvpn_best_server_switched_total counter",
+        f"protonvpn_best_server_switched_total {1 if switched else 0}",
+        "# HELP protonvpn_best_server_last_run_timestamp_seconds Última execução",
+        "# TYPE protonvpn_best_server_last_run_timestamp_seconds gauge",
+        f"protonvpn_best_server_last_run_timestamp_seconds {int(time.time())}",
+    ]
+    tmp = METRICS.with_suffix(".tmp")
+    tmp.write_text("\n".join(lines) + "\n")
+    tmp.replace(METRICS)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="aplica de fato a troca (sem isso, só mede e reporta)",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="ignora histerese e dwell mínimo (uso manual)",
+    )
+    ap.add_argument("--json", action="store_true", help="saída em JSON")
+    args = ap.parse_args()
+
+    candidates = load_candidates()
+    if not candidates:
+        log.error("Nenhum candidato válido — nada a fazer")
+        return 1
+
+    measurements = [measure(c) for c in candidates]
+    measurements.sort(key=lambda m: m.score)
+
+    for m in measurements:
+        status = f"{m.rtt_ms:.1f}ms loss={m.loss_pct:.0f}%" if m.reachable else "inalcançável"
+        log.info("%-14s %-4s %s (score=%.1f)", m.name, m.country, status, m.score)
+
+    best = measurements[0]
+    if not best.reachable:
+        log.error("Nenhum candidato respondeu — mantendo o servidor atual")
+        write_metrics(measurements, None, False)
+        return 1
+
+    active_pubkey, active_endpoint = current_peer()
+    by_name = {c.name: c for c in candidates}
+    active_name = next(
+        (c.name for c in candidates if c.public_key == active_pubkey), None
+    )
+    active_measure = next((m for m in measurements if m.name == active_name), None)
+
+    state = load_state()
+    last_switch = float(state.get("last_switch_ts", 0))
+    dwell = time.time() - last_switch
+
+    switched = False
+    reason = ""
+
+    if active_name == best.name:
+        reason = f"{best.name} já é o melhor — nada a fazer"
+    elif active_measure is None:
+        reason = (
+            f"servidor ativo ({active_endpoint}) não está na lista de candidatos — "
+            f"trocando para {best.name}"
+        )
+    elif not args.force and dwell < MIN_DWELL_SEC:
+        reason = (
+            f"dwell mínimo não vencido ({dwell/60:.0f}min de {MIN_DWELL_SEC/60:.0f}min) — "
+            f"mantendo {active_name}"
+        )
+    else:
+        gain = (active_measure.score - best.score) / active_measure.score * 100
+        if not args.force and gain < MIN_GAIN_PCT:
+            reason = (
+                f"ganho de {gain:.0f}% abaixo do mínimo de {MIN_GAIN_PCT:.0f}% — "
+                f"mantendo {active_name} (evita alternância)"
+            )
+        else:
+            reason = (
+                f"{best.name} é {gain:.0f}% melhor que {active_name} "
+                f"({best.score:.0f} vs {active_measure.score:.0f})"
+            )
+            if apply_peer(by_name[best.name], dry_run=not args.apply):
+                switched = args.apply
+                if switched:
+                    state["last_switch_ts"] = time.time()
+                    state["active"] = best.name
+                    save_state(state)
+
+    log.info("Decisão: %s", reason)
+    active_final = best.name if switched else (active_name or "desconhecido")
+    write_metrics(measurements, active_final, switched)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "measurements": [asdict(m) for m in measurements],
+                    "active": active_final,
+                    "switched": switched,
+                    "reason": reason,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/homelab/storj_payout_monitor.py
+++ b/tools/homelab/storj_payout_monitor.py
@@ -15,6 +15,7 @@ Fluxo:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import os
@@ -181,6 +182,42 @@ def send_telegram_alert(message: str) -> None:
         log.warning("Telegram alert falhou: %s", exc)
 
 
+def _load_storj_withdraw():
+    """Importa storj_withdraw.py (mesmo diretório) sem exigir estar no PYTHONPATH.
+
+    Em produção ambos ficam em /usr/local/bin — import direto funciona porque
+    o Python adiciona o diretório do script ao sys.path. Em testes (módulo
+    carregado via spec_from_file_location) isso não vale, daí o fallback.
+    """
+    try:
+        import storj_withdraw  # type: ignore
+
+        return storj_withdraw
+    except ImportError:
+        spec = importlib.util.spec_from_file_location(
+            "storj_withdraw", Path(__file__).resolve().parent / "storj_withdraw.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _build_transfer_plan_text(wallet_balance: float) -> str:
+    """Monta o plano de retirada (somente leitura) pra anexar no alerta.
+
+    Nunca assina nem transmite nada — só reaproveita storj_withdraw.py pra
+    buscar o endereço de depósito KuCoin e formatar o plano em 2 etapas.
+    """
+    try:
+        sw = _load_storj_withdraw()
+        deposit_info = sw.fetch_kucoin_deposit_address()
+        return "\n\n" + sw.format_transfer_plan_markdown(wallet_balance, deposit_info)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Falha ao montar plano de transferência p/ alerta: %s", exc)
+        return "\n\n⚠️ Não foi possível montar o plano automático — rode storj_withdraw.py manualmente."
+
+
 def write_prom(metrics: dict[str, float | int]) -> None:
     help_text = {
         "storj_payout_disposed_total": ("gauge", "Total disposed (USD) somado de todos satélites"),
@@ -248,6 +285,7 @@ def main() -> int:
             f"Total disposed acumulado: ${disposed_total:.2f}\n"
             f"Saldo atual na carteira: {wallet_balance:.4f} STORJ\n"
             f"Carteira: `{WALLET_ADDRESS}`"
+            + _build_transfer_plan_text(wallet_balance)
         )
         alert_sent += 1
         log.info("Alerta enviado (delta $%.2f >= threshold $%.2f)", delta_disposed_usd, ALERT_THRESHOLD_USD)

--- a/tools/homelab/storj_payout_monitor.py
+++ b/tools/homelab/storj_payout_monitor.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Monitor de saldo liberado (disposed) do payout Storj.
+
+A Storj retém pagamentos por ~2 períodos (meses) antes de liberá-los como
+saldo gasto na carteira do nó. Este script detecta quando o total "disposed"
+(liberado, cumulativo) aumenta e dispara um alerta via Telegram — não move
+nenhum fundo, nem tem acesso a nenhuma chave privada.
+
+Fluxo:
+1. Lê held-history da API local do storagenode (totalDisposed por satélite).
+2. Lê o saldo STORJ atual na carteira via block explorer público do zkSync-era.
+3. Compara com o estado salvo da última execução; se o delta de disposed
+   convertido em USD cruzar o threshold configurado, alerta e persiste.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.request
+from pathlib import Path
+from urllib.error import URLError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("storj-payout-monitor")
+
+STORJ_API_BASE = os.environ.get("STORJ_API_BASE", "http://127.0.0.1:14002/api").rstrip("/")
+WALLET_ADDRESS = os.environ.get(
+    "STORJ_WALLET_ADDRESS", "0x4787E8bA11d9D32f8A51336a1844e663105a7d24"
+)
+ZKSYNC_EXPLORER_BASE = os.environ.get(
+    "ZKSYNC_EXPLORER_BASE", "https://block-explorer-api.mainnet.zksync.io"
+)
+COINGECKO_PRICE_URL = os.environ.get(
+    "COINGECKO_PRICE_URL",
+    "https://api.coingecko.com/api/v3/simple/price?ids=storj&vs_currencies=usd",
+)
+
+STATE_FILE = Path(
+    os.environ.get("STORJ_PAYOUT_STATE_FILE", "/var/lib/storj-payout-monitor/state.json")
+)
+PROM_FILE = Path(
+    os.environ.get(
+        "PROM_FILE",
+        "/var/lib/prometheus/node-exporter/storj_payout_monitor.prom",
+    )
+)
+
+ALERT_THRESHOLD_USD = float(os.environ.get("STORJ_ALERT_THRESHOLD_USD", "20"))
+HTTP_TIMEOUT = int(os.environ.get("STORJ_PAYOUT_HTTP_TIMEOUT", "15"))
+
+
+def _http_json(url: str, *, headers: dict | None = None) -> dict:
+    req = urllib.request.Request(
+        url, headers={"Accept": "application/json", **(headers or {})}
+    )
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_disposed_total() -> float:
+    """Soma totalDisposed (unidades: centavos de USD) de todos os satélites."""
+    data = _http_json(f"{STORJ_API_BASE}/heldamount/held-history")
+    if not isinstance(data, list):
+        raise ValueError(f"held-history com formato inesperado: {type(data)}")
+    total_cents = sum(float(sat.get("totalDisposed", 0) or 0) for sat in data)
+    return total_cents / 100.0
+
+
+def fetch_wallet_storj_balance(wallet: str = WALLET_ADDRESS) -> float:
+    """Saldo STORJ na carteira (zkSync-era), em tokens (não USD)."""
+    data = _http_json(f"{ZKSYNC_EXPLORER_BASE}/address/{wallet}")
+    balances = data.get("balances", {})
+    for entry in balances.values():
+        token = entry.get("token", {})
+        if token.get("symbol") == "STORJ":
+            decimals = int(token.get("decimals", 8))
+            raw = int(entry.get("balance", "0") or "0")
+            return raw / (10**decimals)
+    return 0.0
+
+
+def fetch_storj_usd_price() -> float | None:
+    try:
+        data = _http_json(COINGECKO_PRICE_URL)
+        return float(data.get("storj", {}).get("usd"))
+    except (URLError, ValueError, TypeError, KeyError, OSError) as exc:
+        log.warning("Falha ao buscar preço STORJ/USD: %s", exc)
+        return None
+
+
+def load_state() -> dict:
+    try:
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def save_state(state: dict) -> None:
+    try:
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state), encoding="utf-8")
+        tmp.replace(STATE_FILE)
+    except OSError as exc:
+        log.warning("Falha ao persistir estado: %s", exc)
+
+
+def _fetch_from_secrets_agent(secret_name: str, field: str = "password") -> str | None:
+    """HTTP direto ao secrets agent local — mesmo padrão do kucoin_api.py.
+
+    Evita depender de `tools.secrets_agent_client` estar no PYTHONPATH do
+    host (o script roda de /usr/local/bin, fora do checkout do repo).
+    """
+    api_key = os.getenv("SECRETS_AGENT_API_KEY", "")
+    base_url = os.getenv("SECRETS_AGENT_URL", "http://127.0.0.1:8088")
+    if not api_key:
+        return None
+    try:
+        import requests
+
+        r = requests.get(
+            f"{base_url}/secrets/local/{secret_name}",
+            params={"field": field},
+            headers={"X-API-KEY": api_key},
+            timeout=3,
+        )
+        if r.status_code == 200:
+            return r.json().get("value")
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _resolve_telegram_bot_token() -> str:
+    for name, field in (
+        ("shared/telegram_bot_token", "token"),
+        ("authentik/shared/telegram_bot_token", "token"),
+    ):
+        value = _fetch_from_secrets_agent(name, field)
+        if value:
+            return value
+    return os.getenv("TELEGRAM_BOT_TOKEN", "")
+
+
+def _resolve_telegram_chat_id() -> str:
+    for name, field in (
+        ("shared/telegram_chat_id", "chat_id"),
+        ("authentik/shared/telegram_chat_id", "chat_id"),
+    ):
+        value = _fetch_from_secrets_agent(name, field)
+        if value:
+            return value
+    return os.getenv("TELEGRAM_CHAT_ID", "") or os.getenv("ADMIN_CHAT_ID", "")
+
+
+def send_telegram_alert(message: str) -> None:
+    """Best-effort — nunca lança exceção."""
+    try:
+        import requests
+
+        bot_token = _resolve_telegram_bot_token()
+        chat_id = _resolve_telegram_chat_id()
+        if not bot_token or not chat_id:
+            log.warning("Telegram alert pulado: token/chat_id ausente")
+            return
+        r = requests.post(
+            f"https://api.telegram.org/bot{bot_token}/sendMessage",
+            json={"chat_id": chat_id, "text": message, "parse_mode": "Markdown"},
+            timeout=10,
+        )
+        if r.status_code != 200:
+            requests.post(
+                f"https://api.telegram.org/bot{bot_token}/sendMessage",
+                json={"chat_id": chat_id, "text": message},
+                timeout=10,
+            )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Telegram alert falhou: %s", exc)
+
+
+def write_prom(metrics: dict[str, float | int]) -> None:
+    help_text = {
+        "storj_payout_disposed_total": ("gauge", "Total disposed (USD) somado de todos satélites"),
+        "storj_payout_wallet_balance_storj": ("gauge", "Saldo STORJ atual na carteira on-chain"),
+        "storj_payout_last_run_timestamp": ("gauge", "Unix time última execução"),
+        "storj_payout_monitor_healthy": ("gauge", "1=OK 0=erro"),
+        "storj_payout_alert_sent_total": ("counter", "Alertas de novo saldo liberado enviados"),
+    }
+    lines = []
+    for name, value in metrics.items():
+        mtype, mhelp = help_text.get(name, ("gauge", name))
+        lines.append(f"# HELP {name} {mhelp}")
+        lines.append(f"# TYPE {name} {mtype}")
+        lines.append(f"{name} {value}")
+    try:
+        PROM_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = PROM_FILE.with_suffix(".prom.tmp")
+        tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        tmp.replace(PROM_FILE)
+    except OSError as exc:
+        log.warning("Falha ao escrever métricas: %s", exc)
+
+
+def main() -> int:
+    state = load_state()
+    alert_sent = int(state.get("alert_sent_total", 0))
+
+    try:
+        disposed_total = fetch_disposed_total()
+    except (URLError, ValueError, OSError, KeyError) as exc:
+        log.error("Falha ao ler held-history: %s", exc)
+        write_prom(
+            {
+                "storj_payout_disposed_total": state.get("last_disposed_total", -1),
+                "storj_payout_wallet_balance_storj": state.get("last_wallet_balance", -1),
+                "storj_payout_last_run_timestamp": int(time.time()),
+                "storj_payout_monitor_healthy": 0,
+                "storj_payout_alert_sent_total": alert_sent,
+            }
+        )
+        return 2
+
+    try:
+        wallet_balance = fetch_wallet_storj_balance()
+    except (URLError, ValueError, OSError, KeyError) as exc:
+        log.error("Falha ao ler saldo on-chain: %s", exc)
+        wallet_balance = state.get("last_wallet_balance", 0.0)
+
+    last_disposed_total = float(state.get("last_disposed_total", disposed_total))
+    delta_disposed_usd = disposed_total - last_disposed_total
+
+    log.info(
+        "disposed_total=$%.2f (delta=$%.2f) wallet_balance=%.4f STORJ",
+        disposed_total,
+        delta_disposed_usd,
+        wallet_balance,
+    )
+
+    if delta_disposed_usd >= ALERT_THRESHOLD_USD:
+        price = fetch_storj_usd_price()
+        price_note = f" (~{delta_disposed_usd / price:.2f} STORJ @ ${price:.4f})" if price else ""
+        send_telegram_alert(
+            "💰 *Storj Payout* — novo saldo liberado!\n"
+            f"Delta: +${delta_disposed_usd:.2f}{price_note}\n"
+            f"Total disposed acumulado: ${disposed_total:.2f}\n"
+            f"Saldo atual na carteira: {wallet_balance:.4f} STORJ\n"
+            f"Carteira: `{WALLET_ADDRESS}`"
+        )
+        alert_sent += 1
+        log.info("Alerta enviado (delta $%.2f >= threshold $%.2f)", delta_disposed_usd, ALERT_THRESHOLD_USD)
+
+    save_state(
+        {
+            "last_disposed_total": disposed_total,
+            "last_wallet_balance": wallet_balance,
+            "last_check_ts": int(time.time()),
+            "alert_sent_total": alert_sent,
+        }
+    )
+
+    write_prom(
+        {
+            "storj_payout_disposed_total": round(disposed_total, 2),
+            "storj_payout_wallet_balance_storj": round(wallet_balance, 4),
+            "storj_payout_last_run_timestamp": int(time.time()),
+            "storj_payout_monitor_healthy": 1,
+            "storj_payout_alert_sent_total": alert_sent,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/homelab/storj_withdraw.py
+++ b/tools/homelab/storj_withdraw.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Retirada manual de STORJ da carteira do nó para a KuCoin.
+
+# USO MANUAL APENAS — NUNCA referenciar este script em .service/.timer.
+#
+# Este script NUNCA tem acesso a nenhuma chave privada. A assinatura da(s)
+# transação(ões) real(is) é feita à mão pelo operador, no fluxo oficial da
+# zkSync Era Bridge (https://portal.zksync.io/bridge), com um hardware
+# wallet (Ledger/Trezor) fisicamente conectado — ver
+# docs/storj-withdrawal-runbook.md.
+#
+# O que este script FAZ:
+#   1. Lê o saldo STORJ atual na carteira do nó (só leitura, API pública).
+#   2. Busca (ou cria) o endereço de depósito STORJ da KuCoin, rede ERC20/L1
+#      (reaproveita btc_trading_agent.kucoin_api — precisa das credenciais
+#      KuCoin no secrets agent).
+#   3. Imprime o PLANO de transferência em duas etapas — bridge L2->L1 e
+#      depois transfer ERC20 L1 -> endereço KuCoin — sem executar nada.
+#
+# O que este script NÃO faz (de propósito):
+#   - Não assina nem transmite nenhuma transação on-chain.
+#   - Não importa nenhuma lib de hardware wallet no caminho --dry-run
+#     (padrão), para não criar dependência de USB nesse modo.
+#   - O modo sem --dry-run está deliberadamente NÃO IMPLEMENTADO por ora
+#     (levanta NotImplementedError) — construir e assinar a transação real
+#     é trabalho futuro, feito manualmente pelo operador via zkSync Portal
+#     oficial + hardware wallet, não por este script.
+
+STORJ é um ERC-20 nativo do Ethereum L1 (contrato
+0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC). O saldo do nó fica representado
+no zkSync Era (L2); para chegar numa exchange que só aceita depósito L1
+(caso da KuCoin, presumivelmente — confirmar chain exata antes de qualquer
+transferência real), o caminho oficial documentado pela Storj é:
+  1) Bridge L2 (zkSync Era) -> L1 (Ethereum) via zkSync Era Bridge —
+     taxa pode ser paga no próprio STORJ (meta-transação gasless).
+  2) Transfer ERC-20 padrão em L1 até o endereço de depósito da exchange.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("storj-withdraw")
+
+WALLET_ADDRESS = "0x4787E8bA11d9D32f8A51336a1844e663105a7d24"
+ZKSYNC_EXPLORER_BASE = "https://block-explorer-api.mainnet.zksync.io"
+STORJ_L1_CONTRACT = "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC"
+KUCOIN_DEPOSIT_CHAIN = "eth"  # chainId real da KuCoin p/ STORJ (chainName exibido é "ERC20")
+
+# Este script roda standalone em /usr/local/bin no host — não dentro do
+# checkout do repo — então o diretório de kucoin_api.py precisa ser
+# configurável em vez de derivado de __file__ (que só funciona em dev).
+_DEFAULT_CANDIDATES = (
+    "/apps/crypto-trader/trading/btc_trading_agent",
+    "/apps/crypto-trader/btc_trading_agent",
+    "/home/homelab/myClaude/btc_trading_agent",
+)
+KUCOIN_API_DIR = os.environ.get("KUCOIN_API_DIR", "")
+
+
+def _http_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_wallet_storj_balance(wallet: str = WALLET_ADDRESS) -> float:
+    data = _http_json(f"{ZKSYNC_EXPLORER_BASE}/address/{wallet}")
+    for entry in data.get("balances", {}).values():
+        token = entry.get("token", {})
+        if token.get("symbol") == "STORJ":
+            decimals = int(token.get("decimals", 8))
+            raw = int(entry.get("balance", "0") or "0")
+            return raw / (10**decimals)
+    return 0.0
+
+
+def _resolve_kucoin_api_dir() -> str:
+    if KUCOIN_API_DIR:
+        return KUCOIN_API_DIR
+    for candidate in _DEFAULT_CANDIDATES:
+        if (Path(candidate) / "kucoin_api.py").is_file():
+            return candidate
+    # Fallback dev: dentro do checkout do repo (parents[2] a partir deste arquivo).
+    return str(Path(__file__).resolve().parents[2] / "btc_trading_agent")
+
+
+def fetch_kucoin_deposit_address(chain: str = KUCOIN_DEPOSIT_CHAIN) -> dict:
+    """Busca (ou cria) o endereço de depósito STORJ na KuCoin.
+
+    Reaproveita btc_trading_agent/kucoin_api.py — não duplica autenticação.
+    """
+    api_dir = _resolve_kucoin_api_dir()
+    if api_dir not in sys.path:
+        sys.path.insert(0, api_dir)
+    import kucoin_api  # type: ignore
+
+    result = kucoin_api.get_deposit_addresses("STORJ", chain=chain)
+    addresses = result.get("addresses") or []
+    if result.get("success") and addresses:
+        return {"success": True, **addresses[0]}
+
+    log.info("Nenhum endereço STORJ/%s existente — criando um novo", chain)
+    return kucoin_api.create_deposit_address("STORJ", chain=chain)
+
+
+def print_transfer_plan(wallet_balance: float, deposit_info: dict) -> None:
+    print("=" * 70)
+    print("PLANO DE TRANSFERÊNCIA STORJ (dry-run — nada foi executado)")
+    print("=" * 70)
+    print(f"Origem (carteira do nó, zkSync Era): {WALLET_ADDRESS}")
+    print(f"Saldo disponível: {wallet_balance:.4f} STORJ")
+    print()
+    if not deposit_info.get("success"):
+        print(f"⚠️  Falha ao obter endereço de depósito KuCoin: {deposit_info.get('error')}")
+    else:
+        print(f"Destino (KuCoin, rede ERC20/Ethereum, chainId KuCoin={KUCOIN_DEPOSIT_CHAIN}): {deposit_info.get('address')}")
+        if deposit_info.get("memo"):
+            print(f"Memo/Tag obrigatório: {deposit_info['memo']}")
+    print()
+    print("Etapa 1 — Bridge L2 -> L1:")
+    print("  Via zkSync Era Bridge oficial (https://portal.zksync.io/bridge)")
+    print(f"  Token: STORJ (contrato L1 {STORJ_L1_CONTRACT})")
+    print(f"  Valor: {wallet_balance:.4f} STORJ")
+    print("  Taxa: paga no próprio STORJ (meta-transação gasless)")
+    print("  Assinatura: hardware wallet (Ledger/Trezor) conectado, confirmação física")
+    print()
+    print("Etapa 2 — Transfer ERC-20 padrão em L1:")
+    print(f"  De: {WALLET_ADDRESS} (após bridge concluído)")
+    print(f"  Para: endereço de depósito KuCoin acima (rede ERC20/Ethereum, chainId KuCoin={KUCOIN_DEPOSIT_CHAIN})")
+    print("  Assinatura: mesmo hardware wallet")
+    print()
+    print("⚠️  RECOMENDADO: testar com $1-2 primeiro e confirmar crédito na KuCoin")
+    print("    antes de mover o saldo total. Ver docs/storj-withdrawal-runbook.md.")
+    print("=" * 70)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="(padrão) só calcula e imprime o plano, não executa nada",
+    )
+    parser.add_argument(
+        "--i-am-present",
+        action="store_true",
+        help="Confirma que um humano está fisicamente presente com o hardware wallet "
+        "conectado — necessário para sair do modo --dry-run (ainda não implementado).",
+    )
+    parser.add_argument("--chain", default=KUCOIN_DEPOSIT_CHAIN, help="Rede de depósito na KuCoin")
+    args = parser.parse_args()
+
+    try:
+        wallet_balance = fetch_wallet_storj_balance()
+    except Exception as exc:  # noqa: BLE001
+        log.error("Falha ao ler saldo on-chain: %s", exc)
+        return 2
+
+    try:
+        deposit_info = fetch_kucoin_deposit_address(chain=args.chain)
+    except Exception as exc:  # noqa: BLE001
+        log.error("Falha ao buscar endereço de depósito KuCoin: %s", exc)
+        deposit_info = {"success": False, "error": str(exc)}
+
+    print_transfer_plan(wallet_balance, deposit_info)
+
+    if not args.i_am_present:
+        return 0
+
+    raise NotImplementedError(
+        "Assinatura e transmissão automatizada NÃO estão implementadas por design. "
+        "Siga docs/storj-withdrawal-runbook.md: use o zkSync Era Bridge oficial "
+        "(portal.zksync.io/bridge) com hardware wallet conectado."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/homelab/storj_withdraw.py
+++ b/tools/homelab/storj_withdraw.py
@@ -142,6 +142,31 @@ def print_transfer_plan(wallet_balance: float, deposit_info: dict) -> None:
     print("=" * 70)
 
 
+def format_transfer_plan_markdown(wallet_balance: float, deposit_info: dict) -> str:
+    """Versão compacta (Markdown) do plano, para incluir no alerta do Telegram.
+
+    Mesmo conteúdo de print_transfer_plan(), sem a assinatura/transmissão —
+    isso continua manual, feito pelo operador com hardware/software wallet.
+    """
+    if not deposit_info.get("success"):
+        return f"⚠️ Falha ao obter endereço de depósito KuCoin: {deposit_info.get('error')}"
+
+    lines = [
+        "*Plano de transferência (2 etapas, manual):*",
+        f"Saldo: `{wallet_balance:.4f} STORJ`",
+        f"Destino KuCoin (rede ERC20, chainId={KUCOIN_DEPOSIT_CHAIN}): `{deposit_info.get('address')}`",
+    ]
+    if deposit_info.get("memo"):
+        lines.append(f"Memo/Tag obrigatório: `{deposit_info['memo']}`")
+    lines += [
+        "1️⃣ Bridge STORJ zkSync Era → Ethereum L1: https://portal.zksync.io/bridge"
+        " (taxa em STORJ, hardware/software wallet, confirmação física)",
+        "2️⃣ Transfer ERC-20 padrão L1 → endereço acima (mesma wallet)",
+        "⚠️ Testar com $1-2 antes do valor total — docs/storj-withdrawal-runbook.md",
+    ]
+    return "\n".join(lines)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(


### PR DESCRIPTION
## Problema

O túnel ProtonVPN do homelab é um `wg-quick` estático pinado em **BE#72 (Bélgica, RTT 208ms do Brasil)**. Como o homelab é o gateway da LAN, isso limita a internet da casa inteira:

| Caminho | Throughput |
|---|---|
| Via ProtonVPN (BE#72) | 2,97 MB/s |
| Via `eth-wan` direto | 6,55 MB/s |

Pior que a média é a instabilidade: em 5 medições seguidas pela VPN uma despencou 45%, e de uma workstation da LAN um download de 10 MB travou por completo (0 bytes em 60s). Era a causa do vídeo travando.

## Solução

Seletor horário que mede os candidatos e troca **apenas o bloco `[Peer]`** via `wg syncconf`.

**Por que `syncconf` e não `wg-quick down/up`:** a conf carrega ~40 regras `PostUp` (tabela 205, `fwmark 0xca6c`, rotas da LAN, bridges Docker, exceções de edge Cloudflare por UID `_rpa4all`, macvlan Storj, kill-switch). `syncconf` atualiza o peer no kernel sem disparar `PostDown`/`PostUp`. Derrubar o túnel para trocar de servidor derrubaria a casa.

## Anti-alternância (pedido explícito: 1h)

Duas camadas, porque só o timer não bastaria:
- **Timer horário** — piso da cadência.
- **`PVPN_MIN_DWELL_SEC=3600`** — teto: nem execução manual troca antes de 1h. Persistido, sobrevive a reboot.
- **`PVPN_MIN_GAIN_PCT=20`** — sem isso, dois servidores empatados dentro do ruído de medição se revezariam de hora em hora.

## Detalhe que quase passou

A medição sairia **pelo próprio túnel** (tudo cai na tabela 205), medindo "RTT via Bélgica até o candidato" — inflado e quase idêntico para todos, tornando a escolha aleatória. Corrigido com `ping -m 0xca6c`, a mesma marca que o WireGuard usa contra loop de roteamento.

Medido no homelab: `1.1.1.1` a **206ms com o túnel, 7ms sem**.

## Segurança

- Backup da conf antes de cada troca.
- **Rollback automático** se o peer novo não fechar handshake em 25s.
- `flock` envolvendo o processo (a primeira versão soltava o lock na hora — corrigido).
- Teste trava a regressão de perder um `PostUp`; outro impede servidor mudo (100% de perda) vencer por ausência de dado.

## Testes

20 testes novos, todos passando. Suíte completa: 2538 → 2558 aprovados, **zero regressões** (as 79 falhas da suíte completa são interações pré-existentes — `test_clear_trading.py` passa 100% isolada).

## Para ativar de fato

O deploy semeia a lista com o servidor atual (extraído da conf viva), então o timer roda inofensivo até que servidores de Argentina/Chile/EUA sejam adicionados em `/etc/protonvpn-best-server.json` — as configs vêm de account.protonvpn.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)