### PR TITLE
fix(finetune): pausa quem reergue o ollama durante o pacote de treino

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T17:59:08.880540+00:00",
-  "repo_root": "/tmp/wb-chunked",
+  "generated_at": "2026-07-29T18:05:44.335037+00:00",
+  "repo_root": "/tmp/wb-race",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T17:59:08.880540+00:00`
+- Generated at: `2026-07-29T18:05:44.335037+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/scripts/whatsapp_toolcall_chunked_train.sh
+++ b/scripts/whatsapp_toolcall_chunked_train.sh
@@ -53,11 +53,21 @@ requests.post(
 PY
 }
 
+# Unidades com `Wants=ollama.service` + `Restart=always`: se ficarem de pé,
+# cada restart delas reergue o ollama em segundos, no meio do treino, e as
+# duas brigam pela VRAM da 3060. Medido: eddie-calendar (quebrado, em loop de
+# restart a cada 10s porque o Google Calendar não está autenticado) reergueu
+# o ollama 7s depois do stop. Precisam ser pausadas junto e restauradas no trap.
+OLLAMA_PULLERS=(eddie-calendar.service llm-optimizer.service)
+
 restore_ollama() {
-  echo "--- [chunk] religando ollama+coordinator ---"
+  echo "--- [chunk] religando ollama+coordinator+dependentes ---"
   sudo systemctl start ollama.service 2>/dev/null || true
   sleep 2
   sudo systemctl start ollama-gpu-coordinator.service 2>/dev/null || true
+  for unit in "${OLLAMA_PULLERS[@]}"; do
+    sudo systemctl start "$unit" 2>/dev/null || true
+  done
   local st_ollama st_coord
   st_ollama="$(systemctl is-active ollama.service 2>/dev/null || true)"
   st_coord="$(systemctl is-active ollama-gpu-coordinator.service 2>/dev/null || true)"
@@ -81,10 +91,19 @@ if [[ ! -f "$DATA_DIR/whatsapp_toolcall_train.jsonl" ]]; then
   exit 1
 fi
 
-echo "--- [chunk] pausando ollama+coordinator p/ liberar a 3060 ---"
+echo "--- [chunk] pausando ollama+coordinator+dependentes p/ liberar a 3060 ---"
+# Ordem importa: primeiro quem reergue o ollama, depois o ollama.
+for unit in "${OLLAMA_PULLERS[@]}"; do
+  sudo systemctl stop "$unit" 2>/dev/null || true
+done
 sudo systemctl stop ollama-gpu-coordinator.service 2>/dev/null || true
 sudo systemctl stop ollama.service 2>/dev/null || true
 sleep 4
+
+if [[ "$(systemctl is-active ollama.service 2>/dev/null || true)" == "active" ]]; then
+  echo "[chunk] ERRO: ollama voltou a subir mesmo após o stop — abortando pacote p/ não brigar pela VRAM."
+  exit 1
+fi
 
 cd "$REPO" || exit 1
 FT_DATASET_DIR="$DATA_DIR" \

--- a/systemd/whatsapp-toolcall-chunked-train.service
+++ b/systemd/whatsapp-toolcall-chunked-train.service
@@ -13,6 +13,11 @@ Group=homelab
 TimeoutStartSec=1500
 Environment=PYTHONUNBUFFERED=1
 Environment=FT_TIME_BUDGET_SECONDS=600
+# 1 época (não 2): medido 52,6s/passo na 3060, então 2 épocas custariam ~48
+# pacotes (~2 dias). Com 1 época são ~24 pacotes (~1 dia) — e, num dataset
+# sintético/templated como este, 1 época ainda reduz o risco de overfitting
+# nos templates.
+Environment=FT_EPOCHS=1
 # TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID pro aviso de conclusão/falha.
 EnvironmentFile=/etc/default/eddie-common
 ExecStart=/home/homelab/myClaude/scripts/whatsapp_toolcall_chunked_train.sh


### PR DESCRIPTION
## Bug medido no primeiro pacote real
7s depois do `systemctl stop ollama`, o serviço voltou sozinho. Causa: `eddie-calendar.service` tem `Wants=ollama.service` + `Restart=always` e está em loop de restart a cada 10s (Google Calendar não autenticado) — cada restart reergue o Ollama no meio do treino, brigando pela VRAM da 3060 (o mesmo cenário que já causou CUDA OOM antes).

## Correção
- Pausa `eddie-calendar` + `llm-optimizer` (ambos com `Wants=ollama.service`) **antes** do ollama; restaura no `trap EXIT`.
- Aborta o pacote se o ollama subir mesmo assim — melhor perder um pacote que treinar brigando por VRAM.
- `FT_EPOCHS=1`: 52,6s/passo medido → 2 épocas = ~48 pacotes (~2 dias) vs ~24 (~1 dia).

## Validado
- [x] Ciclo completo: pausou ollama → treinou 4 passos → `checkpoint-4` salvo ao estourar orçamento → trap religou ollama **e** coordinator (`active`/`active`)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)