### PR TITLE
fix(calendar): interrompe loop infinito de restart do eddie-calendar

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T18:45:03.924380+00:00",
-  "repo_root": "/tmp/wb-killswitch",
+  "generated_at": "2026-07-29T18:54:31.641560+00:00",
+  "repo_root": "/tmp/wb-cal",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T18:45:03.924380+00:00`
+- Generated at: `2026-07-29T18:54:31.641560+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/scripts/misc/calendar_reminder_service.py
+++ b/scripts/misc/calendar_reminder_service.py
@@ -306,8 +306,18 @@ Prepare-se! 🚀"""
         
         # Verificar autenticação
         if not self.calendar.is_authenticated():
-            logger.error("❌ Não autenticado! Execute setup_google_calendar.py primeiro.")
-            return
+            logger.error(
+                "❌ Não autenticado! Coloque o credentials.json do Google Cloud em "
+                "scripts/misc/calendar_data/ e rode setup_google_calendar.py."
+            )
+            # Sair com código != 0 é essencial: com `return` o processo saía com
+            # status 0, o systemd considerava execução bem-sucedida e o
+            # `Restart=always` reiniciava a cada 10s pra sempre (chegou a 321
+            # restarts). Como o unit tinha `Wants=ollama.service`, cada restart
+            # ainda reerguia o Ollama — o que sabotava o fine-tune, que precisa
+            # da VRAM da 3060 livre. Falhando de verdade, o StartLimitBurst do
+            # systemd para o loop e o serviço fica visível como `failed`.
+            raise SystemExit(1)
         
         logger.info("✅ Autenticado com Google Calendar")
         

--- a/systemd/eddie-calendar.service
+++ b/systemd/eddie-calendar.service
@@ -1,18 +1,31 @@
 [Unit]
 Description=Eddie Calendar Reminder Service
-After=network.target ollama.service
-Wants=ollama.service
+After=network.target
+# NÃO declarar Wants=/After=ollama.service: este serviço não usa Ollama em
+# nenhum ponto (verificado: zero referências a ollama/11434/11437 no código).
+# A dependência era espúria e tinha um efeito colateral caro — como o serviço
+# estava em loop de restart, cada restart reerguia o ollama.service, inclusive
+# no meio do fine-tune, que precisa da VRAM da RTX 3060 livre.
+# Se o loop de restart voltar, o systemd desiste depois de 3 tentativas em 5min
+# em vez de reiniciar pra sempre.
+StartLimitIntervalSec=300
+StartLimitBurst=3
 
 [Service]
 Type=simple
 User=homelab
 WorkingDirectory=/home/homelab/myClaude
 ExecStart=/usr/bin/python3 /home/homelab/myClaude/calendar_reminder_service.py
-Restart=always
-RestartSec=10
+# on-failure (não `always`): sem credenciais do Google o serviço sai com
+# código 1 e o StartLimitBurst acima interrompe o ciclo; com `always` até uma
+# saída limpa era reiniciada, o que produziu 321 restarts silenciosos.
+Restart=on-failure
+RestartSec=30
 Environment=PYTHONUNBUFFERED=1
-# TELEGRAM_BOT_TOKEN must be provided at runtime from the vault or environment.
-Environment=TELEGRAM_BOT_TOKEN=
+# TELEGRAM_BOT_TOKEN vem da fonte canônica (/etc/default/eddie-common).
+# NÃO reintroduzir `Environment=TELEGRAM_BOT_TOKEN=` vazio aqui: Environment=
+# vence EnvironmentFile= e zeraria o token, derrubando as notificações.
+EnvironmentFile=-/etc/default/eddie-common
 Environment=ADMIN_CHAT_ID=948686300
 Environment=WHATSAPP_NUMBER=5511981193899
 Environment=WAHA_API=http://localhost:3001


### PR DESCRIPTION
## Problema
`eddie-calendar.service` acumulou **321 restarts**. Sem credenciais do Google, `run()` fazia `return` → processo saía com status **0** → systemd via execução bem-sucedida → `Restart=always` reiniciava a cada 10s, pra sempre, sem nunca aparecer como `failed`.

**Efeito colateral caro:** o unit declarava `Wants=ollama.service` embora o serviço **não use Ollama em ponto nenhum** (zero referências a `ollama`/`11434`/`11437` no código). Cada restart reerguia o Ollama — inclusive no meio do fine-tune, que precisa da VRAM da 3060 livre. Medido: 7s depois do `systemctl stop ollama`, ele estava de volta.

## Correções
- `run()` levanta `SystemExit(1)` sem autenticação → falha de verdade, visível como `failed`.
- Unit: `Restart=on-failure` + `StartLimitBurst=3`/`300s` → systemd desiste em vez de girar pra sempre; dependência espúria de ollama removida.
- Token do Telegram via `EnvironmentFile=/etc/default/eddie-common` — o `Environment=TELEGRAM_BOT_TOKEN=` **vazio** que estava no repo teria precedência sobre o EnvironmentFile e zeraria o token.

## Nota
O Google Calendar **nunca foi autenticado** (`calendar_data/` vazio desde abril — sem `credentials.json` nem `token.pickle`). Habilitar de fato exige o OAuth client do Google Cloud Console, que é ação do dono. Esta correção garante que a ausência não vire um loop infinito silencioso.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)