### PR TITLE
fix(finetune): schema reduzido evita OOM no treino de tool-calling

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T17:13:00.969157+00:00",
-  "repo_root": "/tmp/wb-finetune-pipeline",
+  "generated_at": "2026-07-29T17:30:49.575118+00:00",
+  "repo_root": "/tmp/wb-finetune-fix",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T17:13:00.969157+00:00`
+- Generated at: `2026-07-29T17:30:49.575118+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `191`

--- a/docs/variables-taxonomy/FT_FINETUNE_PIPELINE.md
+++ b/docs/variables-taxonomy/FT_FINETUNE_PIPELINE.md
@@ -1,0 +1,33 @@
+# FT_* (pipeline de fine-tuning QLoRA)
+
+## Propósito
+Família de variáveis de configuração dos scripts de fine-tuning QLoRA (transformers+peft+bitsandbytes, sem unsloth) do repo. Todas têm defaults sensatos embutidos no código — só precisam ser setadas para desviar do padrão.
+
+## Consumidores
+- `scripts/trading_analyst_finetune_peft.py` (original — trading-analyst)
+- `scripts/whatsapp_toolcall_finetune_peft.py` (fork — tool-calling MCP do `shared-homelab`, 2026-07-29)
+
+## Variáveis
+
+| Nome | Tipo | Default | Descrição |
+|---|---|---|---|
+| `FT_BASE_MODEL_HF` | string | `unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit` | Repo HF do modelo base pré-quantizado 4-bit |
+| `FT_DATASET_DIR` | path | varia por script | Diretório com os JSONL de treino |
+| `FT_DATASET_FILE` | string | `whatsapp_toolcall_train.jsonl` | Nome do arquivo JSONL de treino (só no fork de tool-calling — o original usa múltiplos arquivos por `call_type`) |
+| `FT_OUTPUT_DIR` | path | varia por script | Diretório de saída (adapter LoRA + modelo merged) |
+| `FT_MAX_SEQ` | int | `2048` | Tamanho máximo de sequência na tokenização |
+| `FT_EPOCHS` | float | `2` | Épocas de treino |
+| `FT_BATCH` | int | `1` | Batch size por device |
+| `FT_GRAD_ACCUM` | int | `8` | Passos de gradient accumulation |
+| `FT_LORA_RANK` | int | `16` | Rank do LoRA |
+| `FT_LORA_ALPHA` | int | `32` | Alpha do LoRA |
+| `FT_LR` | float | `2e-4` | Learning rate |
+| `FT_WARMUP` | int | `10` | Passos de warmup |
+| `FT_MIN_SAMPLES` | int | `120` (trading) / `800` (tool-calling) | Piso de exemplos no dataset antes de liberar treino |
+| `FT_TOOLS_PER_EXAMPLE` | int | `6` (só tool-calling) | Quantas ferramentas incluir no schema de cada exemplo de treino (a certa + distratoras) em vez das 33 completas — a schema completa sozinha já custa ~4.8k tokens (medido em produção), maior que qualquer `FT_MAX_SEQ` viável nesta GPU (RTX 3060 12GB estoura memória no cast fp32 dos logits do llama3.1, vocab=128k). Em produção o Ollama continua recebendo o schema completo; o modelo só precisa aprender o padrão de selecionar a ferramenta certa dentro do que for oferecido. |
+
+## Nota sobre o scanner automático
+`tools/catalog_variables.py` só varre arquivos Python com nome `*config*`/`*settings*` — nenhum dos dois scripts acima bate esse padrão, então essas variáveis nunca são descobertas automaticamente pelo scanner apesar de serem reais e usadas em produção. Catalogadas manualmente aqui.
+
+## Relacionadas
+- [[HOMELAB_URL]], [[API_BASE_URL]]

--- a/scripts/whatsapp_toolcall_finetune_peft.py
+++ b/scripts/whatsapp_toolcall_finetune_peft.py
@@ -30,6 +30,7 @@ import argparse
 import json
 import logging
 import os
+import random
 import sys
 from pathlib import Path
 
@@ -51,7 +52,7 @@ MERGED_OUTPUT = OUTPUT_DIR / "merged_model"
 
 DATASET_FILE = os.environ.get("FT_DATASET_FILE", "whatsapp_toolcall_train.jsonl")
 
-MAX_SEQ_LENGTH = int(os.environ.get("FT_MAX_SEQ", "3072"))  # schemas de tool ocupam mais contexto
+MAX_SEQ_LENGTH = int(os.environ.get("FT_MAX_SEQ", "2048"))
 EPOCHS = float(os.environ.get("FT_EPOCHS", "2"))
 BATCH_SIZE = int(os.environ.get("FT_BATCH", "1"))
 GRAD_ACCUM = int(os.environ.get("FT_GRAD_ACCUM", "8"))
