### PR TITLE
feat(whatsapp): tool-calling MCP real para shared-homelab

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T16:42:51.278515+00:00",
-  "repo_root": "/tmp/wb-dedupe-worktree",
+  "generated_at": "2026-07-29T16:55:23.723608+00:00",
+  "repo_root": "/tmp/wb-toolcalling-worktree",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T16:42:51.278515+00:00`
+- Generated at: `2026-07-29T16:55:23.723608+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `191`

--- a/scripts/misc/mcp_tool_bridge.py
+++ b/scripts/misc/mcp_tool_bridge.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Ponte entre um modelo Ollama com tool-calling e as ferramentas do
+`scripts/homelab_mcp_server.py` (MCP server "homelab").
+
+Sem dependência de WhatsApp/WAHA — pensado para ser testável isolado e
+reutilizável por qualquer outra superfície (ex: um futuro bot Telegram).
+
+Responsabilidades:
+  - Carregar `homelab_mcp_server.py` em processo (mesmo padrão já usado por
+    `specialized_agents/langgraph_base.py::_mcp_rpc`), uma única vez.
+  - Gerar o schema de ferramentas no formato function-calling do Ollama a
+    partir do `FastMCP._tool_manager` do módulo carregado (fonte única de
+    verdade — não é escrito à mão, então não pode divergir das ferramentas
+    reais).
+  - Classificar cada ferramenta por risco (`TOOL_RISK`) e decidir se pode
+    executar na hora ou precisa passar pela trava de aprovação (Telegram,
+    via a camada de governança já existente: intent_declare/intent_check_status).
+  - Fazer o polling de aprovação com backoff e executar a ferramenta real
+    somente depois de `approved`.
+
+Ver plano: /home/edenilson/.claude/plans/hazy-chasing-balloon.md
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger("mcp_tool_bridge")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MCP_SERVER_PATH = os.path.join(os.path.dirname(_HERE), "homelab_mcp_server.py")
+
+# Ferramentas de governança — plumbing da própria trava, nunca expostas ao
+# modelo (ele nunca deve "decidir" chamar intent_declare/intent_complete
+# diretamente; quem chama é esta bridge, em torno da ferramenta real).
+EXCLUDED_TOOLS: frozenset[str] = frozenset(
+    {"intent_declare", "intent_check_status", "intent_complete"}
+)
+
+# Classificação de risco por ferramenta (risk_level aceito por intent_declare:
+# none | low | medium | high | critical). Tabela estática — risco é decisão
+# humana, não algo para inferir de assinatura de função.
+#
+# memory_store fica "low" (ungated) deliberadamente: blast radius é local
+# (ChromaDB), dedupado por hash, com TTL opcional, e o próprio repo já trata
+# escrita de memória como bookkeeping best-effort sem gate em
+# specialized_agents/langgraph_base.py::_node_store_memory. Gatear cada
+# chamada de memory_store tornaria o assistente irritante de usar para a
+# funcionalidade mais básica de conversa.
+TOOL_RISK: dict[str, str] = {
+    # SAFE — leitura, sem efeito colateral, executa na hora
+    "bus_health": "none",
+    "bus_get_messages": "none",
+    "bus_search_by_agent": "none",
+    "api_health": "none",
+    "api_events_list": "none",
+    "api_events_get": "none",
+    "db_list_tables": "none",
+    "db_describe_table": "none",
+    "db_active_events": "none",
+    "journal_query": "none",
+    "memory_search": "none",
+    "trading_performance": "none",
+    "trading_recent_trades": "none",
+    "trading_positions": "none",
+    "trading_market_state": "none",
+    "trading_decisions": "none",
+    "trading_candles": "none",
+    "trading_ai_controls": "none",
+    "trading_ai_plan": "none",
+    "trading_ai_window": "none",
+    "trading_news_sentiment": "none",
+    "trading_learning_stats": "none",
+    "trading_summary": "none",
+    # LOW — grava, mas blast radius local/reversível/best-effort
+    "memory_store": "low",
+    # HIGH — escreve em sistema externo, expõe existência de credenciais,
+    # ou executa SQL arbitrário (mesmo com guardrails de app)
+    "secrets_list": "high",
+    "secrets_health": "high",
+    "api_auth_login": "high",
+    "bus_publish": "high",
+    "bus_record_result": "high",
+    "api_events_create": "high",
+    "api_checkins_create": "high",
+    "db_execute_query": "high",
+    # CRITICAL — expõe valor de credencial
+    "secrets_get": "critical",
+}
+
+# Ferramentas com side-effect ficam pendentes de aprovação humana; o resto
+# executa direto. Mantido em paridade com `_AUTO_APPROVE_LEVELS` do
+# homelab_mcp_server.py (none/low auto-aprovam).
+_AUTO_EXECUTE_LEVELS = frozenset({"none", "low"})
+
+# Backoff de polling (segundos) — o último valor se repete até o timeout.
+_BACKOFF_SCHEDULE = (5, 5, 10, 15, 30)
+
+DEFAULT_AGENT_ID = "whatsapp-bot"
+
+_module_cache: Any = None
+
+
+def _load_mcp_module() -> Any:
+    """Importa scripts/homelab_mcp_server.py como módulo Python, uma vez.
+
+    Mesmo padrão de `specialized_agents/langgraph_base.py::_mcp_rpc`, mas
+    cacheado — o módulo faz resolução de env/DSN em nível de módulo
+    (`_db_url_cache`, `_trading_db_url_cache`) que deve persistir durante o
+    tempo de vida do processo do bot, não ser refeita a cada chamada.
+    """
+    global _module_cache
+    if _module_cache is not None:
+        return _module_cache
+    spec = importlib.util.spec_from_file_location("homelab_mcp_server", _MCP_SERVER_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Não foi possível carregar {_MCP_SERVER_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _module_cache = mod
+    return mod
+
+
+def _all_tools(mod: Any) -> dict[str, Any]:
+    """Retorna {nome: Tool} de todas as ferramentas registradas no FastMCP."""
+    return {t.name: t for t in mod.mcp._tool_manager.list_tools()}
+
+
+def discovered_tool_names(include_excluded: bool = False) -> set[str]:
+    """Nomes de ferramentas descobertas via introspecção do FastMCP.
+
+    Usado por testes para garantir que TOOL_RISK não fica desatualizado
+    quando homelab_mcp_server.py ganha/perde ferramentas.
+    """
+    mod = _load_mcp_module()
+    names = set(_all_tools(mod).keys())
+    if not include_excluded:
+        names -= EXCLUDED_TOOLS
+    return names
+
+
+def classify(tool_name: str) -> str:
+    """Risk level de uma ferramenta. Fail-safe: desconhecida => 'high'."""
+    risk = TOOL_RISK.get(tool_name)
+    if risk is None:
+        logger.warning(
+            "Ferramenta MCP '%s' sem classificação de risco em TOOL_RISK — "
+            "tratando como 'high' (nunca auto-executa por padrão).",
+            tool_name,
+        )
+        return "high"
+    return risk
+
+
+def is_gated(tool_name: str) -> bool:
+    return classify(tool_name) not in _AUTO_EXECUTE_LEVELS
+
+
+def build_ollama_tool_schemas() -> list[dict]:
+    """Gera o array `tools=` no formato function-calling do Ollama.
+
+    Fonte única de verdade: introspecção do FastMCP (`t.parameters` já é um
+    JSON-schema válido gerado a partir da assinatura real da função).
+    Exclui ferramentas de governança (EXCLUDED_TOOLS).
+    """
+    mod = _load_mcp_module()
+    schemas = []
+    for name, tool in sorted(_all_tools(mod).items()):
+        if name in EXCLUDED_TOOLS:
+            continue
+        description = (tool.description or "").strip()
+        # primeiro parágrafo do docstring (antes da primeira linha em branco)
+        description = description.split("\n\n", 1)[0].strip()
+        schemas.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": tool.parameters,
+                },
+            }
+        )
+    return schemas
+
+
+def _call_tool(tool_name: str, kwargs: dict) -> Any:
+    """Chama a função real da ferramenta e faz parse do retorno JSON-string.
+
+    Usa `getattr(mod, tool_name)` (lookup por nome no módulo) em vez do
+    `tool.fn` cacheado pelo FastMCP — o `Tool.fn` captura a referência da
+    função no momento da decoração, então testes que fazem
+    `patch.object(mod, tool_name, ...)` não teriam efeito se chamássemos
+    `tool.fn` diretamente. Mesmo padrão de
+    `specialized_agents/langgraph_base.py::_mcp_rpc`.
+    """
+    mod = _load_mcp_module()
+    if tool_name not in _all_tools(mod):
+        raise KeyError(f"Ferramenta MCP desconhecida: {tool_name}")
+    fn = getattr(mod, tool_name)
+    result = fn(**kwargs)
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except json.JSONDecodeError:
+            return {"raw": result}
+    return result
+
+
+def execute_safe(tool_name: str, kwargs: dict) -> Any:
+    """Executa uma ferramenta 'none'/'low' imediatamente, sem trava.
+
+    Levanta ValueError se a ferramenta exigir aprovação — uso incorreto do
+    caller, não deveria acontecer se `is_gated` foi checado antes.
+    """
+    if is_gated(tool_name):
+        raise ValueError(
+            f"'{tool_name}' requer aprovação (risk={classify(tool_name)}); "
+            "use declare_gate()+await_and_execute(), não execute_safe()."
+        )
+    return _call_tool(tool_name, kwargs)
+
+
+def declare_gate(
+    tool_name: str,
+    kwargs: dict,
+    description: str,
+    agent_id: str = DEFAULT_AGENT_ID,
+) -> str:
+    """Declara a intenção de chamar uma ferramenta arriscada.
+
+    Retorna o intent_id (para poll manual) — o caminho normal é passar
+    direto para `await_and_execute`.
+    """
+    mod = _load_mcp_module()
+    risk = classify(tool_name)
+    context = json.dumps(kwargs, ensure_ascii=False, default=str)[:4000]
+    raw = mod.intent_declare(
+        agent_id=agent_id,
+        action_type="other",
+        description=description,
+        target=tool_name,
+        risk_level=risk,
+        context=context,
+    )
+    data = json.loads(raw)
+    if not data.get("ok"):
+        raise RuntimeError(f"intent_declare falhou para '{tool_name}': {data}")
+    return data["intent_id"]
+
+
+async def await_and_execute(
+    intent_id: str,
+    tool_name: str,
+    kwargs: dict,
+    on_resolved: Callable[[str, Any], Awaitable[None]],
+    max_wait_seconds: Optional[float] = None,
+) -> None:
+    """Faz polling de `intent_check_status` até approved/rejected/expired.
+
+    Em `approved`, executa a ferramenta real e chama `intent_complete`.
+    Chama `on_resolved(status, result_ou_erro)` exatamente uma vez ao final
+    (status ∈ approved|rejected|expired|error). Nunca deixa exceção subir —
+    erros inesperados também resolvem via `on_resolved("error", ...)`.
+    """
+    mod = _load_mcp_module()
+    if max_wait_seconds is None:
+        intent_exp_min = int(os.environ.get("INTENT_EXP_MIN", "10"))
+        max_wait_seconds = intent_exp_min * 60 + 60  # margem sobre a expiração do gateway
+
+    start = time.monotonic()
+    step = 0
+    try:
+        while True:
+            if time.monotonic() - start > max_wait_seconds:
+                logger.info("intent_id=%s expirou no timeout local do bridge", intent_id)
+                await on_resolved("expired", None)
+                return
+
+            raw = mod.intent_check_status(intent_id)
+            data = json.loads(raw)
+            if not data.get("ok"):
+                logger.error("intent_check_status falhou para %s: %s", intent_id, data)
+                await on_resolved("error", data.get("error", "erro desconhecido"))
+                return
+
+            status = data.get("status")
+            if status == "approved":
+                try:
+                    result = _call_tool(tool_name, kwargs)
+                    outcome = json.dumps(result, ensure_ascii=False, default=str)[:2000]
+                    mod.intent_complete(intent_id=intent_id, outcome=outcome, success=True)
+                    await on_resolved("approved", result)
+                except Exception as exc:  # noqa: BLE001 - queremos capturar qualquer falha da ferramenta
+                    logger.exception("Erro executando '%s' após aprovação (intent_id=%s)", tool_name, intent_id)
+                    mod.intent_complete(
+                        intent_id=intent_id,
+                        outcome="Falha ao executar após aprovação",
+                        success=False,
+                        error_detail=str(exc),
+                    )
+                    await on_resolved("error", str(exc))
+                return
+
+            if status in ("rejected", "expired"):
+                await on_resolved(status, None)
+                return
+
+            delay = _BACKOFF_SCHEDULE[min(step, len(_BACKOFF_SCHEDULE) - 1)]
+            step += 1
+            await asyncio.sleep(delay)
+    except Exception as exc:  # noqa: BLE001 - tarefa fire-and-forget nunca pode morrer silenciosa
+        logger.exception("Erro inesperado no polling de aprovação intent_id=%s", intent_id)
+        try:
+            await on_resolved("error", str(exc))
+        except Exception:
+            logger.exception("on_resolved também falhou para intent_id=%s", intent_id)

