### PR TITLE
fix(whatsapp): desliga tool-calling por padrão e conserta aprovação no Telegram

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T18:05:44.335037+00:00",
-  "repo_root": "/tmp/wb-race",
+  "generated_at": "2026-07-29T18:45:03.924380+00:00",
+  "repo_root": "/tmp/wb-killswitch",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T18:05:44.335037+00:00`
+- Generated at: `2026-07-29T18:45:03.924380+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/docs/variables-taxonomy/WHATSAPP_TOOL_CALLING.md
+++ b/docs/variables-taxonomy/WHATSAPP_TOOL_CALLING.md
@@ -1,0 +1,17 @@
+# WHATSAPP_TOOL_CALLING
+
+## Propósito
+Kill-switch do tool-calling MCP do bot do WhatsApp (modelo `shared-homelab`). Quando ligado, o modelo recebe o schema das 33 ferramentas do `homelab_mcp_server.py` e pode chamá-las sozinho; quando desligado, o bot volta ao caminho conversacional anterior (+ atalhos determinísticos de calendário/gmail/relatórios).
+
+## Escopo
+- **Consumidor**: `scripts/misc/whatsapp_bot.py` (`TOOL_CALLING_ENABLED`).
+- **Default**: `0` (desligado).
+- **Ligar**: `WHATSAPP_TOOL_CALLING=1` no drop-in `systemd/eddie-whatsapp-bot.service.d/env.conf`.
+
+## Por que o default é desligado
+Medido em produção em 2026-07-29: o `llama3.1:8b` **sem fine-tune** escolhe a ferramenta errada mesmo recebendo o schema completo. Num pedido de *"crie um evento no meu Google Calendar"* ele chamou `bus_publish` (publicar no bus interno de agentes), que é classificada como risco alto — o turno virou "🔒 aguardando aprovação no Telegram" e expirou 11 min depois sem resposta útil. Isso é pior que o comportamento anterior (resposta conversacional direta).
+
+Só religar depois que o candidato treinado (`scripts/whatsapp_toolcall_finetune_peft.py`) passar no shadow-eval (`scripts/whatsapp_toolcall_shadow_eval.py`) com taxa aceitável de acerto de ferramenta e de falso-positivo — especialmente nas ferramentas de risco alto/crítico.
+
+## Relacionadas
+- [[HOMELAB_URL]], [[API_BASE_URL]], [[MAX_TOOL_ROUNDS]]

