### PR TITLE
fix(secrets): resolve chave do Secrets Agent no próprio homelab

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T19:21:35.260920+00:00",
-  "repo_root": "/tmp/wb-consent",
+  "generated_at": "2026-07-29T19:26:57.918463+00:00",
+  "repo_root": "/tmp/wb-apikey",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T19:21:35.260920+00:00`
+- Generated at: `2026-07-29T19:26:57.918463+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/scripts/import_bw_secret_to_authentik.sh
+++ b/scripts/import_bw_secret_to_authentik.sh
@@ -40,10 +40,29 @@ command -v jq >/dev/null || die "jq não encontrado (apt install jq)."
 
 [[ -n "${BW_SESSION:-}" ]] || die "BW_SESSION não definido. Rode antes: export BW_SESSION=\$(bw unlock --raw)"
 
-# A chave nunca fica em código/repo (público) — vem do ambiente, cuja fonte
-# canônica é ~/.config/homelab/secrets.env (0600, fora do git).
-[[ -n "${SECRETS_AGENT_API_KEY:-}" ]] || die \
-  "SECRETS_AGENT_API_KEY ausente do ambiente. Rode: set -a; source ~/.config/homelab/secrets.env; set +a"
+# A chave nunca fica em código/repo (público). Resolvida em runtime, em ordem:
+#   1. ambiente já exportado
+#   2. ~/.config/homelab/secrets.env (0600, fora do git) — fonte na workstation
+#   3. environment do secrets_agent.service — fonte no próprio homelab, onde
+#      o secrets.env da workstation não existe
+KEY_VAR="SECRETS_AGENT_API_KEY"
+
+if [[ -z "${!KEY_VAR:-}" && -r "$HOME/.config/homelab/secrets.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a; source "$HOME/.config/homelab/secrets.env"; set +a
+fi
+
+if [[ -z "${!KEY_VAR:-}" ]]; then
+  resolved="$(systemctl show secrets_agent.service -p Environment --value 2>/dev/null \
+              | tr ' ' '\n' \
+              | awk -v k="$KEY_VAR" -F= '$1==k { print substr($0, length(k)+2) }' \
+              | head -1)"
+  [[ -n "$resolved" ]] && export "$KEY_VAR"="$resolved"
+  unset resolved
+fi
+
+[[ -n "${!KEY_VAR:-}" ]] || die \
+  "$KEY_VAR não resolvida (nem env, nem ~/.config/homelab/secrets.env, nem secrets_agent.service)."
 
 MODE=""; ITEM=""; TARGET=""; declare -a MAPS=()
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
O script exigia `~/.config/homelab/secrets.env` (fonte da workstation); no homelab a chave vive no environment do `secrets_agent.service`. Agora resolve em cascata: env → secrets.env → systemd.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)