--- a/scripts/misc/whatsapp_bot.py
+++ b/scripts/misc/whatsapp_bot.py
@@ -106,6 +106,15 @@ except ImportError:
     HOME_AVAILABLE = False
     logger.warning("Módulo home_assistant_integration não encontrado - automação desabilitada")
 
+# Import da bridge de tool-calling MCP (ferramentas do homelab_mcp_server.py
+# para o modelo shared-homelab — ver scripts/misc/mcp_tool_bridge.py)
+try:
+    import mcp_tool_bridge
+    MCP_TOOLS_AVAILABLE = True
+except ImportError:
+    MCP_TOOLS_AVAILABLE = False
+    logger.warning("Módulo mcp_tool_bridge não encontrado - tool-calling desabilitado para shared-homelab")
+
 # ============== Configurações ==
 # Número do WhatsApp (formato: código do país + DDD + número, sem +)
 WHATSAPP_NUMBER = os.getenv("WHATSAPP_NUMBER", "5511981193899")
@@ -135,6 +144,14 @@ if OWNER_NUMBER not in ALLOWED_NUMBERS:
 PHONE_MODEL_MAPPING = {
     "11981193899": "shared-homelab",
 }
+
+# Modelo com tool-calling MCP habilitado (ver mcp_tool_bridge.py) e teto de
+# rodadas do loop tool-call -> resultado -> tool-call para evitar loop infinito.
+TOOL_CALLING_MODEL = "shared-homelab"
+try:
+    MAX_TOOL_ROUNDS = int(os.getenv("MAX_TOOL_ROUNDS", "3"))
+except ValueError:
+    MAX_TOOL_ROUNDS = 3
 
 # Caminho dos dados
 DATA_DIR = Path(__file__).parent / "whatsapp_data"
