### PR TITLE
fix(calendar): porta 8771 no consentimento OAuth (8765 é do vault server)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T19:32:56.318831+00:00",
-  "repo_root": "/tmp/wb-fix2",
+  "generated_at": "2026-07-29T22:19:29.897334+00:00",
+  "repo_root": "/tmp/wb-port",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T19:32:56.318831+00:00`
+- Generated at: `2026-07-29T22:19:29.897334+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`

--- a/docs/variables-taxonomy/GCAL_OAUTH_PORT.md
+++ b/docs/variables-taxonomy/GCAL_OAUTH_PORT.md
@@ -1,0 +1,12 @@
+# GCAL_OAUTH_PORT
+
+## Propósito
+Porta do servidor local de redirect usado no consentimento OAuth do Google Calendar (`scripts/misc/google_calendar_oauth_consent.py`). O homelab é headless, então o dono acessa via túnel SSH (`ssh -L <porta>:localhost:<porta> homelab`) e o redirect do Google volta por ele.
+
+## Escopo
+- **Consumidor**: `scripts/misc/google_calendar_oauth_consent.py` (`REDIRECT_PORT`).
+- **Default**: `8771`.
+- **Não usar 8765**: já é do vault server do homelab (`homelab-vault-backup.service` faz health-check em `http://localhost:8765/api/status`). Tentar bindar ali falha com `OSError: [Errno 98] Address already in use` — verificado em produção 2026-07-29.
+
+## Relacionadas
+- [[GOOGLE_OAUTH_SECRET_NAME]]

--- a/scripts/misc/google_calendar_oauth_consent.py
+++ b/scripts/misc/google_calendar_oauth_consent.py
@@ -9,17 +9,14 @@ como fallback de compatibilidade.
 
 O consentimento em si é inerentemente do dono (abrir a URL, autorizar a conta
 Google). Como o homelab é headless, o fluxo usa um servidor local de redirect
-e o dono acessa via túnel SSH:
+e o dono acessa via túnel SSH — UM comando só, do desktop dele (o túnel e a
+execução remota na mesma invocação, pra não confundir sessão local com remota):
 
-  # no SEU desktop (não no homelab):
-  ssh -L 8765:localhost:8765 homelab
+  ssh -L 8771:localhost:8771 homelab 'cd /home/homelab/myClaude && python3 scripts/misc/google_calendar_oauth_consent.py'
 
-  # dentro dessa sessão ssh:
-  cd /home/homelab/myClaude && python3 scripts/misc/google_calendar_oauth_consent.py
-
-  # abra no navegador DO SEU DESKTOP a URL que o script imprimir;
-  # autorize a conta edenilson.adm@gmail.com; o redirect volta pelo túnel
-  # e o token fica salvo em scripts/misc/calendar_data/token.pickle.
+  # a URL aparece no terminal; abra no navegador DO DESKTOP, autorize a conta
+  # edenilson.adm@gmail.com; o redirect volta pelo túnel e o token fica salvo
+  # em scripts/misc/calendar_data/token.pickle.
 
 Depois do token salvo, religar o serviço:
   sudo systemctl reset-failed eddie-calendar.service
@@ -27,6 +24,7 @@ Depois do token salvo, religar o serviço:
 """
 from __future__ import annotations
 
+import os
 import pickle
 import sys
 from pathlib import Path
@@ -35,7 +33,9 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))            # google_calendar_integration
 sys.path.insert(0, str(HERE.parent.parent))  # tools.secrets_loader
 
-REDIRECT_PORT = 8765
+# 8765 NÃO serve: já é do vault server do homelab (homelab-vault-backup.service)
+# — bind falha com EADDRINUSE. 8771 está livre; ajustável via env se preciso.
+REDIRECT_PORT = int(os.environ.get("GCAL_OAUTH_PORT", "8771"))
 
 
 def main() -> int:
@@ -66,8 +66,8 @@ def main() -> int:
         return 1
 
     print(f"\n🌐 Aguardando consentimento na porta {REDIRECT_PORT}…")
-    print("   (rode `ssh -L 8765:localhost:8765 homelab` no seu desktop e abra")
-    print("    a URL abaixo no navegador do desktop)\n")
+    print("   (abra a URL abaixo no navegador do SEU desktop — o redirect")
+    print(f"    volta pelo túnel -L {REDIRECT_PORT}:localhost:{REDIRECT_PORT})\n")
     creds = flow.run_local_server(
         host="localhost", port=REDIRECT_PORT,
         open_browser=False,


### PR DESCRIPTION
A 8765 já está bindada pelo vault server do homelab → `OSError: [Errno 98] Address already in use` antes de imprimir a URL. Porta agora 8771 (`GCAL_OAUTH_PORT`), e a docstring passou a mostrar um comando único (túnel + execução remota juntos).

🤖 Gerado com [Claude Code](https://claude.com/claude-code)