### PR TITLE
feat(calendar): wrapper headless de consentimento OAuth (Authentik-first)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T19:14:33.403088+00:00",
-  "repo_root": "/tmp/wb-authentik",
+  "generated_at": "2026-07-29T19:21:35.260920+00:00",
+  "repo_root": "/tmp/wb-consent",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
@@ -8,10 +8,14 @@
     "hosts": 1,
     "repo_services": 193,
     "trading_instances": 12,
-    "critical_services": 193,
+    "critical_services": 76,
     "domains": {
-      "identity": 175,
-      "monitoring": 18
+      "identity": 4,
+      "monitoring": 18,
+      "network": 22,
+      "operations": 106,
+      "storage": 32,
+      "trading": 11
     }
   },
   "trading_instances": [
@@ -194,158 +198,6 @@
   ],
   "applications_review": [
     {
-      "name": "glpi",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "glpi-db",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mail-db",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mail-server",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-backend",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-db",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-dovecot",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-frontend",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-postfix",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-redis",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-roundcube",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-postgres",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-redis",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-redis-cache",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-worker",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nginx",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ntopng",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ntopng-redis",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "open-webui",
       "domain": "identity",
       "kind": "compose",
@@ -354,450 +206,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "opensearch-dashboards",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "opensearch-node1",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "postgres",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.email-simple.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "printshare",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/printshare/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "proxy",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "roundcube",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "vaultwarden",
       "domain": "identity",
       "kind": "compose",
       "source": "tools/vaultwarden/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "wikijs",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "wikijs-db",
-      "domain": "identity",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "akash-sweep.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "akash-sweep.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "approval-gateway.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/approval-gateway.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "auto_validate.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/auto_validate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "autonomous_remediator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/systemd/autonomous_remediator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "bn-acervo-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/bn-acervo-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "check_projects.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/check_projects.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "check_projects.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/check_projects.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "chromecast-ambilight.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/chromecast-ambilight.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "clear-agent@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/clear-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "clear-trading-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/clear-trading-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-named@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/tunnels/cloudflared-named@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared-tunnel-guardian.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/cloudflared-tunnel-guardian.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "cloudflared.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/tunnels/cloudflared/cloudflared.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "coordinator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "crypto-agent@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/crypto-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-broadcast.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-broadcast.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-panel.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-panel.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "decisions-track-record-rollup.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "decisions-track-record-rollup.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "dhcp-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/dhcp-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "diretor.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/diretor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-spindown.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/homelab/disk-spindown.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-calendar.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/eddie-calendar.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-expurgo.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/eddie-expurgo.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-telegram-bot.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/eddie-telegram-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-tray-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/systemd/eddie-tray-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-whatsapp-bot.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/eddie-whatsapp-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ethwan-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ethwan-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "final-boot-status-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/systemd/final-boot-status-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "gdrive-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/systemd/gdrive-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "github-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/github-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-dashboard.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-dashboard.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-disk-backup.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/backup/homelab-disk-backup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-lan-gateway.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn/homelab-lan-gateway.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -814,782 +226,6 @@
       "domain": "identity",
       "kind": "systemd",
       "source": "systemd/homelab-vault-close.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-presence-watchdog.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-presence-watchdog.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-vpn-bypass-watchdog.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/iot-vpn-bypass-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-vpn-bypass-watchdog.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/iot-vpn-bypass-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ipv6-proxy.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ipv6-proxy.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "journal-ingestor.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "journal-ingestor.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-postgres-sync.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-postgres-sync.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "llm-log-panel.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/llm-log-panel.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "localtunnel@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/tunnels/localtunnel@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-boot-reconcile.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-boot-reconcile.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-button-watch.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-button-watch.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-deep-recovery.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-deep-recovery.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-selfheal-escalator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-sg1.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6b.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6b.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-checkpoint-drain.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-drain.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-checkpoint-recover.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-recover.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-smb-proof-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-api.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-api.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "meeting-translator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/meeting-translator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nas-ollama-load.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/nas-ollama-load.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "notebook-power-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/notebook-power-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nvidia-clock-limit.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/nvidia-clock-limit.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-coordinator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu-coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/ollama-gpu-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu1.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "pandaplus-telegram-bridge.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/pandaplus-telegram-bridge.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "pihole-ipv6-dns-fix.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/pihole-ipv6-dns-fix.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "post-boot-check.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/post-boot-check.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "printshare.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/printshare/printshare.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-best-server.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/protonvpn-best-server.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-best-server.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/protonvpn-best-server.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-boot-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/protonvpn-boot-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-routing-watchdog-fix.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn/protonvpn-routing-watchdog-fix.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-routing-watchdog.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn/protonvpn-routing-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-unit-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/protonvpn-unit-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "protonvpn-unit-selfheal.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/protonvpn-unit-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "python-training.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/python-training.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "python-training.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/python-training.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "review-service.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/systemd/review-service.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-ddns-server.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn/rpa4all-ddns-server.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-vpn-ddns.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "secrets_agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/secrets_agent/secrets_agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "server-error-alert.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/homelab/server-error-alert.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "specialized_agents-dashboard.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/specialized_agents-dashboard.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-host-shim.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/storj-host-shim.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-network.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-network.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-safe-eject.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tape-safe-eject.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-daily-report.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-daily-report.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-local-key-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-local-key-selfheal.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-renewer.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-renewer.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-selfheal.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-selfheal.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.timer",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "wireguard-nat.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "deploy/vpn/wireguard-nat.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "workstation-win11l-http@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/workstation-win11l-http@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "workstation-win11l-rdp@.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "systemd/workstation-win11l-rdp@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "x-agent.service",
-      "domain": "identity",
-      "kind": "systemd",
-      "source": "tools/x_agent/x-agent.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1736,6 +372,1374 @@
       "source": "systemd/tunnel-healthcheck-exporter.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "proxy",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared-named@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/tunnels/cloudflared-named@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared-tunnel-guardian.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/cloudflared-tunnel-guardian.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared-tunnel-guardian.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/cloudflared-tunnel-guardian.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "cloudflared.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/tunnels/cloudflared/cloudflared.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "dhcp-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/dhcp-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-lan-gateway.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn/homelab-lan-gateway.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-vpn-bypass-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-vpn-bypass-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-vpn-bypass-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-vpn-bypass-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ipv6-proxy.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ipv6-proxy.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "localtunnel@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/tunnels/localtunnel@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "pihole-ipv6-dns-fix.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/pihole-ipv6-dns-fix.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-best-server.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-best-server.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-best-server.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-best-server.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-boot-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-boot-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-routing-watchdog-fix.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn/protonvpn-routing-watchdog-fix.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-routing-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn/protonvpn-routing-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-unit-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-unit-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "protonvpn-unit-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/protonvpn-unit-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-ddns-server.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn/rpa4all-ddns-server.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-vpn-ddns.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "wireguard-nat.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/vpn/wireguard-nat.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "glpi",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "glpi-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mail-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mail-server",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-backend",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-dovecot",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-frontend",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-postfix",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-roundcube",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-postgres",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-redis-cache",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-worker",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nginx",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ntopng",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ntopng-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "opensearch-dashboards",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "opensearch-node1",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "postgres",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.email-simple.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "printshare",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/printshare/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "roundcube",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "wikijs",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "wikijs-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "akash-sweep.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "akash-sweep.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "approval-gateway.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/approval-gateway.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "auto_validate.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/auto_validate.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "autonomous_remediator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/autonomous_remediator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "bn-acervo-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/bn-acervo-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "check_projects.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/check_projects.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "check_projects.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/check_projects.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "chromecast-ambilight.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/chromecast-ambilight.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "clear-agent@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/clear-agent@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "coordinator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/coordinator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "crypto-agent@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/crypto-agent@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-broadcast.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-broadcast.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-panel.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "diretor.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/diretor.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-calendar.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-calendar.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-expurgo.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-expurgo.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-telegram-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-telegram-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-tray-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/eddie-tray-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-whatsapp-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-whatsapp-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ethwan-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "final-boot-status-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "gdrive-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/gdrive-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "github-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/github-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "homelab-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "llm-log-panel.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/llm-log-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-drain.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-drain.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-recover.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-recover.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-smb-proof-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "meeting-translator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/meeting-translator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nas-ollama-load.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nas-ollama-load.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "notebook-power-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nvidia-clock-limit.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nvidia-clock-limit.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-coordinator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu-coordinator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/ollama-gpu-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu1.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu1.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "pandaplus-telegram-bridge.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/pandaplus-telegram-bridge.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "post-boot-check.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/post-boot-check.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "printshare.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/printshare/printshare.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "review-service.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/review-service.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "secrets_agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/secrets_agent/secrets_agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "server-error-alert.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/homelab/server-error-alert.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "specialized_agents-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "workstation-win11l-http@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/workstation-win11l-http@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "workstation-win11l-rdp@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/workstation-win11l-rdp@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "x-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/x_agent/x-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "disk-clean.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-clean.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-spindown.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "tools/homelab/disk-spindown.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-disk-backup.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "tools/backup/homelab-disk-backup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-boot-reconcile.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-boot-reconcile.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-button-watch.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-button-watch.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-deep-recovery.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-selfheal-escalator.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-sg1.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6b.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6b.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-host-shim.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-host-shim.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-network.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-network.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-safe-eject.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-safe-eject.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "candle-collector.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "clear-trading-agent.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/clear-trading-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-daily-report.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-daily-report.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
@@ -1979,184 +1983,9 @@
     ],
     "critical_services": [
       {
-        "name": "glpi",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "glpi-db",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-db",
-        "domain": "identity",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-server",
-        "domain": "identity",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-backend",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-db",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-dovecot",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-frontend",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-postfix",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-redis",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-roundcube",
-        "domain": "identity",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-postgres",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis-cache",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-worker",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "nginx",
-        "domain": "identity",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng",
-        "domain": "identity",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng-redis",
-        "domain": "identity",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
         "name": "open-webui",
         "domain": "identity",
         "source": "tools/authentik_management/configs/docker-compose.override.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-dashboards",
-        "domain": "identity",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-node1",
-        "domain": "identity",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "postgres",
-        "domain": "identity",
-        "source": "docker/docker-compose.email-simple.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "printshare",
-        "domain": "identity",
-        "source": "deploy/printshare/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "proxy",
-        "domain": "identity",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "roundcube",
-        "domain": "identity",
-        "source": "docker/docker-compose.simple-mail.yml",
         "kind": "compose",
         "critical": true
       },
@@ -2165,349 +1994,6 @@
         "domain": "identity",
         "source": "tools/vaultwarden/docker-compose.yml",
         "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs",
-        "domain": "identity",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs-db",
-        "domain": "identity",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.service",
-        "domain": "identity",
-        "source": "systemd/akash-sweep.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.timer",
-        "domain": "identity",
-        "source": "systemd/akash-sweep.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "approval-gateway.service",
-        "domain": "identity",
-        "source": "systemd/approval-gateway.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "auto_validate.service",
-        "domain": "identity",
-        "source": "deploy/auto_validate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "autonomous_remediator.service",
-        "domain": "identity",
-        "source": "tools/systemd/autonomous_remediator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "bn-acervo-agent.service",
-        "domain": "identity",
-        "source": "systemd/bn-acervo-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.service",
-        "domain": "identity",
-        "source": "systemd/candle-collector.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.timer",
-        "domain": "identity",
-        "source": "systemd/candle-collector.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.service",
-        "domain": "identity",
-        "source": "systemd/check_projects.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.timer",
-        "domain": "identity",
-        "source": "systemd/check_projects.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "chromecast-ambilight.service",
-        "domain": "identity",
-        "source": "systemd/chromecast-ambilight.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-agent@.service",
-        "domain": "identity",
-        "source": "systemd/clear-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-trading-agent.service",
-        "domain": "identity",
-        "source": "systemd/clear-trading-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-named@.service",
-        "domain": "identity",
-        "source": "tools/tunnels/cloudflared-named@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.service",
-        "domain": "identity",
-        "source": "systemd/cloudflared-tunnel-guardian.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared-tunnel-guardian.timer",
-        "domain": "identity",
-        "source": "systemd/cloudflared-tunnel-guardian.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "cloudflared.service",
-        "domain": "identity",
-        "source": "tools/tunnels/cloudflared/cloudflared.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "coordinator.service",
-        "domain": "identity",
-        "source": "systemd/coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "crypto-agent@.service",
-        "domain": "identity",
-        "source": "systemd/crypto-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-broadcast.service",
-        "domain": "identity",
-        "source": "systemd/daily-agenda-broadcast.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-broadcast.timer",
-        "domain": "identity",
-        "source": "systemd/daily-agenda-broadcast.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-panel.service",
-        "domain": "identity",
-        "source": "systemd/daily-agenda-panel.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "decisions-track-record-rollup.service",
-        "domain": "identity",
-        "source": "systemd/decisions-track-record-rollup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "decisions-track-record-rollup.timer",
-        "domain": "identity",
-        "source": "systemd/decisions-track-record-rollup.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "dhcp-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/dhcp-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "diretor.service",
-        "domain": "identity",
-        "source": "systemd/diretor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-clean.service",
-        "domain": "identity",
-        "source": "systemd/disk-clean.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-clean.timer",
-        "domain": "identity",
-        "source": "systemd/disk-clean.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-spindown.service",
-        "domain": "identity",
-        "source": "tools/homelab/disk-spindown.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-calendar.service",
-        "domain": "identity",
-        "source": "systemd/eddie-calendar.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-expurgo.service",
-        "domain": "identity",
-        "source": "systemd/eddie-expurgo.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-telegram-bot.service",
-        "domain": "identity",
-        "source": "systemd/eddie-telegram-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-tray-agent.service",
-        "domain": "identity",
-        "source": "tools/systemd/eddie-tray-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-whatsapp-bot.service",
-        "domain": "identity",
-        "source": "systemd/eddie-whatsapp-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ethwan-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/ethwan-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "final-boot-status-agent.service",
-        "domain": "identity",
-        "source": "tools/systemd/final-boot-status-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "gdrive-agent.service",
-        "domain": "identity",
-        "source": "tools/systemd/gdrive-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "github-agent.service",
-        "domain": "identity",
-        "source": "systemd/github-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-dashboard.service",
-        "domain": "identity",
-        "source": "systemd/homelab-dashboard.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-disk-backup.service",
-        "domain": "identity",
-        "source": "tools/backup/homelab-disk-backup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-lan-gateway.service",
-        "domain": "identity",
-        "source": "deploy/vpn/homelab-lan-gateway.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.service",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.timer",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.service",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-log-drain-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.timer",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-log-drain-sg1.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.service",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-logrotate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.timer",
-        "domain": "identity",
-        "source": "systemd/homelab-tape-logrotate.timer",
-        "kind": "systemd",
         "critical": true
       },
       {
@@ -2521,685 +2007,6 @@
         "name": "homelab-vault-close.service",
         "domain": "identity",
         "source": "systemd/homelab-vault-close.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-presence-watchdog.service",
-        "domain": "identity",
-        "source": "systemd/iot-presence-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-presence-watchdog.timer",
-        "domain": "identity",
-        "source": "systemd/iot-presence-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-vpn-bypass-watchdog.service",
-        "domain": "identity",
-        "source": "systemd/iot-vpn-bypass-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-vpn-bypass-watchdog.timer",
-        "domain": "identity",
-        "source": "systemd/iot-vpn-bypass-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ipv6-proxy.service",
-        "domain": "identity",
-        "source": "systemd/ipv6-proxy.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "journal-ingestor.service",
-        "domain": "identity",
-        "source": "systemd/journal-ingestor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "journal-ingestor.timer",
-        "domain": "identity",
-        "source": "systemd/journal-ingestor.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-postgres-sync.service",
-        "domain": "identity",
-        "source": "systemd/kucoin-postgres-sync.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-postgres-sync.timer",
-        "domain": "identity",
-        "source": "systemd/kucoin-postgres-sync.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-usdt-rebalance.service",
-        "domain": "identity",
-        "source": "systemd/kucoin-usdt-rebalance.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-usdt-rebalance.timer",
-        "domain": "identity",
-        "source": "systemd/kucoin-usdt-rebalance.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "llm-log-panel.service",
-        "domain": "identity",
-        "source": "systemd/llm-log-panel.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "localtunnel@.service",
-        "domain": "identity",
-        "source": "tools/tunnels/localtunnel@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-backup-catalog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.timer",
-        "domain": "identity",
-        "source": "systemd/ltfs-backup-catalog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-boot-reconcile.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-boot-reconcile.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-button-watch.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-button-watch.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-deep-recovery.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-deep-recovery.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-log-rotation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.timer",
-        "domain": "identity",
-        "source": "systemd/ltfs-log-rotation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-selfheal-escalator.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-sg1.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-lto6-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-lto6.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6b.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-lto6b.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.service",
-        "domain": "identity",
-        "source": "systemd/ltfs-window-enforcer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.timer",
-        "domain": "identity",
-        "source": "systemd/ltfs-window-enforcer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-checkpoint-drain.service",
-        "domain": "identity",
-        "source": "systemd/lto6-checkpoint-drain.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-checkpoint-recover.service",
-        "domain": "identity",
-        "source": "systemd/lto6-checkpoint-recover.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.service",
-        "domain": "identity",
-        "source": "systemd/lto6-drain-backups.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.timer",
-        "domain": "identity",
-        "source": "systemd/lto6-drain-backups.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/lto6-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.timer",
-        "domain": "identity",
-        "source": "systemd/lto6-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-smb-proof-selfheal.service",
-        "domain": "identity",
-        "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-api.service",
-        "domain": "identity",
-        "source": "systemd/marketing-api.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.service",
-        "domain": "identity",
-        "source": "systemd/marketing-daily-report.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.timer",
-        "domain": "identity",
-        "source": "systemd/marketing-daily-report.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.service",
-        "domain": "identity",
-        "source": "systemd/marketing-email-drip.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.timer",
-        "domain": "identity",
-        "source": "systemd/marketing-email-drip.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.service",
-        "domain": "identity",
-        "source": "systemd/marketing-x-posts.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.timer",
-        "domain": "identity",
-        "source": "systemd/marketing-x-posts.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "meeting-translator.service",
-        "domain": "identity",
-        "source": "systemd/meeting-translator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "nas-ollama-load.service",
-        "domain": "identity",
-        "source": "systemd/nas-ollama-load.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "notebook-power-agent.service",
-        "domain": "identity",
-        "source": "systemd/notebook-power-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "nvidia-clock-limit.service",
-        "domain": "identity",
-        "source": "systemd/nvidia-clock-limit.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.service",
-        "domain": "identity",
-        "source": "systemd/ollama-finetune.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.timer",
-        "domain": "identity",
-        "source": "systemd/ollama-finetune.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-coordinator.service",
-        "domain": "identity",
-        "source": "systemd/ollama-gpu-coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-selfheal.service",
-        "domain": "identity",
-        "source": "tools/ollama-gpu-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu1.service",
-        "domain": "identity",
-        "source": "systemd/ollama-gpu1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.service",
-        "domain": "identity",
-        "source": "systemd/ollama-warmup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.timer",
-        "domain": "identity",
-        "source": "systemd/ollama-warmup.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "pandaplus-telegram-bridge.service",
-        "domain": "identity",
-        "source": "systemd/pandaplus-telegram-bridge.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "pihole-ipv6-dns-fix.service",
-        "domain": "identity",
-        "source": "systemd/pihole-ipv6-dns-fix.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "post-boot-check.service",
-        "domain": "identity",
-        "source": "systemd/post-boot-check.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "printshare.service",
-        "domain": "identity",
-        "source": "deploy/printshare/printshare.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-best-server.service",
-        "domain": "identity",
-        "source": "systemd/protonvpn-best-server.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-best-server.timer",
-        "domain": "identity",
-        "source": "systemd/protonvpn-best-server.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-boot-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/protonvpn-boot-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-routing-watchdog-fix.service",
-        "domain": "identity",
-        "source": "deploy/vpn/protonvpn-routing-watchdog-fix.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-routing-watchdog.service",
-        "domain": "identity",
-        "source": "deploy/vpn/protonvpn-routing-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-unit-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/protonvpn-unit-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "protonvpn-unit-selfheal.timer",
-        "domain": "identity",
-        "source": "systemd/protonvpn-unit-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "python-training.service",
-        "domain": "identity",
-        "source": "systemd/python-training.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "python-training.timer",
-        "domain": "identity",
-        "source": "systemd/python-training.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.service",
-        "domain": "identity",
-        "source": "systemd/rag-reindex.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.timer",
-        "domain": "identity",
-        "source": "systemd/rag-reindex.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "review-service.service",
-        "domain": "identity",
-        "source": "tools/systemd/review-service.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-ddns-server.service",
-        "domain": "identity",
-        "source": "deploy/vpn/rpa4all-ddns-server.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.service",
-        "domain": "identity",
-        "source": "systemd/rpa4all-validation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.timer",
-        "domain": "identity",
-        "source": "systemd/rpa4all-validation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-vpn-ddns.service",
-        "domain": "identity",
-        "source": "deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "secrets_agent.service",
-        "domain": "identity",
-        "source": "tools/secrets_agent/secrets_agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "server-error-alert.service",
-        "domain": "identity",
-        "source": "deploy/homelab/server-error-alert.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "specialized_agents-dashboard.service",
-        "domain": "identity",
-        "source": "systemd/specialized_agents-dashboard.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-host-shim.service",
-        "domain": "identity",
-        "source": "systemd/storj-host-shim.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-network.service",
-        "domain": "identity",
-        "source": "systemd/storj-macvlan-network.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.service",
-        "domain": "identity",
-        "source": "systemd/storj-macvlan-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.timer",
-        "domain": "identity",
-        "source": "systemd/storj-macvlan-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.service",
-        "domain": "identity",
-        "source": "systemd/tape-quality-ollama-narrator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.timer",
-        "domain": "identity",
-        "source": "systemd/tape-quality-ollama-narrator.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-safe-eject.service",
-        "domain": "identity",
-        "source": "systemd/tape-safe-eject.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-analyst-weekly-retrain.service",
-        "domain": "identity",
-        "source": "systemd/trading-analyst-weekly-retrain.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-analyst-weekly-retrain.timer",
-        "domain": "identity",
-        "source": "systemd/trading-analyst-weekly-retrain.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-daily-report.service",
-        "domain": "identity",
-        "source": "systemd/trading-daily-report.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-daily-report.timer",
-        "domain": "identity",
-        "source": "systemd/trading-daily-report.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-local-key-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/tuya-local-key-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-local-key-selfheal.timer",
-        "domain": "identity",
-        "source": "systemd/tuya-local-key-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.service",
-        "domain": "identity",
-        "source": "systemd/tuya-token-renewer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.timer",
-        "domain": "identity",
-        "source": "systemd/tuya-token-renewer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-selfheal.service",
-        "domain": "identity",
-        "source": "systemd/tuya-token-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-selfheal.timer",
-        "domain": "identity",
-        "source": "systemd/tuya-token-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "whatsapp-toolcall-chunked-train.service",
-        "domain": "identity",
-        "source": "systemd/whatsapp-toolcall-chunked-train.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "whatsapp-toolcall-chunked-train.timer",
-        "domain": "identity",
-        "source": "systemd/whatsapp-toolcall-chunked-train.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "wireguard-nat.service",
-        "domain": "identity",
-        "source": "deploy/vpn/wireguard-nat.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "workstation-win11l-http@.service",
-        "domain": "identity",
-        "source": "systemd/workstation-win11l-http@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "workstation-win11l-rdp@.service",
-        "domain": "identity",
-        "source": "systemd/workstation-win11l-rdp@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "x-agent.service",
-        "domain": "identity",
-        "source": "tools/x_agent/x-agent.service",
         "kind": "systemd",
         "critical": true
       },
@@ -3326,6 +2133,384 @@
         "name": "tunnel-healthcheck-exporter.service",
         "domain": "monitoring",
         "source": "systemd/tunnel-healthcheck-exporter.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "proxy",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "cloudflared-named@.service",
+        "domain": "network",
+        "source": "tools/tunnels/cloudflared-named@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "cloudflared-tunnel-guardian.service",
+        "domain": "network",
+        "source": "systemd/cloudflared-tunnel-guardian.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "cloudflared-tunnel-guardian.timer",
+        "domain": "network",
+        "source": "systemd/cloudflared-tunnel-guardian.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "cloudflared.service",
+        "domain": "network",
+        "source": "tools/tunnels/cloudflared/cloudflared.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "dhcp-selfheal.service",
+        "domain": "network",
+        "source": "systemd/dhcp-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-lan-gateway.service",
+        "domain": "network",
+        "source": "deploy/vpn/homelab-lan-gateway.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-vpn-bypass-watchdog.service",
+        "domain": "network",
+        "source": "systemd/iot-vpn-bypass-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-vpn-bypass-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/iot-vpn-bypass-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ipv6-proxy.service",
+        "domain": "network",
+        "source": "systemd/ipv6-proxy.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "localtunnel@.service",
+        "domain": "network",
+        "source": "tools/tunnels/localtunnel@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "pihole-ipv6-dns-fix.service",
+        "domain": "network",
+        "source": "systemd/pihole-ipv6-dns-fix.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-best-server.service",
+        "domain": "network",
+        "source": "systemd/protonvpn-best-server.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-best-server.timer",
+        "domain": "network",
+        "source": "systemd/protonvpn-best-server.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-boot-selfheal.service",
+        "domain": "network",
+        "source": "systemd/protonvpn-boot-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-routing-watchdog-fix.service",
+        "domain": "network",
+        "source": "deploy/vpn/protonvpn-routing-watchdog-fix.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-routing-watchdog.service",
+        "domain": "network",
+        "source": "deploy/vpn/protonvpn-routing-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-unit-selfheal.service",
+        "domain": "network",
+        "source": "systemd/protonvpn-unit-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "protonvpn-unit-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/protonvpn-unit-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-ddns-server.service",
+        "domain": "network",
+        "source": "deploy/vpn/rpa4all-ddns-server.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-vpn-ddns.service",
+        "domain": "network",
+        "source": "deploy/vpn-deb/rpa4all-vpn/usr/share/rpa4all-vpn/rpa4all-vpn-ddns.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "wireguard-nat.service",
+        "domain": "network",
+        "source": "deploy/vpn/wireguard-nat.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.service",
+        "domain": "storage",
+        "source": "systemd/disk-clean.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.timer",
+        "domain": "storage",
+        "source": "systemd/disk-clean.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-spindown.service",
+        "domain": "storage",
+        "source": "tools/homelab/disk-spindown.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-disk-backup.service",
+        "domain": "storage",
+        "source": "tools/backup/homelab-disk-backup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-sg1.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-logrotate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-logrotate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-backup-catalog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-backup-catalog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-boot-reconcile.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-boot-reconcile.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-button-watch.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-button-watch.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-deep-recovery.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-log-rotation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-log-rotation.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-selfheal-escalator.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-sg1.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6b.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6b.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-window-enforcer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-window-enforcer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.service",
+        "domain": "storage",
+        "source": "systemd/lto6-drain-backups.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.timer",
+        "domain": "storage",
+        "source": "systemd/lto6-drain-backups.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-host-shim.service",
+        "domain": "storage",
+        "source": "systemd/storj-host-shim.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-network.service",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-network.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.service",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.timer",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.service",
+        "domain": "storage",
+        "source": "systemd/tape-quality-ollama-narrator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.timer",
+        "domain": "storage",
+        "source": "systemd/tape-quality-ollama-narrator.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-safe-eject.service",
+        "domain": "storage",
+        "source": "systemd/tape-safe-eject.service",
         "kind": "systemd",
         "critical": true
       }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,17 +1,21 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T19:14:33.403088+00:00`
+- Generated at: `2026-07-29T19:21:35.260920+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`
-- Critical services flagged for MVP: `193`
+- Critical services flagged for MVP: `76`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
-- `identity`: 175
+- `identity`: 4
 - `monitoring`: 18
+- `network`: 22
+- `operations`: 106
+- `storage`: 32
+- `trading`: 11
 
 ## Trading profile instances (`12`)
 
@@ -34,46 +38,46 @@
 
 ## MVP critical services
 
-- `glpi` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `glpi-db` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `mail-db` (identity, compose) from `docker/docker-compose.simple-mail.yml`
-- `mail-server` (identity, compose) from `docker/docker-compose.simple-mail.yml`
-- `mailu-backend` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-db` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-dovecot` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-frontend` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-postfix` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-redis` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-roundcube` (identity, compose) from `docker/docker-compose.mailu.yml`
-- `netbox` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-postgres` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-redis` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-redis-cache` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-worker` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `nginx` (identity, compose) from `docker/docker-compose.simple-mail.yml`
-- `ntopng` (identity, compose) from `docker/docker-compose.ntopng.yml`
-- `ntopng-redis` (identity, compose) from `docker/docker-compose.ntopng.yml`
 - `open-webui` (identity, compose) from `tools/authentik_management/configs/docker-compose.override.yml`
-- `opensearch-dashboards` (identity, compose) from `docker/docker-compose.opensearch.yml`
-- `opensearch-node1` (identity, compose) from `docker/docker-compose.opensearch.yml`
-- `postgres` (identity, compose) from `docker/docker-compose.email-simple.yml`
-- `printshare` (identity, compose) from `deploy/printshare/docker-compose.yml`
-- `proxy` (identity, compose) from `deploy/cmdb/docker-compose.yml`
-- `roundcube` (identity, compose) from `docker/docker-compose.simple-mail.yml`
 - `vaultwarden` (identity, compose) from `tools/vaultwarden/docker-compose.yml`
-- `wikijs` (identity, compose) from `docker/docker-compose.wikijs.yml`
-- `wikijs-db` (identity, compose) from `docker/docker-compose.wikijs.yml`
-- `akash-sweep.service` (identity, systemd) from `systemd/akash-sweep.service`
-- `akash-sweep.timer` (identity, systemd) from `systemd/akash-sweep.timer`
-- `approval-gateway.service` (identity, systemd) from `systemd/approval-gateway.service`
-- `auto_validate.service` (identity, systemd) from `deploy/auto_validate.service`
-- `autonomous_remediator.service` (identity, systemd) from `tools/systemd/autonomous_remediator.service`
-- `bn-acervo-agent.service` (identity, systemd) from `systemd/bn-acervo-agent.service`
-- `candle-collector.service` (identity, systemd) from `systemd/candle-collector.service`
-- `candle-collector.timer` (identity, systemd) from `systemd/candle-collector.timer`
-- `check_projects.service` (identity, systemd) from `systemd/check_projects.service`
-- `check_projects.timer` (identity, systemd) from `systemd/check_projects.timer`
-- `chromecast-ambilight.service` (identity, systemd) from `systemd/chromecast-ambilight.service`
+- `homelab-vault-backup.service` (identity, systemd) from `systemd/homelab-vault-backup.service`
+- `homelab-vault-close.service` (identity, systemd) from `systemd/homelab-vault-close.service`
+- `cadvisor` (monitoring, compose) from `docker/docker-compose-exporters.yml`
+- `grafana` (monitoring, compose) from `tools/authentik_management/configs/docker-compose.override.yml`
+- `node-exporter` (monitoring, compose) from `docker/docker-compose-exporters.yml`
+- `postfix-exporter` (monitoring, compose) from `docker/docker-compose.simple-mail.yml`
+- `prometheus` (monitoring, compose) from `docker/docker-compose.grafana.yml`
+- `agent-network-exporter.service` (monitoring, systemd) from `tools/systemd/agent-network-exporter.service`
+- `banking-metrics-exporter.service` (monitoring, systemd) from `systemd/banking-metrics-exporter.service`
+- `eddie_central_extended_metrics.service` (monitoring, systemd) from `systemd/eddie_central_extended_metrics.service`
+- `grafana-dashboard-sync.service` (monitoring, systemd) from `systemd/grafana-dashboard-sync.service`
+- `grafana-selfheal.service` (monitoring, systemd) from `systemd/grafana-selfheal.service`
+- `job-monitor.service` (monitoring, systemd) from `systemd/job-monitor.service`
+- `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
+- `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
+- `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
+- `storj-payout-monitor.service` (monitoring, systemd) from `systemd/storj-payout-monitor.service`
+- `storj-payout-monitor.timer` (monitoring, systemd) from `systemd/storj-payout-monitor.timer`
+- `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
+- `tunnel-healthcheck-exporter.service` (monitoring, systemd) from `systemd/tunnel-healthcheck-exporter.service`
+- `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
+- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
+- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
+- `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
+- `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
+- `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
+- `iot-vpn-bypass-watchdog.service` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.service`
+- `iot-vpn-bypass-watchdog.timer` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.timer`
+- `ipv6-proxy.service` (network, systemd) from `systemd/ipv6-proxy.service`
+- `localtunnel@.service` (network, systemd) from `tools/tunnels/localtunnel@.service`
+- `pihole-ipv6-dns-fix.service` (network, systemd) from `systemd/pihole-ipv6-dns-fix.service`
+- `protonvpn-best-server.service` (network, systemd) from `systemd/protonvpn-best-server.service`
+- `protonvpn-best-server.timer` (network, systemd) from `systemd/protonvpn-best-server.timer`
+- `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
+- `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
+- `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
+- `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
 
 ## Serviços anotados manualmente
 

--- a/scripts/misc/google_calendar_oauth_consent.py
+++ b/scripts/misc/google_calendar_oauth_consent.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Consentimento OAuth do Google Calendar — headless, Authentik-first.
+
+Substitui o setup_google_calendar.py antigo (que só entendia credentials.json
+em disco e apontava pro diretório errado). Este wrapper usa o mesmo caminho
+do serviço: client OAuth vem do Authentik via Secrets Agent
+(google/oauth_client_installed#client_id/#client_secret), com credentials.json
+como fallback de compatibilidade.
+
+O consentimento em si é inerentemente do dono (abrir a URL, autorizar a conta
+Google). Como o homelab é headless, o fluxo usa um servidor local de redirect
+e o dono acessa via túnel SSH:
+
+  # no SEU desktop (não no homelab):
+  ssh -L 8765:localhost:8765 homelab
+
+  # dentro dessa sessão ssh:
+  cd /home/homelab/myClaude && python3 scripts/misc/google_calendar_oauth_consent.py
+
+  # abra no navegador DO SEU DESKTOP a URL que o script imprimir;
+  # autorize a conta edenilson.adm@gmail.com; o redirect volta pelo túnel
+  # e o token fica salvo em scripts/misc/calendar_data/token.pickle.
+
+Depois do token salvo, religar o serviço:
+  sudo systemctl reset-failed eddie-calendar.service
+  sudo systemctl start eddie-calendar.service
+"""
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))            # google_calendar_integration
+sys.path.insert(0, str(HERE.parent.parent))  # tools.secrets_loader
+
+REDIRECT_PORT = 8765
+
+
+def main() -> int:
+    from google_calendar_integration import (  # noqa: E402
+        GoogleCalendarIntegration, CREDENTIALS_FILE, TOKEN_FILE, SCOPES,
+        GOOGLE_OAUTH_SECRET,
+    )
+    from google_auth_oauthlib.flow import InstalledAppFlow  # noqa: E402
+
+    integ = GoogleCalendarIntegration()
+    if integ.is_authenticated():
+        print("✅ Já autenticado — token válido em", TOKEN_FILE)
+        return 0
+
+    client_config = integ._client_config_from_vault()
+    if client_config is not None:
+        print(f"🔐 Client OAuth obtido do Authentik ({GOOGLE_OAUTH_SECRET})")
+        flow = InstalledAppFlow.from_client_config(client_config, SCOPES)
+    elif CREDENTIALS_FILE.exists():
+        print(f"⚠️  Cofre vazio — usando fallback {CREDENTIALS_FILE}")
+        flow = InstalledAppFlow.from_client_secrets_file(str(CREDENTIALS_FILE), SCOPES)
+    else:
+        print(
+            f"❌ Secret '{GOOGLE_OAUTH_SECRET}' vazio no Authentik e sem "
+            "credentials.json local.\n   Popule com: "
+            "scripts/import_bw_secret_to_authentik.sh --search google"
+        )
+        return 1
+
+    print(f"\n🌐 Aguardando consentimento na porta {REDIRECT_PORT}…")
+    print("   (rode `ssh -L 8765:localhost:8765 homelab` no seu desktop e abra")
+    print("    a URL abaixo no navegador do desktop)\n")
+    creds = flow.run_local_server(
+        host="localhost", port=REDIRECT_PORT,
+        open_browser=False,
+        authorization_prompt_message="👉 Abra esta URL no navegador:\n{url}\n",
+        success_message="Autorizado! Pode fechar esta aba e voltar ao terminal.",
+    )
+
+    TOKEN_FILE.parent.mkdir(exist_ok=True)
+    with open(TOKEN_FILE, "wb") as fh:
+        pickle.dump(creds, fh)
+    print(f"\n✅ Token salvo em {TOKEN_FILE}")
+    print("   Agora: sudo systemctl reset-failed eddie-calendar.service && "
+          "sudo systemctl start eddie-calendar.service")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Wrapper de consentimento que usa o caminho novo (client OAuth do Authentik, `credentials.json` como fallback) e funciona no homelab headless via `ssh -L 8765:localhost:8765`. Substitui o setup antigo, que só entendia arquivo em disco e apontava pro diretório errado.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)