### PR TITLE
fix(network): mitiga queda espontânea de internet LAN (ProtonVPN policy rules)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,17 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/tools/copilot_hooks/internet_preference_context.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": ".*",

--- a/.grok/hooks/claude-code-import.json
+++ b/.grok/hooks/claude-code-import.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/tools/copilot_hooks/internet_preference_context.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": ".*",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md — eddie-auto-dev / Shared Auto-Dev
+
+Monorepo do homelab RPA4All: automação, trading, Nextcloud/LTO, wiki, agentes especializados e ops.
+
+## Papel dos harnesses
+
+| Ferramenta | Quando usar |
+|------------|-------------|
+| **Claude Code / Grok Build** | Refactors grandes, multi-file, arquitetura |
+| **Codex** | Trechos com modelos OpenAI |
+| **Pi + Ollama** | Coding local barato / fallback (este arquivo é lido pelo Pi) |
+| **specialized_agents + systemd** | Domínio 24/7 (trading, Nextcloud, wiki, selfheal) |
+
+Setup Pi: `docs/PI_CODING_AGENT_SETUP.md`  
+Hooks Pi: `.pi/extensions/rpa4all-hooks/` (bridge para `tools/hooks` + `tools/copilot_hooks`)
+
+## Políticas críticas (não violar)
+
+1. **Sem LLM chinês** (Qwen, DeepSeek, ERNIE, ChatGLM, etc.) — política 2026-07-01. Preferir Llama, Mistral, Gemma, Phi.
+2. **PostgreSQL** na porta **5433** (schema `btc`); SQLite proibido para trading.
+3. **Fita LTO**: nunca `ltfsck`/`mkltfs`/`sg_raw` diretos — usar orchestrator `ltfs_recovery.py`.
+4. **Sem force-push** em `main`; sem `rm -rf` / `git reset --hard` sem ordem explícita do usuário.
+5. **Secrets**: vault/Authentik/env — nunca hardcode em código.
+6. Rede/firewall: só com rollback `at` agendado.
+7. Wiki: publicar via agent `wiki_rpa4all`, não scrape/update direto arbitrário.
+8. **Internet desta workstation**: preferir **RJ45** (`enp0s31f6`) e **Wi‑Fi GVT-38AA**; SSID **TANK** só como fallback. Hook: `tools/copilot_hooks/internet_preference_context.py`.
+
+## Layout útil
+
+- `scripts/`, `tools/` — utilitários e hooks
+- `specialized_agents/` — agentes de domínio
+- `systemd/` — unidades de produção (cuidado)
+- `docs/` — documentação operacional
+- `tests/` — pytest
+
+## Preferências de código
+
+- Python 3.13, mudanças mínimas e focadas.
+- Não commitar secrets, sessões, ou artefatos de runtime.
+- Antes de mexer em trading live / LTO / rede: confirmar com o usuário.

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-29T22:19:29.897334+00:00",
-  "repo_root": "/tmp/wb-port",
+  "generated_at": "2026-07-30T01:31:25.151236+00:00",
+  "repo_root": "/tmp/eddie-vpn-pr-11996",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
@@ -8,14 +8,11 @@
     "hosts": 1,
     "repo_services": 193,
     "trading_instances": 12,