--- a/scripts/misc/whatsapp_bot.py
+++ b/scripts/misc/whatsapp_bot.py
@@ -148,6 +148,14 @@ PHONE_MODEL_MAPPING = {
 # Modelo com tool-calling MCP habilitado (ver mcp_tool_bridge.py) e teto de
 # rodadas do loop tool-call -> resultado -> tool-call para evitar loop infinito.
 TOOL_CALLING_MODEL = "shared-homelab"
+# Kill-switch do tool-calling. Default DESLIGADO até o fine-tune ficar pronto:
+# medido em produção (2026-07-29), o llama3.1:8b base escolhe a ferramenta
+# errada mesmo recebendo o schema — num pedido de "criar evento no Google
+# Calendar" ele chamou `bus_publish`, que é de risco alto, então o turno virou
+# "aguardando aprovação no Telegram" e expirou 11min depois sem resposta útil.
+# Pior que o comportamento anterior (resposta conversacional). Religar com
+# WHATSAPP_TOOL_CALLING=1 só depois do candidato treinado passar no shadow-eval.
+TOOL_CALLING_ENABLED = os.getenv("WHATSAPP_TOOL_CALLING", "0").lower() in ("1", "true", "yes", "on")
 try:
     MAX_TOOL_ROUNDS = int(os.getenv("MAX_TOOL_ROUNDS", "3"))
 except ValueError:
@@ -1126,9 +1134,14 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
                     continue
 
                 if mcp_tool_bridge.is_gated(tool_name):
+                    # Sem dump cru do dict: nomes de argumento com `_`/`*`
+                    # quebravam o Markdown do approval_gateway e a aprovação
+                    # não chegava no Telegram (medido em produção 2026-07-29).
+                    arg_names = ", ".join(sorted(kwargs.keys())) or "sem argumentos"
                     description = (
                         f"Modelo {model} (self-chat WhatsApp) pediu para chamar "
-                        f"'{tool_name}' com argumentos {kwargs}"
+                        f"a ferramenta {tool_name} ({arg_names}). "
+                        f"Argumentos completos no context_snapshot."
                     )
                     try:
                         intent_id = mcp_tool_bridge.declare_gate(tool_name, kwargs, description)
@@ -1188,7 +1201,11 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
         # dados de uma fonte errada/desatualizada.
         _sender_number = message.sender.split("@")[0]
         _sender_clean = _sender_number.replace("55", "", 1) if _sender_number.startswith("55") else _sender_number
-        _will_use_tool_calling = MCP_TOOLS_AVAILABLE and PHONE_MODEL_MAPPING.get(_sender_clean) == TOOL_CALLING_MODEL
+        _will_use_tool_calling = (
+            TOOL_CALLING_ENABLED
+            and MCP_TOOLS_AVAILABLE
+            and PHONE_MODEL_MAPPING.get(_sender_clean) == TOOL_CALLING_MODEL
+        )
 
         # === VERIFICAR INTENÇÃO DE CALENDÁRIO ===
         if CALENDAR_AVAILABLE:
@@ -1281,7 +1298,7 @@ Olá! Sou um assistente de IA integrado ao WhatsApp.
         # Preparar mensagens para o modelo
         messages = session.get_history()
 
-        if model == TOOL_CALLING_MODEL and MCP_TOOLS_AVAILABLE:
+        if TOOL_CALLING_ENABLED and model == TOOL_CALLING_MODEL and MCP_TOOLS_AVAILABLE:
             response = await self._process_with_tools(messages, model, system_prompt, message.chat_id)
             self.db.save_message(
                 message.chat_id, WHATSAPP_PHONE_ID, "assistant", response, message.is_group,

--- a/specialized_agents/approval_gateway.py
+++ b/specialized_agents/approval_gateway.py
@@ -126,7 +126,18 @@ def _tg(method: str, body: dict[str, Any], timeout: int = 10) -> dict[str, Any] 
         resp = _req.post(f"{_BOT_URL}/{method}", json=body, timeout=timeout)
         data = resp.json()
         if not data.get("ok"):
-            log.warning("Telegram/%s: %s", method, data.get("description"))
+            desc = data.get("description") or ""
+            # Fallback crítico: se o texto do agente contém Markdown inválido
+            # (ex: `_` de nomes tipo message_type, `*`, `[`), o Telegram recusa
+            # a mensagem inteira e a aprovação NUNCA chega — o portão vira um
+            # buraco negro em que toda ação expira sem chance de decisão.
+            # Reenviar sem parse_mode: melhor a mensagem feia que nenhuma.
+            # Observado em produção 2026-07-29 com o agente whatsapp-bot.
+            if "parse entities" in desc and body.get("parse_mode"):
+                log.warning("Telegram/%s: Markdown inválido (%s) — reenviando sem parse_mode", method, desc)
+                retry = {k: v for k, v in body.items() if k != "parse_mode"}
+                return _tg(method, retry, timeout)
+            log.warning("Telegram/%s: %s", method, desc)
             return None
         return data.get("result")
     except Exception as exc:

--- a/tests/test_whatsapp_bot_tool_calls.py
+++ b/tests/test_whatsapp_bot_tool_calls.py
@@ -242,3 +242,15 @@ def test_process_with_tools_stops_after_max_rounds():
         )
 
     assert "não consegui concluir" in response.lower()
+
+
+# ── Kill-switch do tool-calling ──────────────────────────────────────────
+
+
+def test_tool_calling_disabled_by_default():
+    """Default DESLIGADO: o llama3.1:8b base escolhe ferramenta errada (medido
+    em produção — pediu `bus_publish` para um pedido de Google Calendar), o que
+    é pior que a resposta conversacional anterior. Só religar (WHATSAPP_TOOL_CALLING=1)
+    depois do candidato treinado passar no shadow-eval."""
+    wb = _load_module()
+    assert wb.TOOL_CALLING_ENABLED is False


### PR DESCRIPTION
## Dois bugs encadeados, medidos em produção hoje

**1. Modelo base escolhe ferramenta errada.** Pedido de *"crie um evento no Google Calendar"* → o `llama3.1:8b` sem fine-tune chamou `bus_publish` (risco alto) → turno virou "🔒 aguardando aprovação" e expirou 11 min depois. Pior que o comportamento anterior (resposta conversacional).
→ Tool-calling agora é **opt-in** (`WHATSAPP_TOOL_CALLING=1`), default desligado, até o candidato treinado passar no shadow-eval.

**2. A aprovação nunca chegava no Telegram.** O `approval_gateway` envia com `parse_mode=Markdown`; a descrição gerada pelo bot continha o dict de argumentos cru, e o `_` de `message_type` abre um itálico que nunca fecha → Telegram recusa a mensagem inteira (`can't parse entities`) → **o portão de segurança virava um buraco negro**: toda ação travada expirava sem chance de decisão.
→ Corrigido dos dois lados: gateway reenvia sem `parse_mode` no erro de parsing (vale para **qualquer** agente), e o bot não despeja mais o dict cru.

## Test plan
- [x] 37 testes passando, incluindo novo `test_tool_calling_disabled_by_default`
- [x] `py_compile` de ambos os arquivos

🤖 Gerado com [Claude Code](https://claude.com/claude-code)