@@ -536,6 +553,54 @@ class OllamaClient:
             logger.error(f"Exceção no Ollama: {e}")
             return f"Erro de conexão: {str(e)}"
 
+    async def chat_with_tools(
+        self,
+        messages: List[Dict[str, Any]],
+        model: str = MODEL,
+        system: str = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        """Como chat(), mas envia `tools=` (function-calling do Ollama) e
+        retorna (content, tool_calls) em vez de só o texto.
+
+        tool_calls vem no formato nativo do Ollama:
+        [{"function": {"name": ..., "arguments": {...}}}, ...] — lista vazia
+        se o modelo não chamou nenhuma ferramenta. Método separado de chat()
+        para não alterar a assinatura/retorno usada pelos demais call-sites
+        (calendário, gmail, home, relatórios, resumo de contexto).
+        """
+        try:
+            full_messages = []
+            if system:
+                full_messages.append({"role": "system", "content": system})
+            full_messages.extend(messages)
+
+            payload: Dict[str, Any] = {
+                "model": model,
+                "messages": full_messages,
+                "stream": False,
+                "options": {
+                    "temperature": 0.7,
+                    "num_predict": 2048,
+                },
+            }
+            if tools:
+                payload["tools"] = tools
+
+            response = await self.client.post(f"{self.host}/api/chat", json=payload)
+
+            if response.status_code == 200:
+                data = response.json()
+                msg = data.get("message", {}) or {}
+                return msg.get("content", "") or "", msg.get("tool_calls") or []
+
+            logger.error(f"Erro Ollama (chat_with_tools): {response.status_code} - {response.text}")
+            return f"Erro ao conectar com modelo: {response.status_code}", []
+
+        except Exception as e:
+            logger.error(f"Exceção no Ollama (chat_with_tools): {e}")
+            return f"Erro de conexão: {str(e)}", []
+
     async def chat_validated(
         self,
         messages: List[Dict[str, str]],
@@ -644,7 +709,12 @@ class WhatsAppBot:
         self.search_engine = None
         self.running = False
         self.whatsapp_client = None
-        
+        # Callable(chat_id, text) -> Awaitable, setado via set_notifier() em
+        # main() — permite que uma tarefa de fundo (aprovação de ferramenta
+        # travada) mande uma mensagem WhatsApp minutos depois, fora do ciclo
+        # request/response do webhook.
+        self._notifier: Optional[Any] = None
+
         # Inicializar busca web se disponível
         if WEB_SEARCH_AVAILABLE:
             try:
@@ -653,6 +723,12 @@ class WhatsAppBot:
             except Exception as e:
                 logger.error(f"Erro ao inicializar busca: {e}")
     
+    def set_notifier(self, fn) -> None:
+        """Registra o callable(chat_id, text) usado para mandar mensagens
+        WhatsApp fora do ciclo request/response (ex: resultado de uma
+        ferramenta que ficou pendente de aprovação no Telegram)."""
+        self._notifier = fn
+
     def get_session(self, chat_id: str) -> ChatSession:
         """Obtém ou cria sessão de chat"""
         if chat_id not in self.sessions:
@@ -968,6 +1044,121 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
         owner_clean = OWNER_NUMBER.replace("55", "", 1) if OWNER_NUMBER.startswith("55") else OWNER_NUMBER
         return clean_number == owner_clean or number == OWNER_NUMBER or number == owner_clean
     
+    @staticmethod
+    def _format_tool_result(result: Any) -> str:
+        """Formata o resultado de uma ferramenta pra mensagem WhatsApp (JSON
+        compacto, truncado — sem round-trip extra no modelo pra sintetizar
+        texto natural, mantendo o caminho simples)."""
+        try:
+            text = json.dumps(result, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            text = str(result)
+        if len(text) > 1500:
+            text = text[:1500] + "… (truncado)"
+        return f"```\n{text}\n```"
+
+    async def _await_gated_tool(self, intent_id: str, tool_name: str, kwargs: dict, chat_id: str) -> None:
+        """Tarefa de fundo: aguarda aprovação (Telegram) e notifica o WhatsApp
+        com o resultado, seja qual for o desfecho (nunca deixa o usuário sem
+        resposta)."""
+
+        async def on_resolved(status: str, result: Any) -> None:
+            if status == "approved":
+                text = f"✅ Aprovado — executei `{tool_name}`.\n\n{self._format_tool_result(result)}"
+            elif status == "rejected":
+                text = f"❌ Ação `{tool_name}` foi rejeitada no Telegram. Não fiz nada."
+            elif status == "expired":
+                text = f"⌛ A aprovação de `{tool_name}` expirou sem resposta. Manda de novo se ainda quiser."
+            else:
+                text = f"⚠️ Deu erro tentando executar `{tool_name}` após aprovação: {result}"
+
+            if self._notifier is None:
+                logger.warning("Notifier não configurado — não consegui avisar %s sobre %s", chat_id, intent_id)
+                return
+            try:
+                await self._notifier(chat_id, text)
+            except Exception:
+                logger.exception("Falha ao notificar %s sobre intent_id=%s", chat_id, intent_id)
+
+        await mcp_tool_bridge.await_and_execute(intent_id, tool_name, kwargs, on_resolved)
+
+    async def _process_with_tools(
+        self,
+        messages: List[Dict[str, Any]],
+        model: str,
+        system_prompt: str,
+        chat_id: str,
+    ) -> str:
+        """Loop de tool-calling para o modelo com fine-tune de ferramentas
+        MCP (TOOL_CALLING_MODEL). Ferramentas seguras (`none`/`low`) executam
+        na hora; ferramentas com efeito colateral são travadas via governança
+        (intent_declare + aprovação Telegram) — ver mcp_tool_bridge.py.
+        """
+        tools = mcp_tool_bridge.build_ollama_tool_schemas()
+        working_messages = list(messages)
+
+        for _round in range(MAX_TOOL_ROUNDS):
+            content, tool_calls = await self.ollama.chat_with_tools(
+                working_messages, model=model, system=system_prompt, tools=tools,
+            )
+            if not tool_calls:
+                return content
+
+            working_messages.append({
+                "role": "assistant",
+                "content": content,
+                "tool_calls": tool_calls,
+            })
+
+            for call in tool_calls:
+                fn = call.get("function", {}) if isinstance(call, dict) else {}
+                tool_name = fn.get("name", "")
+                raw_args = fn.get("arguments") or {}
+                if isinstance(raw_args, str):
+                    try:
+                        kwargs = json.loads(raw_args)
+                    except json.JSONDecodeError:
+                        kwargs = {}
+                else:
+                    kwargs = raw_args
+
+                if not tool_name:
+                    continue
+
+                if mcp_tool_bridge.is_gated(tool_name):
+                    description = (
+                        f"Modelo {model} (self-chat WhatsApp) pediu para chamar "
+                        f"'{tool_name}' com argumentos {kwargs}"
+                    )
+                    try:
+                        intent_id = mcp_tool_bridge.declare_gate(tool_name, kwargs, description)
+                    except Exception as exc:
+                        logger.exception("Falha ao declarar intent para %s", tool_name)
+                        return f"⚠️ Não consegui pedir aprovação para `{tool_name}`: {exc}"
+
+                    asyncio.create_task(self._await_gated_tool(intent_id, tool_name, kwargs, chat_id))
+                    # Encerra o turno aqui — não tenta continuar a conversa de
+                    # forma síncrona enquanto a aprovação está pendente.
+                    return (
+                        f"🔒 Ação `{tool_name}` requer sua aprovação — te aviso no "
+                        "Telegram assim que for decidido."
+                    )
+
+                try:
+                    result = mcp_tool_bridge.execute_safe(tool_name, kwargs)
+                except Exception as exc:
+                    logger.exception("Erro executando ferramenta segura '%s'", tool_name)
+                    result = {"ok": False, "error": str(exc)}
+
+                working_messages.append({
+                    "role": "tool",
+                    "content": json.dumps(result, ensure_ascii=False, default=str),
+                    "name": tool_name,
+                })
+
+        logger.warning("Loop de tool-calling excedeu MAX_TOOL_ROUNDS=%s", MAX_TOOL_ROUNDS)
+        return "Desculpa, não consegui concluir isso a tempo (muitas chamadas de ferramenta seguidas)."
+
     async def process_message(self, message: WhatsAppMessage) -> str:
         """Processa uma mensagem e gera resposta"""
         # Ignorar mensagens próprias, EXCETO se for mensagem para si mesmo (Notes to Self)
@@ -988,7 +1179,17 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
         command_response = await self.handle_command(message)
         if command_response:
             return command_response
-        
+
+        # Resolve cedo se essa mensagem vai pro modelo com tool-calling real
+        # (shared-homelab) — se sim, pula o atalho de "relatório" hardcoded
+        # abaixo e deixa o próprio modelo decidir, chamando as ferramentas
+        # MCP reais (trading_summary/trading_performance/etc.) com os
+        # parâmetros que ele julgar certos, em vez de um template fixo com
+        # dados de uma fonte errada/desatualizada.
+        _sender_number = message.sender.split("@")[0]
+        _sender_clean = _sender_number.replace("55", "", 1) if _sender_number.startswith("55") else _sender_number
+        _will_use_tool_calling = MCP_TOOLS_AVAILABLE and PHONE_MODEL_MAPPING.get(_sender_clean) == TOOL_CALLING_MODEL
+
         # === VERIFICAR INTENÇÃO DE CALENDÁRIO ===
         if CALENDAR_AVAILABLE:
             calendar_response = await process_calendar_request(message.text, message.chat_id)
@@ -1026,7 +1227,7 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
                     return home_response
 
         # === VERIFICAR INTENÇÃO DE RELATÓRIO ===
-        if REPORTS_AVAILABLE:
+        if REPORTS_AVAILABLE and not _will_use_tool_calling:
             text_lower = message.text.lower()
             report_keywords = [
                 'relatório', 'relatorio', 'report', 'status',
@@ -1076,10 +1277,18 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
         system_prompt = self.get_system_prompt(session.current_profile, is_owner)
 
         await self.refresh_session_summary(session, model)
-        
+
         # Preparar mensagens para o modelo
         messages = session.get_history()
-        
+
+        if model == TOOL_CALLING_MODEL and MCP_TOOLS_AVAILABLE:
+            response = await self._process_with_tools(messages, model, system_prompt, message.chat_id)
+            self.db.save_message(
+                message.chat_id, WHATSAPP_PHONE_ID, "assistant", response, message.is_group,
+            )
+            session.add_message("assistant", response)
+            return response
+
         # Primeira tentativa de resposta
         response = await self.ollama.chat_validated(
             messages,
@@ -1088,7 +1297,7 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
             validator=self._response_validator,
             max_attempts=2,
         )
-        
+
         # Se detectar incapacidade, tentar com busca web
         if self.detect_inability(response) and self.search_engine:
             logger.info(f"Incapacidade detectada, buscando na web: {message.text}")
@@ -1701,7 +1910,12 @@ async def main():
     # URL do WAHA/Evolution API (configurar conforme sua instalação)
     waha_url = os.getenv("WAHA_URL", "http://localhost:3000")
     waha = WAHAClient(base_url=waha_url, session="default")
-    
+
+    # Permite que tarefas de fundo (aprovação de ferramenta MCP travada)
+    # mandem uma mensagem WhatsApp minutos depois, fora do request/response
+    # do webhook. Ver WhatsAppBot._await_gated_tool.
+    bot.set_notifier(waha.send_text)
+
     # Iniciar servidor webhook
     webhook = WebhookServer(bot, waha, port=5001)
     

--- a/tests/test_mcp_tool_bridge.py
+++ b/tests/test_mcp_tool_bridge.py
@@ -1,0 +1,217 @@
+"""Testes do mcp_tool_bridge — geração de schema, classificação de risco e,
+principalmente, o invariante de que ferramentas travadas nunca executam
+antes de uma aprovação (`status == "approved"`)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "mcp_tool_bridge.py"
+
+
+def _load_bridge():
+    module_name = "mcp_tool_bridge_for_tests"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bridge = _load_bridge()
+
+
+# ── Descoberta de ferramentas / schema ──────────────────────────────────────
+
+
+def test_discovers_36_tools_including_excluded():
+    names = bridge.discovered_tool_names(include_excluded=True)
+    assert len(names) == 36, sorted(names)
+
+
+def test_excludes_governance_tools_from_model_visible_set():
+    names = bridge.discovered_tool_names(include_excluded=False)
+    assert names.isdisjoint(bridge.EXCLUDED_TOOLS)
+    assert len(names) == 36 - len(bridge.EXCLUDED_TOOLS)
+
+
+def test_schema_generation_matches_visible_tools():
+    schemas = bridge.build_ollama_tool_schemas()
+    names = {s["function"]["name"] for s in schemas}
+    assert names == bridge.discovered_tool_names(include_excluded=False)
+    for s in schemas:
+        assert s["type"] == "function"
+        assert "parameters" in s["function"]
+        assert s["function"]["parameters"].get("type") == "object"
+
+
+def test_schema_includes_known_tool_with_correct_params():
+    schemas = {s["function"]["name"]: s for s in bridge.build_ollama_tool_schemas()}
+    secrets_get = schemas["secrets_get"]
+    props = secrets_get["function"]["parameters"]["properties"]
+    assert "name" in props
+    assert "name" in secrets_get["function"]["parameters"]["required"]
+
+    trading_summary = schemas["trading_summary"]
+    props = trading_summary["function"]["parameters"]["properties"]
+    assert "symbol" in props and "profile" in props
+    # symbol/profile têm default -> não obrigatórios
+    assert trading_summary["function"]["parameters"].get("required", []) == []
+
+
+# ── Tabela de risco ──────────────────────────────────────────────────────
+
+
+def test_tool_risk_table_exactly_matches_discovered_visible_tools():
+    """Guarda de regressão: se homelab_mcp_server.py ganhar/perder ferramenta,
+    este teste falha até alguém classificar/limpar TOOL_RISK explicitamente."""
+    discovered = bridge.discovered_tool_names(include_excluded=False)
+    classified = set(bridge.TOOL_RISK.keys())
+    assert discovered == classified, (
+        f"Descobertas mas não classificadas: {discovered - classified}; "
+        f"Classificadas mas não existem mais: {classified - discovered}"
+    )
+
+
+def test_classify_unknown_tool_defaults_to_high(caplog):
+    assert bridge.classify("tool_que_nao_existe_ainda") == "high"
+
+
+@pytest.mark.parametrize(
+    "tool_name,expected",
+    [
+        ("secrets_get", "critical"),
+        ("secrets_list", "high"),
+        ("db_execute_query", "high"),
+        ("bus_publish", "high"),
+        ("memory_store", "low"),
+        ("memory_search", "none"),
+        ("trading_summary", "none"),
+        ("db_list_tables", "none"),
+    ],
+)
+def test_classify_known_tools(tool_name, expected):
+    assert bridge.classify(tool_name) == expected
+
+
+@pytest.mark.parametrize(
+    "tool_name,expected_gated",
+    [
+        ("secrets_get", True),
+        ("db_execute_query", True),
+        ("memory_store", False),
+        ("trading_summary", False),
+    ],
+)
+def test_is_gated(tool_name, expected_gated):
+    assert bridge.is_gated(tool_name) is expected_gated
+
+
+# ── Execução segura ──────────────────────────────────────────────────────
+
+
+def test_execute_safe_calls_underlying_function_and_parses_json():
+    mod = bridge._load_mcp_module()
+    with patch.object(mod, "db_list_tables", return_value=json.dumps({"ok": True, "rows": []})) as fake:
+        result = bridge.execute_safe("db_list_tables", {})
+    fake.assert_called_once_with()
+    assert result == {"ok": True, "rows": []}
+
+
+def test_execute_safe_refuses_gated_tool():
+    with pytest.raises(ValueError):
+        bridge.execute_safe("secrets_get", {"name": "eddie/foo"})
+
+
+# ── Caminho travado: nunca executa antes de aprovado (teste mais importante) ──
+
+
+def test_gated_tool_never_executes_before_approval():
+    """Se a aprovação nunca chega (fica sempre 'pending'), a ferramenta real
+    jamais é chamada e o bridge resolve como 'expired' ao estourar o timeout."""
+    mod = bridge._load_mcp_module()
+    calls: list[tuple[str, object]] = []
+
+    async def on_resolved(status, result):
+        calls.append((status, result))
+
+    with patch.object(mod, "secrets_get") as fake_secrets_get, \
+         patch.object(mod, "intent_check_status", return_value=json.dumps({"ok": True, "status": "pending"})), \
+         patch.object(bridge.asyncio, "sleep", new=AsyncMock(return_value=None)):
+        asyncio.run(
+            bridge.await_and_execute(
+                "intent-x", "secrets_get", {"name": "eddie/foo"}, on_resolved,
+                max_wait_seconds=0.001,
+            )
+        )
+
+    fake_secrets_get.assert_not_called()
+    assert calls and calls[0][0] == "expired"
+
+
+def test_gated_tool_executes_only_after_approved():
+    mod = bridge._load_mcp_module()
+    calls: list[tuple[str, object]] = []
+
+    async def on_resolved(status, result):
+        calls.append((status, result))
+
+    statuses = iter([
+        json.dumps({"ok": True, "status": "pending"}),
+        json.dumps({"ok": True, "status": "approved"}),
+    ])
+
+    with patch.object(mod, "secrets_get", return_value=json.dumps({"ok": True, "value": "shh"})) as fake_secrets_get, \
+         patch.object(mod, "intent_check_status", side_effect=lambda intent_id: next(statuses)), \
+         patch.object(mod, "intent_complete", return_value=json.dumps({"ok": True})) as fake_complete:
+
+        async def run():
+            await bridge.await_and_execute(
+                "intent-y", "secrets_get", {"name": "eddie/foo"}, on_resolved,
+            )
+
+        # backoff schedule começa em 5s; patch pra teste não esperar de verdade
+        with patch.object(bridge.asyncio, "sleep", new=AsyncMock(return_value=None)):
+            asyncio.run(run())
+
+    fake_secrets_get.assert_called_once_with(name="eddie/foo")
+    fake_complete.assert_called_once()
+    assert calls == [("approved", {"ok": True, "value": "shh"})]
+
+
+def test_gated_tool_rejected_never_executes():
+    mod = bridge._load_mcp_module()
+    calls: list[tuple[str, object]] = []
+
+    async def on_resolved(status, result):
+        calls.append((status, result))
+
+    with patch.object(mod, "secrets_get") as fake_secrets_get, \
+         patch.object(mod, "intent_check_status", return_value=json.dumps({"ok": True, "status": "rejected"})):
+        asyncio.run(bridge.await_and_execute("intent-z", "secrets_get", {"name": "eddie/foo"}, on_resolved))
+
+    fake_secrets_get.assert_not_called()
+    assert calls == [("rejected", None)]
+
+
+def test_declare_gate_uses_classified_risk_level():
+    mod = bridge._load_mcp_module()
+    with patch.object(
+        mod, "intent_declare",
+        return_value=json.dumps({"ok": True, "intent_id": "intent-abc", "status": "pending"}),
+    ) as fake_declare:
+        intent_id = bridge.declare_gate("secrets_get", {"name": "eddie/foo"}, "quer ler um segredo")
+    assert intent_id == "intent-abc"
+    _, kwargs = fake_declare.call_args
+    assert kwargs["risk_level"] == "critical"
+    assert kwargs["target"] == "secrets_get"

--- a/tests/test_whatsapp_bot_tool_calls.py
+++ b/tests/test_whatsapp_bot_tool_calls.py
@@ -1,0 +1,244 @@
+"""Testes do tool-calling do WhatsApp bot (OllamaClient.chat_with_tools e
+WhatsAppBot._process_with_tools) — segue o padrão de importlib+stub de
+tests/test_whatsapp_context_summary.py."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "whatsapp_bot.py"
+
+
+def _load_module():
+    module_name = "whatsapp_bot_for_tests"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+
+    fake_psycopg2 = types.ModuleType("psycopg2")
+    fake_extras = types.ModuleType("psycopg2.extras")
+    fake_pool = types.ModuleType("psycopg2.pool")
+    fake_aiohttp = types.ModuleType("aiohttp")
+
+    class _FakePool:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_extras.RealDictCursor = object
+    fake_pool.SimpleConnectionPool = _FakePool
+    fake_aiohttp.web = types.SimpleNamespace()
+
+    sys.modules.setdefault("psycopg2", fake_psycopg2)
+    sys.modules.setdefault("psycopg2.extras", fake_extras)
+    sys.modules.setdefault("psycopg2.pool", fake_pool)
+    sys.modules.setdefault("aiohttp", fake_aiohttp)
+
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+# ── OllamaClient.chat_with_tools ─────────────────────────────────────────
+
+
+def test_chat_with_tools_sends_tools_and_parses_tool_calls():
+    wb = _load_module()
+    client = object.__new__(wb.OllamaClient)
+    client.host = "http://fake-ollama"
+
+    captured = {}
+
+    async def fake_post(url, json):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(200, {
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "trading_summary", "arguments": {"symbol": "BTC-USDT"}}}
+                ],
+            }
+        })
+
+    client.client = types.SimpleNamespace(post=fake_post)
+    schema = [{"type": "function", "function": {"name": "trading_summary", "parameters": {}}}]
+
+    content, tool_calls = asyncio.run(
+        client.chat_with_tools([{"role": "user", "content": "resume o trading"}], model="shared-homelab", tools=schema)
+    )
+
+    assert captured["json"]["tools"] == schema
+    assert content == ""
+    assert tool_calls == [{"function": {"name": "trading_summary", "arguments": {"symbol": "BTC-USDT"}}}]
+
+
+def test_chat_with_tools_no_tool_calls_returns_empty_list():
+    wb = _load_module()
+    client = object.__new__(wb.OllamaClient)
+    client.host = "http://fake-ollama"
+
+    async def fake_post(url, json):
+        return _FakeResponse(200, {"message": {"content": "Bom dia!"}})
+
+    client.client = types.SimpleNamespace(post=fake_post)
+
+    content, tool_calls = asyncio.run(
+        client.chat_with_tools([{"role": "user", "content": "oi"}], model="shared-homelab")
+    )
+    assert content == "Bom dia!"
+    assert tool_calls == []
+
+
+def test_chat_with_tools_http_error():
+    wb = _load_module()
+    client = object.__new__(wb.OllamaClient)
+    client.host = "http://fake-ollama"
+
+    async def fake_post(url, json):
+        return _FakeResponse(500, {})
+
+    client.client = types.SimpleNamespace(post=fake_post)
+
+    content, tool_calls = asyncio.run(client.chat_with_tools([], model="shared-homelab"))
+    assert "Erro" in content
+    assert tool_calls == []
+
+
+# ── WhatsAppBot._process_with_tools ──────────────────────────────────────
+
+
+def _make_bot(wb):
+    bot = object.__new__(wb.WhatsAppBot)
+    bot._notifier = None
+    return bot
+
+
+def test_process_with_tools_executes_safe_tool_then_returns_final_content():
+    wb = _load_module()
+    bot = _make_bot(wb)
+
+    calls = []
+
+    async def fake_chat_with_tools(messages, model, system, tools):
+        calls.append(list(messages))
+        if len(calls) == 1:
+            return "", [{"function": {"name": "trading_summary", "arguments": {"symbol": "BTC-USDT"}}}]
+        return "O trading está indo bem.", []
+
+    bot.ollama = types.SimpleNamespace(chat_with_tools=fake_chat_with_tools)
+
+    with patch.object(wb.mcp_tool_bridge, "build_ollama_tool_schemas", return_value=[]), \
+         patch.object(wb.mcp_tool_bridge, "is_gated", return_value=False), \
+         patch.object(wb.mcp_tool_bridge, "execute_safe", return_value={"ok": True, "symbol": "BTC-USDT"}) as fake_exec, \
+         patch.object(wb.mcp_tool_bridge, "declare_gate") as fake_declare:
+
+        response = asyncio.run(
+            bot._process_with_tools(
+                [{"role": "user", "content": "resume o trading"}],
+                "shared-homelab", "system prompt", "5511981193899@c.us",
+            )
+        )
+
+    fake_exec.assert_called_once_with("trading_summary", {"symbol": "BTC-USDT"})
+    fake_declare.assert_not_called()
+    assert response == "O trading está indo bem."
+    # segunda chamada ao modelo deve incluir a mensagem role=tool com o resultado
+    tool_messages = [m for m in calls[1] if m.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert "BTC-USDT" in tool_messages[0]["content"]
+
+
+def test_process_with_tools_no_tool_call_returns_content_immediately():
+    wb = _load_module()
+    bot = _make_bot(wb)
+
+    async def fake_chat_with_tools(messages, model, system, tools):
+        return "Bom dia! Como posso ajudar?", []
+
+    bot.ollama = types.SimpleNamespace(chat_with_tools=fake_chat_with_tools)
+
+    with patch.object(wb.mcp_tool_bridge, "build_ollama_tool_schemas", return_value=[]):
+        response = asyncio.run(
+            bot._process_with_tools([{"role": "user", "content": "bom dia"}], "shared-homelab", "sys", "chat-1")
+        )
+
+    assert response == "Bom dia! Como posso ajudar?"
+
+
+def test_process_with_tools_gated_tool_declares_intent_and_spawns_task_without_executing():
+    """O teste mais importante deste arquivo: ferramenta arriscada nunca é
+    executada de dentro do loop — só é declarada e delegada a uma task de
+    fundo; o turno atual só devolve o ack de aprovação pendente."""
+    wb = _load_module()
+    bot = _make_bot(wb)
+
+    async def fake_chat_with_tools(messages, model, system, tools):
+        return "", [{"function": {"name": "secrets_get", "arguments": {"name": "eddie/foo"}}}]
+
+    bot.ollama = types.SimpleNamespace(chat_with_tools=fake_chat_with_tools)
+
+    created_tasks = []
+
+    def fake_create_task(coro):
+        created_tasks.append(coro)
+        coro.close()  # evita "coroutine was never awaited"; não queremos rodar de verdade
+        return object()
+
+    with patch.object(wb.mcp_tool_bridge, "build_ollama_tool_schemas", return_value=[]), \
+         patch.object(wb.mcp_tool_bridge, "is_gated", return_value=True), \
+         patch.object(wb.mcp_tool_bridge, "execute_safe") as fake_exec_safe, \
+         patch.object(wb.mcp_tool_bridge, "declare_gate", return_value="intent-abc") as fake_declare, \
+         patch.object(wb.asyncio, "create_task", side_effect=fake_create_task):
+
+        response = asyncio.run(
+            bot._process_with_tools(
+                [{"role": "user", "content": "me mostra o segredo eddie/foo"}],
+                "shared-homelab", "sys", "5511981193899@c.us",
+            )
+        )
+
+    fake_exec_safe.assert_not_called()
+    fake_declare.assert_called_once()
+    assert fake_declare.call_args[0][0] == "secrets_get"
+    assert len(created_tasks) == 1
+    assert "requer sua aprovação" in response
+    assert "secrets_get" in response
+
+
+def test_process_with_tools_stops_after_max_rounds():
+    wb = _load_module()
+    bot = _make_bot(wb)
+
+    async def always_calls_tool(messages, model, system, tools):
+        return "", [{"function": {"name": "trading_summary", "arguments": {}}}]
+
+    bot.ollama = types.SimpleNamespace(chat_with_tools=always_calls_tool)
+
+    with patch.object(wb.mcp_tool_bridge, "build_ollama_tool_schemas", return_value=[]), \
+         patch.object(wb.mcp_tool_bridge, "is_gated", return_value=False), \
+         patch.object(wb.mcp_tool_bridge, "execute_safe", return_value={"ok": True}), \
+         patch.object(wb, "MAX_TOOL_ROUNDS", 2):
+
+        response = asyncio.run(
+            bot._process_with_tools([{"role": "user", "content": "oi"}], "shared-homelab", "sys", "chat-1")
+        )
+
+    assert "não consegui concluir" in response.lower()


### PR DESCRIPTION
## Resumo
- `scripts/misc/mcp_tool_bridge.py` (novo): importa `homelab_mcp_server.py` em processo, gera schema de function-calling do Ollama por introspecção, classifica risco por ferramenta, executa na hora as seguras e trava as arriscadas via governança existente (`intent_declare` + aprovação Telegram).
- `scripts/misc/whatsapp_bot.py`: `OllamaClient.chat_with_tools()` + loop de tool-calling em `process_message`, ativo só pra `model == "shared-homelab"`. Ferramenta travada dispara task de fundo que aguarda aprovação e manda 2ª mensagem WhatsApp com o resultado.
- Pra esse modelo, o atalho hardcoded de "relatório" (`reports_integration.py`, que lia SQLite inexistente e sempre devolvia zero/simulado) é pulado — o modelo busca dados reais via `trading_summary`/`trading_performance` autonomamente.

## Test plan
- [x] `tests/test_mcp_tool_bridge.py` (24 testes) + `tests/test_whatsapp_bot_tool_calls.py` (7 testes) — inclui o invariante de que ferramenta travada nunca executa antes de aprovada.
- [x] `mcp`/`requests` já instalados no host; `DATABASE_URL` já resolve pro schema `btc.*` real; `approval-gateway.service` já ativo com `agent_actions`/`agent_audit_log` existentes.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)