-    "critical_services": 76,
+    "critical_services": 193,
     "domains": {
       "identity": 4,
       "monitoring": 18,
-      "network": 22,
-      "operations": 106,
-      "storage": 32,
-      "trading": 11
+      "network": 171
     }
   },
   "trading_instances": [
@@ -374,10 +371,322 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "glpi",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "glpi-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mail-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mail-server",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-backend",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-dovecot",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-frontend",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-postfix",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-roundcube",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-postgres",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-redis-cache",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-worker",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nginx",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ntopng",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ntopng-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "opensearch-dashboards",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "opensearch-node1",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "postgres",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.email-simple.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "printshare",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/printshare/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "proxy",
       "domain": "network",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "roundcube",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "wikijs",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "wikijs-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "akash-sweep.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "akash-sweep.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "approval-gateway.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/approval-gateway.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "auto_validate.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/auto_validate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "autonomous_remediator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/autonomous_remediator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "bn-acervo-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/bn-acervo-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "check_projects.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/check_projects.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "check_projects.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/check_projects.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "chromecast-ambilight.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/chromecast-ambilight.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "clear-agent@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/clear-agent@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "clear-trading-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/clear-trading-agent.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -414,6 +723,62 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "coordinator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/coordinator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "crypto-agent@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/crypto-agent@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-broadcast.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-broadcast.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-panel.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-panel.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "decisions-track-record-rollup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "decisions-track-record-rollup.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "dhcp-selfheal.service",
       "domain": "network",
       "kind": "systemd",
@@ -422,10 +787,194 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "diretor.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/diretor.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-clean.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-clean.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-spindown.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/homelab/disk-spindown.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-calendar.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-calendar.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-expurgo.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-expurgo.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-telegram-bot.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-telegram-bot.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-tray-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/eddie-tray-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-whatsapp-bot.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-whatsapp-bot.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ethwan-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "final-boot-status-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "gdrive-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/gdrive-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "github-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/github-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-dashboard.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-disk-backup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/backup/homelab-disk-backup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "homelab-lan-gateway.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/homelab-lan-gateway.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-presence-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-presence-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -454,6 +1003,62 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "journal-ingestor.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "journal-ingestor.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-postgres-sync.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-postgres-sync.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "llm-log-panel.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/llm-log-panel.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "localtunnel@.service",
       "domain": "network",
       "kind": "systemd",
@@ -462,10 +1067,338 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "ltfs-backup-catalog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-boot-reconcile.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-boot-reconcile.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-button-watch.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-button-watch.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-deep-recovery.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-selfheal-escalator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-sg1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6b.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6b.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-checkpoint-drain.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-drain.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-checkpoint-recover.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-recover.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-smb-proof-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-api.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-api.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-daily-report.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-daily-report.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-email-drip.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-email-drip.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-x-posts.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-x-posts.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "meeting-translator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/meeting-translator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nas-ollama-load.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/nas-ollama-load.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "notebook-power-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nvidia-clock-limit.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/nvidia-clock-limit.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-finetune.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-finetune.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu-coordinator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu-coordinator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/ollama-gpu-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-warmup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-warmup.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "pandaplus-telegram-bridge.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/pandaplus-telegram-bridge.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "pihole-ipv6-dns-fix.service",
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/pihole-ipv6-dns-fix.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "post-boot-check.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/post-boot-check.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "printshare.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/printshare/printshare.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -526,10 +1459,66 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "python-training.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/python-training.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "python-training.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/python-training.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rag-reindex.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rag-reindex.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "review-service.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/review-service.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "rpa4all-ddns-server.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/rpa4all-ddns-server.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-validation.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-validation.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -542,6 +1531,182 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "secrets_agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/secrets_agent/secrets_agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "server-error-alert.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/homelab/server-error-alert.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "specialized_agents-dashboard.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-host-shim.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-host-shim.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-network.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-network.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-safe-eject.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-safe-eject.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-daily-report.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-daily-report.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-local-key-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-local-key-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-renewer.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-renewer.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "wireguard-nat.service",
       "domain": "network",
       "kind": "systemd",
@@ -550,1196 +1715,28 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "glpi",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "glpi-db",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mail-db",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mail-server",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-backend",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-db",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-dovecot",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-frontend",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-postfix",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-redis",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-roundcube",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-postgres",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-redis",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-redis-cache",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-worker",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nginx",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ntopng",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ntopng-redis",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "opensearch-dashboards",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "opensearch-node1",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "postgres",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.email-simple.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "printshare",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "deploy/printshare/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "roundcube",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "wikijs",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "wikijs-db",
-      "domain": "operations",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "akash-sweep.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "akash-sweep.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "approval-gateway.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/approval-gateway.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "auto_validate.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "deploy/auto_validate.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "autonomous_remediator.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/systemd/autonomous_remediator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "bn-acervo-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/bn-acervo-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "check_projects.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/check_projects.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "check_projects.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/check_projects.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "chromecast-ambilight.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/chromecast-ambilight.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "clear-agent@.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/clear-agent@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "coordinator.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/coordinator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "crypto-agent@.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/crypto-agent@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-broadcast.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-broadcast.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-panel.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-panel.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "decisions-track-record-rollup.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "decisions-track-record-rollup.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "diretor.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/diretor.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-calendar.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/eddie-calendar.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-expurgo.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/eddie-expurgo.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-telegram-bot.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/eddie-telegram-bot.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-tray-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/systemd/eddie-tray-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-whatsapp-bot.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/eddie-whatsapp-bot.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ethwan-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ethwan-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "final-boot-status-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/systemd/final-boot-status-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "gdrive-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/systemd/gdrive-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "github-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/github-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "homelab-dashboard.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/homelab-dashboard.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "iot-presence-watchdog.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "iot-presence-watchdog.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "journal-ingestor.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "journal-ingestor.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "llm-log-panel.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/llm-log-panel.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-checkpoint-drain.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-drain.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-checkpoint-recover.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-recover.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-selfheal.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-smb-proof-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-api.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-api.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-daily-report.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-daily-report.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-email-drip.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-email-drip.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-x-posts.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-x-posts.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "meeting-translator.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/meeting-translator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nas-ollama-load.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/nas-ollama-load.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "notebook-power-agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/notebook-power-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nvidia-clock-limit.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/nvidia-clock-limit.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-finetune.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-finetune.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu-coordinator.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu-coordinator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/ollama-gpu-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu1.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu1.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-warmup.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-warmup.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "pandaplus-telegram-bridge.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/pandaplus-telegram-bridge.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "post-boot-check.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/post-boot-check.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "printshare.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "deploy/printshare/printshare.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "python-training.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/python-training.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "python-training.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/python-training.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rag-reindex.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rag-reindex.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "review-service.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/systemd/review-service.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rpa4all-validation.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rpa4all-validation.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "secrets_agent.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "tools/secrets_agent/secrets_agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "server-error-alert.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "deploy/homelab/server-error-alert.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "specialized_agents-dashboard.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/specialized_agents-dashboard.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-local-key-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-local-key-selfheal.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-renewer.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-renewer.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-selfheal.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-selfheal.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.service",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.timer",
-      "domain": "operations",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
       "name": "workstation-win11l-http@.service",
-      "domain": "operations",
+      "domain": "network",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-http@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
     },
     {
       "name": "workstation-win11l-rdp@.service",
-      "domain": "operations",
+      "domain": "network",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-rdp@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
     },
     {
       "name": "x-agent.service",
-      "domain": "operations",
+      "domain": "network",
       "kind": "systemd",
       "source": "tools/x_agent/x-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "disk-clean.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-spindown.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/homelab/disk-spindown.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-disk-backup.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/backup/homelab-disk-backup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-boot-reconcile.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-boot-reconcile.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-button-watch.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-button-watch.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-deep-recovery.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-deep-recovery.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-selfheal-escalator.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-sg1.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6b.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6b.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-host-shim.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-host-shim.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-network.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-network.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-safe-eject.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-safe-eject.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "candle-collector.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "clear-trading-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/clear-trading-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-postgres-sync.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-postgres-sync.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-daily-report.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-daily-report.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
     },
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
@@ -2137,10 +2134,283 @@
         "critical": true
       },
       {
+        "name": "glpi",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "glpi-db",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mail-db",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mail-server",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-backend",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-db",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-dovecot",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-frontend",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-postfix",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-redis",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-roundcube",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-postgres",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-redis",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-redis-cache",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-worker",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "nginx",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "ntopng",
+        "domain": "network",
+        "source": "docker/docker-compose.ntopng.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "ntopng-redis",
+        "domain": "network",
+        "source": "docker/docker-compose.ntopng.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "opensearch-dashboards",
+        "domain": "network",
+        "source": "docker/docker-compose.opensearch.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "opensearch-node1",
+        "domain": "network",
+        "source": "docker/docker-compose.opensearch.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "postgres",
+        "domain": "network",
+        "source": "docker/docker-compose.email-simple.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "printshare",
+        "domain": "network",
+        "source": "deploy/printshare/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
         "name": "proxy",
         "domain": "network",
         "source": "deploy/cmdb/docker-compose.yml",
         "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "roundcube",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "wikijs",
+        "domain": "network",
+        "source": "docker/docker-compose.wikijs.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "wikijs-db",
+        "domain": "network",
+        "source": "docker/docker-compose.wikijs.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "akash-sweep.service",
+        "domain": "network",
+        "source": "systemd/akash-sweep.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "akash-sweep.timer",
+        "domain": "network",
+        "source": "systemd/akash-sweep.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "approval-gateway.service",
+        "domain": "network",
+        "source": "systemd/approval-gateway.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "auto_validate.service",
+        "domain": "network",
+        "source": "deploy/auto_validate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "autonomous_remediator.service",
+        "domain": "network",
+        "source": "tools/systemd/autonomous_remediator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "bn-acervo-agent.service",
+        "domain": "network",
+        "source": "systemd/bn-acervo-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "candle-collector.service",
+        "domain": "network",
+        "source": "systemd/candle-collector.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "candle-collector.timer",
+        "domain": "network",
+        "source": "systemd/candle-collector.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "check_projects.service",
+        "domain": "network",
+        "source": "systemd/check_projects.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "check_projects.timer",
+        "domain": "network",
+        "source": "systemd/check_projects.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "chromecast-ambilight.service",
+        "domain": "network",
+        "source": "systemd/chromecast-ambilight.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "clear-agent@.service",
+        "domain": "network",
+        "source": "systemd/clear-agent@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "clear-trading-agent.service",
+        "domain": "network",
+        "source": "systemd/clear-trading-agent.service",
+        "kind": "systemd",
         "critical": true
       },
       {
@@ -2172,6 +2442,55 @@
         "critical": true
       },
       {
+        "name": "coordinator.service",
+        "domain": "network",
+        "source": "systemd/coordinator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "crypto-agent@.service",
+        "domain": "network",
+        "source": "systemd/crypto-agent@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-broadcast.service",
+        "domain": "network",
+        "source": "systemd/daily-agenda-broadcast.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-broadcast.timer",
+        "domain": "network",
+        "source": "systemd/daily-agenda-broadcast.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-panel.service",
+        "domain": "network",
+        "source": "systemd/daily-agenda-panel.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "decisions-track-record-rollup.service",
+        "domain": "network",
+        "source": "systemd/decisions-track-record-rollup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "decisions-track-record-rollup.timer",
+        "domain": "network",
+        "source": "systemd/decisions-track-record-rollup.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "dhcp-selfheal.service",
         "domain": "network",
         "source": "systemd/dhcp-selfheal.service",
@@ -2179,9 +2498,170 @@
         "critical": true
       },
       {
+        "name": "diretor.service",
+        "domain": "network",
+        "source": "systemd/diretor.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.service",
+        "domain": "network",
+        "source": "systemd/disk-clean.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.timer",
+        "domain": "network",
+        "source": "systemd/disk-clean.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-spindown.service",
+        "domain": "network",
+        "source": "tools/homelab/disk-spindown.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-calendar.service",
+        "domain": "network",
+        "source": "systemd/eddie-calendar.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-expurgo.service",
+        "domain": "network",
+        "source": "systemd/eddie-expurgo.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-telegram-bot.service",
+        "domain": "network",
+        "source": "systemd/eddie-telegram-bot.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-tray-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/eddie-tray-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-whatsapp-bot.service",
+        "domain": "network",
+        "source": "systemd/eddie-whatsapp-bot.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ethwan-selfheal.service",
+        "domain": "network",
+        "source": "systemd/ethwan-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "final-boot-status-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/final-boot-status-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "gdrive-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/gdrive-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "github-agent.service",
+        "domain": "network",
+        "source": "systemd/github-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-dashboard.service",
+        "domain": "network",
+        "source": "systemd/homelab-dashboard.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-disk-backup.service",
+        "domain": "network",
+        "source": "tools/backup/homelab-disk-backup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "homelab-lan-gateway.service",
         "domain": "network",
         "source": "deploy/vpn/homelab-lan-gateway.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-sg1.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-logrotate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-logrotate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-presence-watchdog.service",
+        "domain": "network",
+        "source": "systemd/iot-presence-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-presence-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/iot-presence-watchdog.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2207,6 +2687,55 @@
         "critical": true
       },
       {
+        "name": "journal-ingestor.service",
+        "domain": "network",
+        "source": "systemd/journal-ingestor.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "journal-ingestor.timer",
+        "domain": "network",
+        "source": "systemd/journal-ingestor.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-postgres-sync.service",
+        "domain": "network",
+        "source": "systemd/kucoin-postgres-sync.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-postgres-sync.timer",
+        "domain": "network",
+        "source": "systemd/kucoin-postgres-sync.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-usdt-rebalance.service",
+        "domain": "network",
+        "source": "systemd/kucoin-usdt-rebalance.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-usdt-rebalance.timer",
+        "domain": "network",
+        "source": "systemd/kucoin-usdt-rebalance.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "llm-log-panel.service",
+        "domain": "network",
+        "source": "systemd/llm-log-panel.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "localtunnel@.service",
         "domain": "network",
         "source": "tools/tunnels/localtunnel@.service",
@@ -2214,9 +2743,296 @@
         "critical": true
       },
       {
+        "name": "ltfs-backup-catalog.service",
+        "domain": "network",
+        "source": "systemd/ltfs-backup-catalog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-backup-catalog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-boot-reconcile.service",
+        "domain": "network",
+        "source": "systemd/ltfs-boot-reconcile.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-button-watch.service",
+        "domain": "network",
+        "source": "systemd/ltfs-button-watch.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-deep-recovery.service",
+        "domain": "network",
+        "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.service",
+        "domain": "network",
+        "source": "systemd/ltfs-log-rotation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-log-rotation.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-selfheal-escalator.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-sg1.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6b.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6b.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.service",
+        "domain": "network",
+        "source": "systemd/ltfs-window-enforcer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-window-enforcer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-checkpoint-drain.service",
+        "domain": "network",
+        "source": "systemd/lto6-checkpoint-drain.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-checkpoint-recover.service",
+        "domain": "network",
+        "source": "systemd/lto6-checkpoint-recover.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.service",
+        "domain": "network",
+        "source": "systemd/lto6-drain-backups.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.timer",
+        "domain": "network",
+        "source": "systemd/lto6-drain-backups.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-selfheal.service",
+        "domain": "network",
+        "source": "systemd/lto6-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/lto6-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-smb-proof-selfheal.service",
+        "domain": "network",
+        "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-api.service",
+        "domain": "network",
+        "source": "systemd/marketing-api.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-daily-report.service",
+        "domain": "network",
+        "source": "systemd/marketing-daily-report.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-daily-report.timer",
+        "domain": "network",
+        "source": "systemd/marketing-daily-report.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-email-drip.service",
+        "domain": "network",
+        "source": "systemd/marketing-email-drip.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-email-drip.timer",
+        "domain": "network",
+        "source": "systemd/marketing-email-drip.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-x-posts.service",
+        "domain": "network",
+        "source": "systemd/marketing-x-posts.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-x-posts.timer",
+        "domain": "network",
+        "source": "systemd/marketing-x-posts.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "meeting-translator.service",
+        "domain": "network",
+        "source": "systemd/meeting-translator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "nas-ollama-load.service",
+        "domain": "network",
+        "source": "systemd/nas-ollama-load.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "notebook-power-agent.service",
+        "domain": "network",
+        "source": "systemd/notebook-power-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "nvidia-clock-limit.service",
+        "domain": "network",
+        "source": "systemd/nvidia-clock-limit.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-finetune.service",
+        "domain": "network",
+        "source": "systemd/ollama-finetune.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-finetune.timer",
+        "domain": "network",
+        "source": "systemd/ollama-finetune.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu-coordinator.service",
+        "domain": "network",
+        "source": "systemd/ollama-gpu-coordinator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu-selfheal.service",
+        "domain": "network",
+        "source": "tools/ollama-gpu-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu1.service",
+        "domain": "network",
+        "source": "systemd/ollama-gpu1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-warmup.service",
+        "domain": "network",
+        "source": "systemd/ollama-warmup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-warmup.timer",
+        "domain": "network",
+        "source": "systemd/ollama-warmup.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "pandaplus-telegram-bridge.service",
+        "domain": "network",
+        "source": "systemd/pandaplus-telegram-bridge.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "pihole-ipv6-dns-fix.service",
         "domain": "network",
         "source": "systemd/pihole-ipv6-dns-fix.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "post-boot-check.service",
+        "domain": "network",
+        "source": "systemd/post-boot-check.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "printshare.service",
+        "domain": "network",
+        "source": "deploy/printshare/printshare.service",
         "kind": "systemd",
         "critical": true
       },
