### PR TITLE
fix(calendar): corrige nome da classe no wrapper de consentimento OAuth

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T19:26:57.918463+00:00",
-  "repo_root": "/tmp/wb-apikey",
+  "generated_at": "2026-07-29T19:32:56.318831+00:00",
+  "repo_root": "/tmp/wb-fix2",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T19:26:57.918463+00:00`
+- Generated at: `2026-07-29T19:32:56.318831+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/scripts/misc/google_calendar_oauth_consent.py
+++ b/scripts/misc/google_calendar_oauth_consent.py
@@ -40,12 +40,12 @@ REDIRECT_PORT = 8765
 
 def main() -> int:
     from google_calendar_integration import (  # noqa: E402
-        GoogleCalendarIntegration, CREDENTIALS_FILE, TOKEN_FILE, SCOPES,
+        GoogleCalendarClient, CREDENTIALS_FILE, TOKEN_FILE, SCOPES,
         GOOGLE_OAUTH_SECRET,
     )
     from google_auth_oauthlib.flow import InstalledAppFlow  # noqa: E402
 
-    integ = GoogleCalendarIntegration()
+    integ = GoogleCalendarClient()
     if integ.is_authenticated():
         print("✅ Já autenticado — token válido em", TOKEN_FILE)
         return 0


### PR DESCRIPTION
A classe é `GoogleCalendarClient`, não `GoogleCalendarIntegration` — o wrapper falhava no import. Verificado no host: com o nome certo, o client config é montado a partir do Authentik com sucesso.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)