### PR TITLE
fix(whatsapp): deduplica webhooks message/message.any

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T13:27:24.577903+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-07-29T16:42:51.278515+00:00",
+  "repo_root": "/tmp/wb-dedupe-worktree",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-28T13:27:24.577903+00:00`
+- Generated at: `2026-07-29T16:42:51.278515+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `191`

--- a/scripts/misc/whatsapp_bot.py
+++ b/scripts/misc/whatsapp_bot.py
@@ -1470,6 +1470,14 @@ class WebhookServer:
         self.port = port
         self.app = web.Application()
         self.setup_routes()
+        # WAHA manda webhook tanto pra "message" quanto pra "message.any" pra
+        # cada mensagem real (às vezes com redelivery do mesmo evento) — sem
+        # dedupe isso gera 2+ respostas (2+ chamadas ao Ollama, 2+ sendText)
+        # pra uma única mensagem recebida. Dedupe pelo id real da mensagem do
+        # WhatsApp (payload.id), não pelo id do evento de webhook, porque é a
+        # única coisa estável entre as entregas duplicadas.
+        self._recent_message_ids: Dict[str, float] = {}
+        self._recent_message_ids_ttl = 300.0  # segundos
     
     def setup_routes(self):
         """Configura rotas do webhook"""
@@ -1523,6 +1531,24 @@ class WebhookServer:
             logger.error(f"Erro ao processar mensagem: {e}")
             return web.json_response({"error": str(e)}, status=500)
     
+    def _is_duplicate_message(self, wa_message_id: str) -> bool:
+        """Marca `wa_message_id` como visto e retorna True se já tinha sido
+        processado antes. Síncrono e sem `await` no meio — corre até o fim
+        antes de qualquer outra corrotina rodar, então não há corrida entre
+        as entregas quase-simultâneas de "message"/"message.any" pro mesmo
+        evento."""
+        now = time.time()
+        if wa_message_id in self._recent_message_ids:
+            return True
+        self._recent_message_ids[wa_message_id] = now
+        # Poda oportunista — evita crescimento ilimitado num processo de vida longa.
+        if len(self._recent_message_ids) > 500:
+            cutoff = now - self._recent_message_ids_ttl
+            expired = [mid for mid, ts in self._recent_message_ids.items() if ts < cutoff]
+            for mid in expired:
+                del self._recent_message_ids[mid]
+        return False
+
     async def process_message_event(self, data: dict):
         """Processa evento de mensagem (com logs temporários para debug)"""
         try:
@@ -1545,6 +1571,14 @@ class WebhookServer:
 
             if not msg_data:
                 logger.debug("Nenhum msg_data encontrado no payload, abortando")
+                return
+
+            # Dedupe: WAHA entrega o mesmo evento em múltiplos webhooks
+            # ("message" + "message.any", às vezes com redelivery do mesmo
+            # evento) — sem isso cada entrega vira uma resposta separada.
+            wa_message_id = msg_data.get("id", msg_data.get("key", {}).get("id", ""))
+            if wa_message_id and self._is_duplicate_message(wa_message_id):
+                logger.debug(f"Evento duplicado pra mensagem já processada (id={wa_message_id}), ignorando")
                 return
 
             # Extrair informações

--- a/tests/test_whatsapp_webhook_dedupe.py
+++ b/tests/test_whatsapp_webhook_dedupe.py
@@ -1,0 +1,105 @@
+"""Testes do dedupe de eventos de webhook duplicados (WAHA manda "message" +
+"message.any" — às vezes redelivery do mesmo evento — pra uma única mensagem
+real; sem dedupe isso gera respostas duplicadas)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "whatsapp_bot.py"
+
+
+def _load_module():
+    module_name = "whatsapp_bot_for_tests"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+
+    fake_psycopg2 = types.ModuleType("psycopg2")
+    fake_extras = types.ModuleType("psycopg2.extras")
+    fake_pool = types.ModuleType("psycopg2.pool")
+    fake_aiohttp = types.ModuleType("aiohttp")
+
+    class _FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_extras.RealDictCursor = object
+    fake_pool.SimpleConnectionPool = _FakePool
+    fake_aiohttp.web = types.SimpleNamespace(Application=object)
+
+    sys.modules.setdefault("psycopg2", fake_psycopg2)
+    sys.modules.setdefault("psycopg2.extras", fake_extras)
+    sys.modules.setdefault("psycopg2.pool", fake_pool)
+    sys.modules.setdefault("aiohttp", fake_aiohttp)
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_server(wb):
+    server = object.__new__(wb.WebhookServer)
+    server._recent_message_ids = {}
+    server._recent_message_ids_ttl = 300.0
+    return server
+
+
+def test_is_duplicate_message_flags_second_occurrence():
+    wb = _load_module()
+    server = _make_server(wb)
+
+    assert server._is_duplicate_message("msg-1") is False
+    assert server._is_duplicate_message("msg-1") is True
+    assert server._is_duplicate_message("msg-2") is False
+
+
+def test_prunes_old_entries_once_over_cap():
+    wb = _load_module()
+    server = _make_server(wb)
+
+    for i in range(501):
+        server._recent_message_ids[f"old-{i}"] = 0.0  # bem no passado
+
+    assert server._is_duplicate_message("new-msg") is False
+    # entradas expiradas (ts=0.0, bem além do TTL) devem ter sido podadas
+    assert "old-0" not in server._recent_message_ids
+    assert "new-msg" in server._recent_message_ids
+
+
+def test_process_message_event_skips_duplicate_delivery():
+    """Simula WAHA mandando o mesmo message.id duas vezes (message + message.any)
+    — só a primeira deve chamar bot.process_message / waha.send_text."""
+    wb = _load_module()
+    server = _make_server(wb)
+    server.bot = types.SimpleNamespace(process_message=AsyncMock(return_value="Bom dia!"))
+    server.waha = types.SimpleNamespace(
+        mark_as_read=AsyncMock(return_value=None),
+        send_text=AsyncMock(return_value={"id": "sent-1"}),
+    )
+
+    payload = {
+        "id": "true_143430516752629@lid_ABC123_out",
+        "timestamp": 1785336241,
+        "from": "5511981193899@c.us",
+        "fromMe": True,
+        "body": "Bom dia",
+    }
+    event_message_any = {"event": "message.any", "payload": dict(payload)}
+    event_message = {"event": "message", "payload": dict(payload)}
+
+    async def run():
+        await server.process_message_event(event_message_any)
+        await server.process_message_event(event_message)  # mesmo payload.id — deve ser ignorado
+
+    asyncio.run(run())
+
+    server.bot.process_message.assert_awaited_once()
+    server.waha.send_text.assert_awaited_once()


### PR DESCRIPTION
## Resumo
- WAHA entrega o mesmo evento de mensagem tanto como `message` quanto `message.any` (às vezes com redelivery do mesmo evento) — cada entrega disparava uma chamada independente ao Ollama + `sendText`, gerando 2 respostas pra 1 mensagem recebida.
- Dedupe pelo id real da mensagem do WhatsApp (`payload.id`), síncrono, sem `await` no meio, com poda oportunista.

## Test plan
- [x] `tests/test_whatsapp_webhook_dedupe.py` (3 testes, incluindo simulação de duas entregas com o mesmo `payload.id` confirmando só 1 chamada a `process_message`/`send_text`)
- [x] Suíte completa do bot sem regressão

🤖 Gerado com [Claude Code](https://claude.com/claude-code)