@@ -2270,9 +3086,58 @@
         "critical": true
       },
       {
+        "name": "python-training.service",
+        "domain": "network",
+        "source": "systemd/python-training.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "python-training.timer",
+        "domain": "network",
+        "source": "systemd/python-training.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rag-reindex.service",
+        "domain": "network",
+        "source": "systemd/rag-reindex.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rag-reindex.timer",
+        "domain": "network",
+        "source": "systemd/rag-reindex.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "review-service.service",
+        "domain": "network",
+        "source": "tools/systemd/review-service.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "rpa4all-ddns-server.service",
         "domain": "network",
         "source": "deploy/vpn/rpa4all-ddns-server.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-validation.service",
+        "domain": "network",
+        "source": "systemd/rpa4all-validation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-validation.timer",
+        "domain": "network",
+        "source": "systemd/rpa4all-validation.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2284,6 +3149,160 @@
         "critical": true
       },
       {
+        "name": "secrets_agent.service",
+        "domain": "network",
+        "source": "tools/secrets_agent/secrets_agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "server-error-alert.service",
+        "domain": "network",
+        "source": "deploy/homelab/server-error-alert.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "specialized_agents-dashboard.service",
+        "domain": "network",
+        "source": "systemd/specialized_agents-dashboard.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-host-shim.service",
+        "domain": "network",
+        "source": "systemd/storj-host-shim.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-network.service",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-network.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.service",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.service",
+        "domain": "network",
+        "source": "systemd/tape-quality-ollama-narrator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.timer",
+        "domain": "network",
+        "source": "systemd/tape-quality-ollama-narrator.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-safe-eject.service",
+        "domain": "network",
+        "source": "systemd/tape-safe-eject.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-analyst-weekly-retrain.service",
+        "domain": "network",
+        "source": "systemd/trading-analyst-weekly-retrain.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-analyst-weekly-retrain.timer",
+        "domain": "network",
+        "source": "systemd/trading-analyst-weekly-retrain.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-daily-report.service",
+        "domain": "network",
+        "source": "systemd/trading-daily-report.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-daily-report.timer",
+        "domain": "network",
+        "source": "systemd/trading-daily-report.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-local-key-selfheal.service",
+        "domain": "network",
+        "source": "systemd/tuya-local-key-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-local-key-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/tuya-local-key-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-renewer.service",
+        "domain": "network",
+        "source": "systemd/tuya-token-renewer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-renewer.timer",
+        "domain": "network",
+        "source": "systemd/tuya-token-renewer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-selfheal.service",
+        "domain": "network",
+        "source": "systemd/tuya-token-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/tuya-token-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "whatsapp-toolcall-chunked-train.service",
+        "domain": "network",
+        "source": "systemd/whatsapp-toolcall-chunked-train.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "whatsapp-toolcall-chunked-train.timer",
+        "domain": "network",
+        "source": "systemd/whatsapp-toolcall-chunked-train.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "wireguard-nat.service",
         "domain": "network",
         "source": "deploy/vpn/wireguard-nat.service",
@@ -2291,226 +3310,23 @@
         "critical": true
       },
       {
-        "name": "disk-clean.service",
-        "domain": "storage",
-        "source": "systemd/disk-clean.service",
+        "name": "workstation-win11l-http@.service",
+        "domain": "network",
+        "source": "systemd/workstation-win11l-http@.service",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "disk-clean.timer",
-        "domain": "storage",
-        "source": "systemd/disk-clean.timer",
+        "name": "workstation-win11l-rdp@.service",
+        "domain": "network",
+        "source": "systemd/workstation-win11l-rdp@.service",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "disk-spindown.service",
-        "domain": "storage",
-        "source": "tools/homelab/disk-spindown.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-disk-backup.service",
-        "domain": "storage",
-        "source": "tools/backup/homelab-disk-backup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-sg1.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-logrotate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-logrotate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-backup-catalog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-backup-catalog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-boot-reconcile.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-boot-reconcile.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-button-watch.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-button-watch.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-deep-recovery.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-deep-recovery.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-log-rotation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-log-rotation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-selfheal-escalator.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-sg1.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6b.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6b.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-window-enforcer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-window-enforcer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.service",
-        "domain": "storage",
-        "source": "systemd/lto6-drain-backups.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.timer",
-        "domain": "storage",
-        "source": "systemd/lto6-drain-backups.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-host-shim.service",
-        "domain": "storage",
-        "source": "systemd/storj-host-shim.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-network.service",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-network.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.service",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.timer",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.service",
-        "domain": "storage",
-        "source": "systemd/tape-quality-ollama-narrator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.timer",
-        "domain": "storage",
-        "source": "systemd/tape-quality-ollama-narrator.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-safe-eject.service",
-        "domain": "storage",
-        "source": "systemd/tape-safe-eject.service",
+        "name": "x-agent.service",
+        "domain": "network",
+        "source": "tools/x_agent/x-agent.service",
         "kind": "systemd",
         "critical": true
       }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-07-29T22:19:29.897334+00:00`
+- Generated at: `2026-07-30T01:31:25.151236+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `193`
-- Critical services flagged for MVP: `76`
+- Critical services flagged for MVP: `193`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,10 +12,7 @@
 
 - `identity`: 4
 - `monitoring`: 18
