### PR TITLE
feat(finetune): treino em pacotes de 10min/h para não segurar a GPU de produção

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-07-29T17:30:49.575118+00:00",
-  "repo_root": "/tmp/wb-finetune-fix",
+  "generated_at": "2026-07-29T17:59:08.880540+00:00",
+  "repo_root": "/tmp/wb-chunked",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 191,
+    "repo_services": 193,
     "trading_instances": 12,
     "critical_services": 76,
     "domains": {
       "identity": 4,
       "monitoring": 18,
       "network": 22,
-      "operations": 104,
+      "operations": 106,
       "storage": 32,
       "trading": 11
     }
@@ -1354,6 +1354,22 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/tuya-token-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T17:30:49.575118+00:00`
+- Generated at: `2026-07-29T17:59:08.880540+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `191`
+- Repo services discovered: `193`
 - Critical services flagged for MVP: `76`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 18
 - `network`: 22
-- `operations`: 104
+- `operations`: 106
 - `storage`: 32
 - `trading`: 11
 

--- a/docs/variables-taxonomy/FT_FINETUNE_PIPELINE.md
+++ b/docs/variables-taxonomy/FT_FINETUNE_PIPELINE.md
@@ -25,6 +25,15 @@ Família de variáveis de configuração dos scripts de fine-tuning QLoRA (trans
 | `FT_WARMUP` | int | `10` | Passos de warmup |
 | `FT_MIN_SAMPLES` | int | `120` (trading) / `800` (tool-calling) | Piso de exemplos no dataset antes de liberar treino |
 | `FT_TOOLS_PER_EXAMPLE` | int | `6` (só tool-calling) | Quantas ferramentas incluir no schema de cada exemplo de treino (a certa + distratoras) em vez das 33 completas — a schema completa sozinha já custa ~4.8k tokens (medido em produção), maior que qualquer `FT_MAX_SEQ` viável nesta GPU (RTX 3060 12GB estoura memória no cast fp32 dos logits do llama3.1, vocab=128k). Em produção o Ollama continua recebendo o schema completo; o modelo só precisa aprender o padrão de selecionar a ferramenta certa dentro do que for oferecido. |
+| `FT_TIME_BUDGET_SECONDS` | int | `0` = sem limite (`600` no systemd) | Orçamento de tempo de parede de UM pacote de treino. Ao estourar, salva checkpoint e sai com sucesso; a invocação seguinte retoma do último checkpoint. Existe porque a GPU de treino é a mesma do Ollama de produção — treinar em pacotes de 10min de hora em hora evita segurar produção parada por ~7h seguidas. |
+| `FT_SAVE_STEPS` | int | `2` | Frequência de checkpoint (em passos) quando `FT_TIME_BUDGET_SECONDS` está ativo. Baixo de propósito: cada passo já leva dezenas de segundos nesta GPU, então precisa salvar cedo pra garantir progresso dentro de um pacote de 10min. |
+
+## Variáveis do orquestrador de pacotes (`scripts/whatsapp_toolcall_chunked_train.sh`)
+
+| Nome | Tipo | Default | Descrição |
+|---|---|---|---|
+| `WHATSAPP_TOOLCALL_REPO` | path | `/home/homelab/myClaude` | Checkout do repo no host de treino |
+| `WHATSAPP_TOOLCALL_FT_BASE` | path | `/home/homelab/finetune` | Raiz do ambiente de fine-tuning (venv, dados, saída) |
 
 ## Nota sobre o scanner automático
 `tools/catalog_variables.py` só varre arquivos Python com nome `*config*`/`*settings*` — nenhum dos dois scripts acima bate esse padrão, então essas variáveis nunca são descobertas automaticamente pelo scanner apesar de serem reais e usadas em produção. Catalogadas manualmente aqui.

--- a/scripts/whatsapp_toolcall_chunked_train.sh
+++ b/scripts/whatsapp_toolcall_chunked_train.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Treino QLoRA do shared-homelab em PACOTES CURTOS (default 10min, disparado
+# de hora em hora por systemd timer) em vez de uma tacada de ~7h.
+#
+# Motivação: o treino precisa da RTX 3060, que é a mesma GPU do Ollama de
+# produção (trading + bot WhatsApp). Segurar produção parada por horas não é
+# aceitável; segurar por 10min de hora em hora é. Cada invocação:
+#   1. para ollama+coordinator (libera a 3060)
+#   2. treina por FT_TIME_BUDGET_SECONDS, salvando checkpoint
+#   3. RELIGA ollama+coordinator (trap EXIT — sempre, mesmo em falha)
+#   4. sai; a próxima invocação retoma do último checkpoint
+#
+# Quando o treino termina (o trainer escreve TRAINING_COMPLETE no FT_OUTPUT_DIR),
+# este script desabilita o próprio timer e avisa no Telegram — não fica
+# reiniciando treino já concluído.
+#
+# Uso manual:
+#   scripts/whatsapp_toolcall_chunked_train.sh
+#   FT_TIME_BUDGET_SECONDS=300 scripts/whatsapp_toolcall_chunked_train.sh
+set -uo pipefail
+
+REPO="${WHATSAPP_TOOLCALL_REPO:-/home/homelab/myClaude}"
+BASE="${WHATSAPP_TOOLCALL_FT_BASE:-/home/homelab/finetune}"
+VENV="$BASE/env/bin/python"
+DATA_DIR="${FT_DATASET_DIR:-$BASE/data-toolcall}"
+OUT_DIR="${FT_OUTPUT_DIR:-$BASE/work-toolcall}"
+BUDGET="${FT_TIME_BUDGET_SECONDS:-600}"
+LOG="$OUT_DIR/chunked_train.log"
+TIMER_UNIT="whatsapp-toolcall-chunked-train.timer"
+
+mkdir -p "$OUT_DIR"
+exec >> >(tee -a "$LOG") 2>&1
+
+echo "=== [chunk] início $(date '+%F %T') orçamento=${BUDGET}s ==="
+
+send_telegram() {
+  local text="$1"
+  /usr/bin/python3 - "$text" <<'PY' || true
+import os, sys
+try:
+    import requests
+except ImportError:
+    sys.exit(0)
+token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+if not token or not chat_id:
+    sys.exit(0)
+requests.post(
+    f"https://api.telegram.org/bot{token}/sendMessage",
+    data={"chat_id": chat_id, "text": sys.argv[1], "parse_mode": "Markdown"},
+    timeout=15,
+)
+PY
+}
+
+restore_ollama() {
+  echo "--- [chunk] religando ollama+coordinator ---"
+  sudo systemctl start ollama.service 2>/dev/null || true
+  sleep 2
+  sudo systemctl start ollama-gpu-coordinator.service 2>/dev/null || true
+  local st_ollama st_coord
+  st_ollama="$(systemctl is-active ollama.service 2>/dev/null || true)"
+  st_coord="$(systemctl is-active ollama-gpu-coordinator.service 2>/dev/null || true)"
+  echo "--- [chunk] ollama=$st_ollama coordinator=$st_coord ---"
+  if [[ "$st_ollama" != "active" ]]; then
+    send_telegram "🚨 *Treino tool-calling*%0A%0AFalha ao religar ollama.service após o pacote de treino. Verificar manualmente no homelab."
+  fi
+}
+trap restore_ollama EXIT
+
+# Já terminou? Desliga o timer e sai (idempotente — timer pode disparar de novo
+# antes de alguém desabilitar na mão).
+if [[ -f "$OUT_DIR/TRAINING_COMPLETE" ]]; then
+  echo "[chunk] TRAINING_COMPLETE presente — nada a fazer; desabilitando timer."
+  sudo systemctl disable --now "$TIMER_UNIT" 2>/dev/null || true
+  exit 0
+fi
+
+if [[ ! -f "$DATA_DIR/whatsapp_toolcall_train.jsonl" ]]; then
+  echo "[chunk] ERRO: dataset ausente em $DATA_DIR — rode whatsapp_toolcall_dataset_builder.py antes."
+  exit 1
+fi
+
+echo "--- [chunk] pausando ollama+coordinator p/ liberar a 3060 ---"
+sudo systemctl stop ollama-gpu-coordinator.service 2>/dev/null || true
+sudo systemctl stop ollama.service 2>/dev/null || true
+sleep 4
+
+cd "$REPO" || exit 1
+FT_DATASET_DIR="$DATA_DIR" \
+FT_OUTPUT_DIR="$OUT_DIR" \
+FT_TIME_BUDGET_SECONDS="$BUDGET" \
+CUDA_VISIBLE_DEVICES=0 \
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  "$VENV" -u scripts/whatsapp_toolcall_finetune_peft.py --merge
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  echo "[chunk] treino saiu com código $rc"
+  send_telegram "⚠️ *Treino tool-calling*%0A%0APacote falhou (rc=$rc). Ver $LOG"
+  exit $rc
+fi
+
+if [[ -f "$OUT_DIR/TRAINING_COMPLETE" ]]; then
+  steps="$(cat "$OUT_DIR/TRAINING_COMPLETE" 2>/dev/null || echo '?')"
+  echo "[chunk] ✅ treino COMPLETO ($steps) — desabilitando timer."
+  sudo systemctl disable --now "$TIMER_UNIT" 2>/dev/null || true
+  send_telegram "✅ *Treino tool-calling concluído*%0A%0A$steps%0A%0APróximo passo (manual): GGUF + deploy na NAS + shadow-eval. O modelo em produção NÃO foi trocado."
+else
+  ckpt="$(ls -d "$OUT_DIR"/lora_adapters/checkpoint-* 2>/dev/null | sort -V | tail -1 || true)"
+  echo "[chunk] pacote concluído; último checkpoint: ${ckpt:-nenhum}"
+fi
+
+echo "=== [chunk] fim $(date '+%F %T') ==="
+exit 0

--- a/scripts/whatsapp_toolcall_finetune_peft.py
+++ b/scripts/whatsapp_toolcall_finetune_peft.py
@@ -32,6 +32,7 @@ import logging
 import os
 import random
 import sys
+import time
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s",
@@ -64,6 +65,18 @@ MIN_SAMPLES = int(os.environ.get("FT_MIN_SAMPLES", "800"))
 # Quantas ferramentas incluir no schema de CADA exemplo de treino (a certa +
 # distratoras) em vez das 33 completas — ver comentário em to_text().
 TOOLS_PER_EXAMPLE = int(os.environ.get("FT_TOOLS_PER_EXAMPLE", "6"))
+
+# Treino em pacotes curtos (ex: 10min a cada 1h, pra não segurar o Ollama de
+# produção pausado por horas seguidas). 0 = sem limite, roda até o fim numa
+# tacada só. Quando setado, o script salva checkpoint e sai ao atingir o
+# orçamento; a próxima invocação retoma sozinha do último checkpoint em
+# FT_OUTPUT_DIR/lora_adapters — orquestrado por
+# scripts/whatsapp_toolcall_chunked_train.sh + systemd timer.
+TIME_BUDGET_SECONDS = int(os.environ.get("FT_TIME_BUDGET_SECONDS", "0"))
+# Baixo de propósito: cada passo (após GRAD_ACCUM micro-batches) já leva
+# dezenas de segundos nesta GPU — precisa salvar com frequência pra garantir
+# ao menos 1 checkpoint dentro de um orçamento de ~10min.
+SAVE_STEPS = int(os.environ.get("FT_SAVE_STEPS", "2"))
 
 # Versão condensada da persona homelab — a instrução detalhada de
 # tool-calling propriamente dita fica embutida nos pesos pelo treino, não
@@ -133,6 +146,29 @@ def _verify_tool_call_template(tokenizer) -> bool:
         BASE_MODEL,
     )
     return False
+
+
+def _make_time_budget_callback(budget_seconds: int):
+    """Cria um TrainerCallback que força parada (com checkpoint) ao estourar
+    o orçamento de tempo de parede de um pacote de treino. Subclassea
+    transformers.TrainerCallback de verdade (não duck-typing) — é o que o
+    CallbackHandler do Trainer espera."""
+    from transformers import TrainerCallback
+
+    class _TimeBudgetCallback(TrainerCallback):
+        def __init__(self):
+            self.budget_seconds = budget_seconds
+            self.start = time.monotonic()
+            self.stopped_early = False
+
+        def on_step_end(self, args, state, control, **kwargs):
+            if time.monotonic() - self.start >= self.budget_seconds:
+                control.should_training_stop = True
+                control.should_save = True
+                self.stopped_early = True
+            return control
+
+    return _TimeBudgetCallback()
 
 
 def train(dry_run: bool, do_merge: bool) -> int:
@@ -229,24 +265,52 @@ def train(dry_run: bool, do_merge: bool) -> int:
     ds = ds.map(tokenize, batched=True, remove_columns=["text"])
     log.info("Dataset tokenizado: %d exemplos", len(ds))
 
+    resume_ckpt = None
+    if TIME_BUDGET_SECONDS and LORA_OUTPUT.exists():
+        checkpoints = sorted(
+            LORA_OUTPUT.glob("checkpoint-*"),
+            key=lambda p: int(p.name.rsplit("-", 1)[-1]),
+        )
+        if checkpoints:
+            resume_ckpt = str(checkpoints[-1])
+            log.info("Retomando de checkpoint anterior: %s", resume_ckpt)
+
     args = TrainingArguments(
         output_dir=str(LORA_OUTPUT), per_device_train_batch_size=BATCH_SIZE,
         gradient_accumulation_steps=GRAD_ACCUM, num_train_epochs=EPOCHS,
         learning_rate=LR, warmup_steps=WARMUP, fp16=True, logging_steps=5,
-        save_strategy="no", optim="paged_adamw_8bit", seed=42, report_to="none",
+        save_strategy=("steps" if TIME_BUDGET_SECONDS else "no"),
+        save_steps=SAVE_STEPS, save_total_limit=2,
+        optim="paged_adamw_8bit", seed=42, report_to="none",
     )
+    callbacks = []
+    time_budget_cb = None
+    if TIME_BUDGET_SECONDS:
+        time_budget_cb = _make_time_budget_callback(TIME_BUDGET_SECONDS)
+        callbacks.append(time_budget_cb)
+
     trainer = Trainer(
         model=model, args=args, train_dataset=ds,
         data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+        callbacks=callbacks,
     )
-    log.info("Treinando...")
-    result = trainer.train()
-    log.info("Loss final: %.4f | steps: %d", result.training_loss, result.global_step)
+    log.info("Treinando... (orçamento=%s)", f"{TIME_BUDGET_SECONDS}s" if TIME_BUDGET_SECONDS else "sem limite")
+    result = trainer.train(resume_from_checkpoint=resume_ckpt)
+
+    if time_budget_cb is not None and time_budget_cb.stopped_early:
+        log.info(
+            "⏸️  PARCIAL — orçamento de %ds atingido no passo %d. Checkpoint salvo em %s. "
+            "Rode de novo (mesmo FT_OUTPUT_DIR) pra continuar de onde parou.",
+            TIME_BUDGET_SECONDS, result.global_step, LORA_OUTPUT,
+        )
+        return 0
+
+    log.info("✅ COMPLETO — Loss final: %.4f | steps: %d", result.training_loss, result.global_step)
 
     LORA_OUTPUT.mkdir(parents=True, exist_ok=True)
     model.save_pretrained(str(LORA_OUTPUT))
     tokenizer.save_pretrained(str(LORA_OUTPUT))
-    log.info("LoRA salvo em %s", LORA_OUTPUT)
+    log.info("LoRA final salvo em %s", LORA_OUTPUT)
 
     if do_merge:
         log.info("Merge LoRA → fp16 (RAM-heavy)...")
@@ -256,6 +320,7 @@ def train(dry_run: bool, do_merge: bool) -> int:
         tokenizer.save_pretrained(str(MERGED_OUTPUT))
         log.info("Merged fp16 salvo em %s", MERGED_OUTPUT)
 
+    (OUTPUT_DIR / "TRAINING_COMPLETE").write_text(f"steps={result.global_step}\n", encoding="utf-8")
     return 0
 
 

--- a/systemd/whatsapp-toolcall-chunked-train.service
+++ b/systemd/whatsapp-toolcall-chunked-train.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Pacote curto de treino QLoRA do shared-homelab (tool-calling MCP)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=homelab
+Group=homelab
+# Orçamento de 10min de treino + margem pra carregar o modelo (~2min),
+# salvar checkpoint e religar o ollama. Nunca deve encostar nesse teto:
+# se encostar, o trap do script já religou a produção.
+TimeoutStartSec=1500
+Environment=PYTHONUNBUFFERED=1
+Environment=FT_TIME_BUDGET_SECONDS=600
+# TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID pro aviso de conclusão/falha.
+EnvironmentFile=/etc/default/eddie-common
+ExecStart=/home/homelab/myClaude/scripts/whatsapp_toolcall_chunked_train.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/whatsapp-toolcall-chunked-train.timer
+++ b/systemd/whatsapp-toolcall-chunked-train.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Timer dos pacotes de treino QLoRA do shared-homelab (10min a cada 1h)
+
+[Timer]
+# De hora em hora. O serviço se auto-desabilita (systemctl disable --now)
+# assim que o treino termina, então o timer não fica disparando pra sempre.
+OnCalendar=hourly
+# Sem Persistent=true de propósito: se a máquina ficou desligada, não queremos
+# disparar um treino "atrasado" logo no boot, competindo com a subida do
+# Ollama de produção.
+Persistent=false
+# Espalha até 5min pra não bater sempre no mesmo instante de outros timers.
+RandomizedDelaySec=300
+Unit=whatsapp-toolcall-chunked-train.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Problema medido no hardware real
1 passo de treino = ~53s na RTX 3060 → dataset completo (482 passos) daria **~7h de Ollama de produção pausado**. Inaceitável: a mesma GPU serve o trading e o bot do WhatsApp.

## Solução
- `FT_TIME_BUDGET_SECONDS` no trainer: estourou o orçamento → salva checkpoint e sai com sucesso; próxima invocação retoma via `resume_from_checkpoint`. Ao concluir de verdade, escreve `TRAINING_COMPLETE`.
- `scripts/whatsapp_toolcall_chunked_train.sh`: para ollama+coordinator, treina pelo orçamento, **religa via `trap EXIT`** (sempre, inclusive em falha). Ao ver `TRAINING_COMPLETE`, desabilita o próprio timer e avisa no Telegram.
- Timer de hora em hora, `Persistent=false` de propósito (nada de treino atrasado no boot competindo com a subida do Ollama).

## Test plan
- [x] `py_compile` do trainer, `bash -n` do orquestrador, `systemd-analyze verify` dos units
- [x] `sudo -n systemctl` confirmado sem senha para o usuário `homelab`
- [ ] Primeiro pacote real validado no homelab após o merge (checkpoint escrito + ollama religado)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)