@@ -60,6 +61,9 @@ LORA_ALPHA = int(os.environ.get("FT_LORA_ALPHA", "32"))
 LR = float(os.environ.get("FT_LR", "2e-4"))
 WARMUP = int(os.environ.get("FT_WARMUP", "10"))
 MIN_SAMPLES = int(os.environ.get("FT_MIN_SAMPLES", "800"))
+# Quantas ferramentas incluir no schema de CADA exemplo de treino (a certa +
+# distratoras) em vez das 33 completas — ver comentário em to_text().
+TOOLS_PER_EXAMPLE = int(os.environ.get("FT_TOOLS_PER_EXAMPLE", "6"))
 
 # Versão condensada da persona homelab — a instrução detalhada de
 # tool-calling propriamente dita fica embutida nos pesos pelo treino, não
@@ -71,6 +75,26 @@ SYSTEM = (
     "chame a ferramenta certa em vez de inventar a resposta. Para conversa "
     "normal, responda direto em português, sem chamar ferramenta nenhuma."
 )
+
+
+def _subset_schema(all_schemas: list[dict], ex: dict, k: int, rng: "random.Random") -> list[dict]:
+    """Monta um schema reduzido para um exemplo: a(s) ferramenta(s) realmente
+    chamada(s) (ou mencionada(s) no near-miss) + distratoras aleatórias até
+    completar `k`. Determinístico dado o mesmo `rng` (chamado em ordem fixa
+    pelos exemplos, já que `random.Random(42)` é recriado uma vez por run)."""
+    required_names = {tc["function"]["name"] for tc in (ex.get("tool_calls") or [])}
+    near_miss = ex.get("near_miss_of")
+    if near_miss:
+        required_names.add(near_miss)
+
+    required = [s for s in all_schemas if s["function"]["name"] in required_names]
+    others = [s for s in all_schemas if s["function"]["name"] not in required_names]
+    rng.shuffle(others)
+
+    fill = max(0, k - len(required))
+    subset = required + others[:fill]
+    rng.shuffle(subset)
+    return subset
 
 
 def load_examples(dataset_dir: Path, filename: str) -> list[dict]:
@@ -158,10 +182,22 @@ def train(dry_run: bool, do_merge: bool) -> int:
     ))
     model.print_trainable_parameters()
 
-    def to_text(ex: dict) -> str:
+    def to_text(ex: dict, rng: "random.Random") -> str:
         user = (ex["instruction"] + (ex.get("input") or "")).strip()
         tool_calls = ex.get("tool_calls") or []
         tool_result = ex.get("tool_result")
+
+        # Schema reduzido por exemplo: a schema completa das 33 ferramentas
+        # sozinha já custa ~4.8k tokens (medido: apply_chat_template com as
+        # 33 definições) — maior que qualquer MAX_SEQ que cabe nesta GPU
+        # (RTX 3060 12GB fica sem memória no cast fp32 dos logits do llama3.1,
+        # vocab=128k, antes mesmo de chegar no texto do exemplo). Em vez de
+        # ensinar as 33 de uma vez, cada exemplo vê a(s) ferramenta(s) certa(s)
+        # + algumas distratoras aleatórias — ensina a discriminar sem estourar
+        # o orçamento de contexto. Em produção o Ollama continua recebendo o
+        # schema completo (tools= com as 33) — o modelo só precisa aprender o
+        # PADRÃO de selecionar a ferramenta certa dentro do que for oferecido.
+        example_schema = _subset_schema(tool_schemas, ex, k=TOOLS_PER_EXAMPLE, rng=rng)
 
         messages = [{"role": "system", "content": SYSTEM}, {"role": "user", "content": user}]
 
@@ -181,9 +217,10 @@ def train(dry_run: bool, do_merge: bool) -> int:
             # negativo/near-miss: resposta conversacional normal, sem tool_calls
             messages.append({"role": "assistant", "content": ex.get("output") or "Certo."})
 
-        return tokenizer.apply_chat_template(messages, tools=tool_schemas or None, tokenize=False)
+        return tokenizer.apply_chat_template(messages, tools=example_schema or None, tokenize=False)
 
-    texts = [to_text(ex) for ex in examples]
+    _rng = random.Random(42)
+    texts = [to_text(ex, _rng) for ex in examples]
     ds = Dataset.from_dict({"text": texts})
 
     def tokenize(batch: dict) -> dict:


### PR DESCRIPTION
Medido em produção: 33 ferramentas completas custam ~4.8k tokens sozinhas (maior que qualquer FT_MAX_SEQ viável na RTX 3060) — causava CUDA OOM no cast fp32 dos logits do llama3.1 logo no primeiro passo de treino. Cada exemplo agora usa a ferramenta certa + distratoras (default 6 no total) em vez das 33.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)