-- `network`: 22
-- `operations`: 106
-- `storage`: 32
-- `trading`: 11
+- `network`: 171
 
 ## Trading profile instances (`12`)
 
@@ -60,24 +57,24 @@
 - `storj-payout-monitor.timer` (monitoring, systemd) from `systemd/storj-payout-monitor.timer`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `tunnel-healthcheck-exporter.service` (monitoring, systemd) from `systemd/tunnel-healthcheck-exporter.service`
-- `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
-- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
-- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
-- `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
-- `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
-- `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
-- `iot-vpn-bypass-watchdog.service` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.service`
-- `iot-vpn-bypass-watchdog.timer` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.timer`
-- `ipv6-proxy.service` (network, systemd) from `systemd/ipv6-proxy.service`
-- `localtunnel@.service` (network, systemd) from `tools/tunnels/localtunnel@.service`
-- `pihole-ipv6-dns-fix.service` (network, systemd) from `systemd/pihole-ipv6-dns-fix.service`
-- `protonvpn-best-server.service` (network, systemd) from `systemd/protonvpn-best-server.service`
-- `protonvpn-best-server.timer` (network, systemd) from `systemd/protonvpn-best-server.timer`
-- `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
-- `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
-- `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
-- `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
+- `glpi` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `glpi-db` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `mail-db` (network, compose) from `docker/docker-compose.simple-mail.yml`
+- `mail-server` (network, compose) from `docker/docker-compose.simple-mail.yml`
+- `mailu-backend` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-db` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-dovecot` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-frontend` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-postfix` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-redis` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-roundcube` (network, compose) from `docker/docker-compose.mailu.yml`
+- `netbox` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-postgres` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-redis` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-redis-cache` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-worker` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `nginx` (network, compose) from `docker/docker-compose.simple-mail.yml`
+- `ntopng` (network, compose) from `docker/docker-compose.ntopng.yml`
 
 ## Serviços anotados manualmente
 

--- a/deploy/vpn/README-protonvpn-watchdog.md
+++ b/deploy/vpn/README-protonvpn-watchdog.md
@@ -22,9 +22,14 @@
 - **Localização:** `/etc/systemd/system/wg-quick@protonvpn.service.d/restore-iprules.conf`
 
 ### 3. **Watchdog Service + Timer**
-- **Executa a cada 5 minutos** — health check completo
+- **Executa a cada 60 segundos** (era 5 min; reduzido após incidente 2026-07-29)
 - Verifica: interface, tabela 205, ip rules 32764/32765, caminho efetivo da LAN, rotas Docker, IP público
 - **Auto-fix** — restaura tudo automaticamente se detectar desvio
+
+### 3b. **ensure-protonvpn-policy-rules.sh** (leve)
+- Reaplica **somente** rules `32764`/`32765` (sem HTTP health-check)
+- Chamado por: `iot-vpn-bypass --heal/--restore`, `cloudflared-vpn-routes.sh`, `wan-selfheal.sh`, `ExecStartPost` do wg-quick
+- Evita janela em que um heal IoT/CF roda com a policy routing da LAN já caída
 
 ### 4. **Gateway da LAN**
 - **Contrato operacional:** clientes da LAN usam `192.168.15.2` como gateway e DNS

--- a/deploy/vpn/cloudflared-vpn-routes.sh
+++ b/deploy/vpn/cloudflared-vpn-routes.sh
@@ -114,6 +114,12 @@ ensure_cf_table_routes
 ensure_subnet_routes
 ip route flush cache
 
+# Defesa em profundidade: heals de CF às vezes rodam quando a policy routing
+# da LAN já caiu. Reaplica só 32764/32765 (script leve, sem recursão).
+if [[ -x /usr/local/bin/ensure-protonvpn-policy-rules.sh ]]; then
+  /usr/local/bin/ensure-protonvpn-policy-rules.sh >/dev/null || true
+fi
+
 if verify_routes; then
   log "OK: Cloudflare via ${WAN_GW} dev ${WAN_IF} (UID table ${CF_TABLE} + main; tabela ${PROTONVPN_TABLE} limpa)"
 else

--- a/deploy/vpn/ensure-protonvpn-policy-rules.sh
+++ b/deploy/vpn/ensure-protonvpn-policy-rules.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# ensure-protonvpn-policy-rules.sh — reaplica só as rules críticas 32764/32765
+#
+# Motivo: quando ProtonVPN reconecta (ou algum heal mexe em ip rules), as rules
+# de policy routing da LAN somem e o tráfego não-IoT cai no DROP do homelab-proxy.
+# Este script é leve (sem health-check HTTP) e pode ser chamado de:
+#   - iot-vpn-bypass --heal/--restore
+#   - cloudflared-vpn-routes.sh
+#   - wan-selfheal.sh
+#   - dispatcher NM / ExecStartPost
+#
+# Não chama cloudflared-vpn-routes (evita recursão).
+set -euo pipefail
+
+readonly PROTONVPN_FWMARK="${PROTONVPN_FWMARK:-0xca6c}"
+readonly PROTONVPN_TABLE="${PROTONVPN_TABLE:-205}"
+readonly RULE_PRIO="${POLICY_RULE_PRIORITY:-32764}"
+readonly SUPPRESS_PRIO="${MAIN_SUPPRESS_PRIORITY:-32765}"
+
+log() { logger -t ensure-protonvpn-rules "$*"; echo "[ensure-protonvpn-rules] $*"; }
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Execute como root" >&2
+  exit 1
+fi
+
+added=0
+
+if ! ip rule show | grep -Eq "^${RULE_PRIO}:.*lookup ${PROTONVPN_TABLE}( |$)"; then
+  # remove residual broken pref if any, then add
+  while ip rule show | grep -qE "^${RULE_PRIO}:"; do
+    ip rule del pref "$RULE_PRIO" 2>/dev/null || break
+  done
+  ip rule add not fwmark "$PROTONVPN_FWMARK" table "$PROTONVPN_TABLE" pref "$RULE_PRIO"
+  log "rule ${RULE_PRIO} restored: not fwmark ${PROTONVPN_FWMARK} → table ${PROTONVPN_TABLE}"
+  added=1
+fi
+
+if ! ip rule show | grep -Eq "^${SUPPRESS_PRIO}:.*lookup main suppress_prefixlength 0$"; then
+  while ip rule show | grep -qE "^${SUPPRESS_PRIO}:"; do
+    ip rule del pref "$SUPPRESS_PRIO" 2>/dev/null || break
+  done
+  ip rule add lookup main suppress_prefixlength 0 pref "$SUPPRESS_PRIO"
+  log "rule ${SUPPRESS_PRIO} restored: lookup main suppress_prefixlength 0"
+  added=1
+fi
+
+if [[ "$added" -eq 1 ]]; then
+  ip route flush cache 2>/dev/null || true
+  log "policy rules restored + route cache flushed"
+else
+  log "policy rules OK (no change)"
+fi
+
+exit 0

--- a/deploy/vpn/protonvpn-routing-watchdog.timer
+++ b/deploy/vpn/protonvpn-routing-watchdog.timer
@@ -1,12 +1,13 @@
 [Unit]
-Description=ProtonVPN Routing Watchdog Timer (a cada 5 min)
+Description=ProtonVPN Routing Watchdog Timer (a cada 60s)
 Documentation=file:///workspace/eddie-auto-dev/deploy/vpn/README-protonvpn-watchdog.md
 
 [Timer]
-# Executa a cada 5 minutos
-OnBootSec=30s
-OnUnitActiveSec=5min
-RandomizedDelaySec=10s
+# Após incidente 2026-07-29: rules 32764/32765 sumiram e LAN ficou sem net
+# até o ciclo de 5min. Reduzido para 60s para limitar a janela de impacto.
+OnBootSec=20s
+OnUnitActiveSec=60s
+RandomizedDelaySec=5s
 AccuracySec=1s
 
 # Se perder uma execução (servidor desligado), executa imediatamente ao voltar

--- a/deploy/vpn/restore-iprules.conf
+++ b/deploy/vpn/restore-iprules.conf
@@ -1,0 +1,4 @@
+[Service]
+# Imediato: rules 32764/32765 + rotas CF; backstop watchdog em t+5s
+# (antes: sleep 90 deixava LAN sem net por até 1.5min após reconnect VPN)
+ExecStartPost=/bin/bash -c '/usr/local/bin/ensure-protonvpn-policy-rules.sh 2>/dev/null || true; /usr/local/sbin/cloudflared-vpn-routes.sh 2>/dev/null || true; sleep 5 && /usr/local/bin/protonvpn-routing-watchdog.sh --ensure || true; /usr/local/sbin/cloudflared-tunnel-guardian.sh 2>/dev/null || true &'

--- a/docs/INCIDENTS/2026-07-29_PROTONVPN_POLICY_RULES_GAP.md
+++ b/docs/INCIDENTS/2026-07-29_PROTONVPN_POLICY_RULES_GAP.md
@@ -1,0 +1,152 @@
+# Incidente — LAN sem internet por perda das rules 32764/32765 — 2026-07-29
+
+> Queda espontânea de internet na LAN (notebook RJ45/GVT e demais clientes não-IoT).
+> Causa: policy routing ProtonVPN (`ip rule` 32764/32765) sumiu sozinha; selfheal
+> restaurou em ~5 min. Mitigações: timer 60s + ensure leve em heals colaterais.
+
+**Status:** mitigado em produção (homelab) + versionado no repo  
+**Host:** `192.168.15.2` (homelab)  
+**Backup deploy:** `/root/backup-vpn-rules-20260729-222921`
+
+---
+
+## Resumo executivo
+
+Por volta de **22:09–22:14 -03**, a internet da LAN “morreu sem ninguém tocar”.
+
+1. As rules de policy routing **`32764`** (`not fwmark 0xca6c → table 205`) e **`32765`**
+   (`lookup main suppress_prefixlength 0`) **desapareceram**.
+2. Clientes LAN não-IoT caíram no path default `eth-wan` e no **DROP** do `homelab-proxy`
+   (só IoT em `isp-bypass` passa).
+3. O `protonvpn-routing-watchdog` detectou o desvio às **22:14:22** e restaurou às **22:14:27**.
+4. Em paralelo, o notebook (ainda no SSID **TANK**) teve flap de Wi‑Fi — sintoma local
+   amplificado, não a causa-raiz do homelab.
+
+---
+
+## Timeline (homelab)
+
+| Hora (local) | Evento |
+|--------------|--------|
+| 22:09:21 | Watchdog: rules OK, saída via ProtonVPN (`79.127.164.75`) |
+| 22:09–22:14 | Janela: rules 32764/32765 ausentes |
+| 22:12:25 | `iot-vpn-bypass --heal` recriou **todos** os `ip rule` IoT (“Bypass IoT restaurado”) |
+| 22:12–22:14 | `cloudflared` unhealthy; tunnel-heal em loop em `cloudflared-vpn-routes.sh` |
+| 22:14:01 | `protonvpn-unit-selfheal`: unit `wg-quick@protonvpn` **inactive**, handshake **136s** |
+| 22:14:22 | Watchdog: `32764 ausente`, tráfego **não** sai por `protonvpn`, IP público **ISP** `189.27.196.49` |
+| 22:14:23–27 | Autocorreção: rules restauradas, IP de volta a `79.127.164.75` |
+| 22:29 | Deploy de mitigações (timer 60s + ensure hooks); backup em `/root/backup-vpn-rules-20260729-222921` |
+
+Único “Desvio crítico” do watchdog nos **7 dias** anteriores a este incidente.
+
+---
+
+## Causa raiz
+
+**Policy routing da LAN→ProtonVPN é efêmera e não é reaplicada em todos os caminhos de heal.**
+
+Arquitetura canônica (ver `docs/PROTONVPN_LAN_ROUTING_ARCHITECTURE.md`):
+
+- VPN é a **regra** (table 205 / rules 32764–32765).
+- Bypass ISP é **exceção** (prio 150, IoT).
+- Sem 32764, o tráfego LAN não-IoT tenta `eth-wan` e é **dropado** pelo nft `homelab-proxy`.
+
+Gatilho provável da limpeza de rules (não 100% atribuído a um único PID):
+
+- reconexão / rehandshake do stack ProtonVPN (iface viva, mas `wg-quick@protonvpn` inactive);
+- em paralelo, storm de heals (`iot-vpn-bypass`, `cloudflared-vpn-routes`) rodando **sem** reaplicar 32764/32765.
+
+Documentado previamente em:
+
+- `docs/PROTONVPN_LAN_ROUTING_ARCHITECTURE.md`
+- `deploy/vpn/README-protonvpn-watchdog.md`
+- memória `feedback_protonvpn_lan_routing_gap`
+
+---
+
+## Impacto
+
+| Quem | Efeito |
+|------|--------|
+| Notebook / celulares / LAN não-IoT | Sem internet (ou “network unreachable” / DROP silencioso) |
+| IoT em isp-bypass | Em geral preservado (prio 150) |
+| Homelab outbound via eth-wan | Continuava OK no ISP (`189.x`) durante a janela |
+| Cloudflare Tunnel | Flaps / DOWN transitório no mesmo intervalo |
+
+---
+
+## Mitigações deployadas (2026-07-29)
+
+### Código / units (repo → host)
+
+| Item | Mudança |
+|------|---------|
+| `protonvpn-routing-watchdog.timer` | `OnUnitActiveSec` **5min → 60s** |
+| `ensure-protonvpn-policy-rules.sh` | **Novo** — reaplica só 32764/32765 (leve) |
+| `iot-vpn-bypass --heal/--restore` | Chama ensure no final (patch no host) |
+| `cloudflared-vpn-routes.sh` | Chama ensure no final |
+| `wan-selfheal.sh` | Chama ensure no final (patch no host) |
+| `wg-quick@protonvpn` `restore-iprules.conf` | ensure imediato + CF routes + watchdog em **t+5s** (era sleep 90) |
+
+### Validação pós-deploy
+
+- `ip rule`: 32764/32765 presentes
+- `ip route get 1.1.1.1 from 192.168.15.137 iif eth-onboard` → `dev protonvpn table 205`
+- `protonvpn-routing-watchdog.sh --health-check` → OK
+- Notebook: Google HTTP 200, IP público `79.127.164.75`
+
+### Rollback
+
+```bash
+ssh homelab
+sudo cp -a /root/backup-vpn-rules-20260729-222921/. /staging-review/
+# restaurar paths originais a partir do backup, depois:
+sudo systemctl daemon-reload
+sudo systemctl restart protonvpn-routing-watchdog.timer
+```
+
+---
+
+## Preferência de internet no notebook (hook de agente)
+
+Além do incidente de infra, ficou registrado o contrato operacional do usuário:
+
+1. **RJ45** (`enp0s31f6`) preferencial  
+2. **Wi‑Fi GVT-38AA** preferencial  
+3. **TANK** só fallback  
+
+Hook: `tools/copilot_hooks/internet_preference_context.py` (`UserPromptSubmit` em Claude/Grok).  
+Política: `AGENTS.md` item 8.
+
+---
+
+## Lições aprendidas
+
+1. “Internet caiu sem tocar” na LAN deste homelab → **primeiro** checar `ip rule | grep -E '32764|32765'`.
+2. Watchdog a cada 5 min deixa janela longa demais quando rules somem.
+3. Heals de IoT/CF/WAN **devem** reaplicar as rules da LAN VPN, senão “curam o satélite e deixam o planeta offline”.
+4. `wg-quick@protonvpn` inactive + iface `protonvpn` viva = stack mista; dispatcher NM pode não disparar.
+
+---
+
+## Fix imediato (operacional)
+
+```bash
+ssh 192.168.15.2 "sudo /usr/local/bin/protonvpn-routing-watchdog.sh --fix"
+# ou só rules:
+ssh 192.168.15.2 "sudo /usr/local/bin/ensure-protonvpn-policy-rules.sh"
+ssh 192.168.15.2 "sudo /usr/local/bin/protonvpn-routing-watchdog.sh --health-check"
+```
+
+---
+
+## Arquivos relacionados
+
+- `deploy/vpn/ensure-protonvpn-policy-rules.sh`
+- `deploy/vpn/protonvpn-routing-watchdog.timer`
+- `deploy/vpn/protonvpn-routing-watchdog.sh`
+- `deploy/vpn/cloudflared-vpn-routes.sh`
+- `deploy/vpn/restore-iprules.conf`
+- `deploy/vpn/51-protonvpn-policy-routing`
+- `docs/PROTONVPN_LAN_ROUTING_ARCHITECTURE.md`
+- `tools/copilot_hooks/internet_preference_context.py`

--- a/docs/PROTONVPN_LAN_ROUTING_ARCHITECTURE.md
+++ b/docs/PROTONVPN_LAN_ROUTING_ARCHITECTURE.md
@@ -158,11 +158,17 @@ ExecStartPost=/bin/bash -c 'sleep 5 && /usr/local/bin/protonvpn-routing-watchdog
 
 Backstop para o caso de o dispatcher NM não cobrir (ex: wg-quick sem NM). Reduzido de 90s para 5s.
 
-### Camada 3 — Watchdog Timer (a cada 5min)
+### Camada 3 — Watchdog Timer (a cada 60s)
 
 **Arquivo:** `protonvpn-routing-watchdog.service` + `.timer`
 
-Health check completo a cada 5 minutos. Detecta e corrige qualquer desvio nas regras, rotas da tabela 205 e Docker bridges.
+Health check completo a cada **60 segundos** (era 5 min; apertado em 2026-07-29). Detecta e corrige qualquer desvio nas regras, rotas da tabela 205 e Docker bridges.
+
+### Camada 3b — ensure leve em heals colaterais
+
+**Arquivo:** `ensure-protonvpn-policy-rules.sh` → `/usr/local/bin/`
+
+Chamado ao final de `iot-vpn-bypass --heal/--restore`, `cloudflared-vpn-routes.sh` e `wan-selfheal.sh`. Só reaplicam `32764`/`32765` (sem health HTTP), porque esses heals já rodaram no incidente 2026-07-29 **enquanto** as rules da LAN estavam ausentes.
 
 ### Janela de impacto após fixes
 
@@ -171,9 +177,10 @@ ProtonVPN reconecta
     │
     ├─ t+0s:  regras removidas
     ├─ t~1s:  NM dispatcher executa → regras restauradas ✅
-    └─ t+5s:  ExecStartPost watchdog confirma (backup)
+    ├─ t+5s:  ExecStartPost watchdog confirma (backup)
+    └─ t≤60s: timer watchdog (pior caso se dispatcher não disparar)
 
-Janela máxima de impacto: ~1 segundo
+Janela máxima de impacto: ~1s (NM) / ≤60s (timer only)
 ```
 
 ---

--- a/hooks.json
+++ b/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/tools/copilot_hooks/internet_preference_context.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": ".*",

--- a/tests/copilot_hooks/test_internet_preference_context.py
+++ b/tests/copilot_hooks/test_internet_preference_context.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "tools" / "copilot_hooks" / "internet_preference_context.py"
+
+
+def _run(payload: dict) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+class TestInternetPreferenceContext(unittest.TestCase):
+    def test_triggers_on_minha_internet(self) -> None:
+        out = _run({"hookEventName": "UserPromptSubmit", "prompt": "minha internet está instável, verifique"})
+        self.assertTrue(out["continue"])
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("RJ45", ctx)
+        self.assertIn("GVT-38AA", ctx)
+        self.assertIn("TANK", ctx)
+        self.assertIn("não preferidos", ctx)
+
+    def test_triggers_on_wifi_and_rj45(self) -> None:
+        out = _run({"prompt": "conecte no wifi gvt-38aa e no rj45"})
+        self.assertIn("enp0s31f6", out["additionalContext"])
+
+    def test_skips_unrelated_prompt(self) -> None:
+        out = _run({"prompt": "refatore o agent de trading BTC"})
+        self.assertEqual(out, {"continue": True})
+        self.assertNotIn("additionalContext", out)
+
+    def test_skips_empty_payload(self) -> None:
+        out = _run({})
+        self.assertEqual(out, {"continue": True})
+
+    def test_matches_helper(self) -> None:
+        # import local helpers
+        sys.path.insert(0, str(SCRIPT.parent))
+        import internet_preference_context as mod  # type: ignore
+
+        self.assertTrue(mod.matches_internet_topic("sem internet no notebook"))
+        self.assertTrue(mod.matches_internet_topic("packet loss no cabo"))
+        self.assertFalse(mod.matches_internet_topic("atualizar dashboard grafana"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/copilot_hooks/internet_preference_context.py
+++ b/tools/copilot_hooks/internet_preference_context.py
@@ -1,0 +1,160 @@
+"""UserPromptSubmit hook — preferência de internet do usuário.
+
+Quando o usuário fala de internet/rede/conectividade, injeta additionalContext
+com a ordem preferida de saída:
+
+1. RJ45 (enp0s31f6 / Wired connection 1) — preferencial
+2. Wi-Fi GVT-38AA (SSID GVT-38AA) — preferencial
+3. TANK e outros SSIDs — só fallback / diagnóstico secundário
+
+Não altera rotas do sistema: apenas orienta o agente (Claude/Grok/Pi).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+# Frases/termos que disparam o contexto de preferência de internet.
+_TRIGGER_RE = re.compile(
+    r"""
+    \b(
+        minha\s+internet
+      | nossa\s+internet
+      | a\s+internet
+      | internet
+      | conectividade
+      | sem\s+net
+      | sem\s+internet
+      | net\s+caiu
+      | internet\s+caiu
+      | internet\s+inst[aá]vel
+      | rede\s+inst[aá]vel
+      | wi[\-\s]?fi
+      | wifi
+      | wlan
+      | rj45
+      | cabo\s+(de\s+)?rede
+      | ethernet
+      | enp0s31f6
+      | wlp2s0
+      | gvt[\-\s]?38aa
+      | default\s+route
+      | rota\s+padr[aã]o
+      | gateway
+      | networkmanager
+      | nmcli
+      | dns
+      | ping\b
+      | packet\s+loss
+      | perda\s+de\s+pacotes
+    )\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+CONTEXT = """# Preferência de internet (hook 2026-07-29)
+
+Quando o usuário fala de **internet / rede / conectividade** nesta workstation:
+
+## Ordem preferida de saída
+1. **RJ45** — interface `enp0s31f6`, perfil NM `Wired connection 1`, MAC `18:66:da:fe:58:94`, LAN `192.168.15.0/24`
+2. **Wi‑Fi GVT-38AA** — SSID `GVT-38AA`, perfis NM `GVT-38AA Automático(a)`, mesma subnet do homelab quando associado
+3. **TANK / outros SSIDs** — **não preferidos**; só fallback explícito ou diagnóstico secundário
+
+## Como diagnosticar (ordem)
+1. Cabo UP + IP em `enp0s31f6`? (`ip -br a`, `nmcli device status`)
+2. Gateway homelab/ISP via cabo: `192.168.15.2` (LAN) e/ou `192.168.15.1` (ZTE GPON)
+3. Internet **por interface**: `curl --interface enp0s31f6 -sS --max-time 5 https://1.1.1.1`
+4. Se cabo sem WAN: Wi‑Fi **GVT-38AA** (não TANK primeiro): `nmcli device wifi`, `nmcli connection up "GVT-38AA Automático(a)"`
+5. Só então considerar TANK (`wlp2s0` em 10.x) como fallback
+
+## Notas operacionais
+- RJ45 pode estar com `ipv4.never-default=yes` (só LAN). Preferência do usuário = **tentar internet real pelo cabo** (rota via .1/.2 / isp-bypass no homelab) antes de confiar no Wi‑Fi vizinho TANK.
+- Browser/PAC: `http://192.168.15.2/wpad.dat` — depende da rota LAN via cabo.
+- Não reconfigure firewall/rotas do homelab sem confirmação; mudanças de NM no notebook ok se forem para priorizar cabo + GVT-38AA.
+"""
+
+
+def _load_input() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    return json.loads(raw) if raw else {}
+
+
+def _extract_prompt(payload: dict[str, Any]) -> str:
+    """Extrai texto do prompt de vários formatos (Claude / Grok / Pi)."""
+    candidates: list[Any] = [
+        payload.get("prompt"),
+        payload.get("user_prompt"),
+        payload.get("userPrompt"),
+        payload.get("message"),
+        payload.get("text"),
+        payload.get("content"),
+    ]
+    # envelopes aninhados comuns
+    for key in ("hook_event_input", "hookEventInput", "input"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            candidates.extend(
+                [
+                    nested.get("prompt"),
+                    nested.get("user_prompt"),
+                    nested.get("userPrompt"),
+                    nested.get("message"),
+                    nested.get("text"),
+                ]
+            )
+    parts: list[str] = []
+    for c in candidates:
+        if isinstance(c, str) and c.strip():
+            parts.append(c)
+        elif isinstance(c, list):
+            for item in c:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+    return "\n".join(parts)
+
+
+def matches_internet_topic(text: str) -> bool:
+    if not text or not text.strip():
+        return False
+    return bool(_TRIGGER_RE.search(text))
+
+
+def build_output(event_name: str = "UserPromptSubmit") -> dict[str, Any]:
+    return {
+        "continue": True,
+        "additionalContext": CONTEXT,
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": CONTEXT,
+        },
+    }
+
+
+def main() -> int:
+    payload = _load_input()
+    event = str(
+        payload.get("hook_event_name")
+        or payload.get("hookEventName")
+        or "UserPromptSubmit"
+    )
+    # Normaliza nome para saída Claude/Grok
+    if event.lower() in {"user_prompt_submit", "usersubmitprompt", "beforesubmitprompt"}:
+        event = "UserPromptSubmit"
+
+    prompt = _extract_prompt(payload)
+    # Fail-open: sem prompt legível não injeta (evita poluir todos os turns)
+    if not matches_internet_topic(prompt):
+        print(json.dumps({"continue": True}))
+        return 0
+
+    print(json.dumps(build_output(event), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Incidente **2026-07-29**: LAN sem internet porque as `ip rule` **32764/32765** sumiram sozinhas; watchdog restaurou em ~5 min.
- **Mitigações**: timer do `protonvpn-routing-watchdog` **5min → 60s**; novo `ensure-protonvpn-policy-rules.sh`; hooks em `cloudflared-vpn-routes`, `iot-vpn-bypass` heal/restore (host), `wan-selfheal` (host), `restore-iprules` t+5s.
- **Docs**: `docs/INCIDENTS/2026-07-29_PROTONVPN_POLICY_RULES_GAP.md` + updates em arquitetura/README VPN.
- **Hook de agente**: preferência de internet RJ45 + GVT-38AA (`internet_preference_context.py` + testes).

## Deploy já feito no homelab

Backup: `/root/backup-vpn-rules-20260729-222921`  
Validado: health-check OK, path `.137 → protonvpn table 205`.

## Test plan

- [x] `pytest tests/copilot_hooks/test_internet_preference_context.py`
- [x] `ensure-protonvpn-policy-rules.sh` no host (rules OK)
- [x] `protonvpn-routing-watchdog.sh --health-check` OK
- [x] Timer lista próximo fire ~60s
- [ ] Após merge: `sudo cp` units/scripts se host divergir do repo e `daemon-reload`