### PR TITLE
fix(trading): reconstrução de posições órfãs + timeout GPU pós-treino

### DIFF
--- a/btc_trading_agent/position_reconstruction.py
+++ b/btc_trading_agent/position_reconstruction.py
@@ -43,43 +43,29 @@ def _is_excluded_buy(trade: dict[str, Any], *, exclude_external_deposits: bool) 
     return source in ("external_deposit", "conversion")
 
 
-def _reconstruct_recent_buy_streak(
-    trades: list[dict[str, Any]],
-    *,
-    exclude_external_deposits: bool,
-) -> list[dict[str, Any]]:
-    """Em conta compartilhada, usa apenas a sequência recente de BUYs ainda não revertida.
-
-    Isso evita ressuscitar posições antigas de outro profile quando o saldo spot
-    global é compartilhado e o ledger por profile já divergiu da KuCoin.
-    """
-    open_buys: list[dict[str, Any]] = []
-    for trade in trades:
-        side = trade.get("side")
-        if side in SELL_SIDES:
-            break
-        if side == "buy" and not _is_excluded_buy(
-            trade,
-            exclude_external_deposits=exclude_external_deposits,
-        ):
-            open_buys.append(trade)
-    return open_buys
-
-
 def reconstruct_open_buys(
     trades: list[dict[str, Any]],
     *,
     shared_profile_ambiguous: bool = False,
     exclude_external_deposits: bool = True,
 ) -> list[dict[str, Any]]:
-    """Reconstrói BUYs abertos a partir de trades em ordem decrescente de tempo."""
-    normalized = [_normalize_trade(trade) for trade in trades]
+    """Reconstrói BUYs abertos a partir de trades em ordem decrescente de tempo.
 
-    if shared_profile_ambiguous:
-        return _reconstruct_recent_buy_streak(
-            normalized,
-            exclude_external_deposits=exclude_external_deposits,
-        )
+    Um SELL com metadata de saída por slot (`slot_exit_reason`) fecha apenas a
+    entrada específica que ele referencia (por `slot_buy_trade_id`, ou por preço
+    como fallback) — nunca todas as entradas anteriores. Só um SELL "cego" (sem
+    metadata de slot, ex.: reconciliação manual/exchange) é tratado como
+    flatten global, encerrando a reconstrução naquele ponto.
+
+    Em conta compartilhada (`shared_profile_ambiguous=True`), o matching por
+    preço fica desabilitado — preços podem colidir entre profiles que dividem
+    a mesma subconta KuCoin — mas o matching por `slot_buy_trade_id` continua
+    válido, pois o id referencia um trade já filtrado por profile na consulta
+    ao banco. Isso evita "esquecer" entradas antigas ainda abertas sempre que
+    qualquer SELL por slot mais recente acontece na mesma conta.
+    """
+    normalized = [_normalize_trade(trade) for trade in trades]
+    allow_price_matching = not shared_profile_ambiguous
 
     slot_sells_by_id: dict[int, int] = {}
     slot_sells_by_price: dict[float, int] = {}
@@ -96,7 +82,7 @@ def reconstruct_open_buys(
             if buy_id:
                 key = int(buy_id)
                 slot_sells_by_id[key] = slot_sells_by_id.get(key, 0) + 1
-            elif slot_price:
+            elif slot_price and allow_price_matching:
                 try:
                     key = round(float(slot_price), 2)
                     slot_sells_by_price[key] = slot_sells_by_price.get(key, 0) + 1
@@ -132,7 +118,7 @@ def reconstruct_open_buys(
             if slot_sells_by_id.get(trade_id_int, 0) > 0:
                 slot_sells_by_id[trade_id_int] -= 1
                 consumed = True
-        if not consumed and slot_sells_by_price.get(price_key, 0) > 0:
+        if not consumed and allow_price_matching and slot_sells_by_price.get(price_key, 0) > 0:
             slot_sells_by_price[price_key] -= 1
             consumed = True
         if not consumed and slot_sells_blind > 0:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T02:25:49.903027+00:00",
+  "generated_at": "2026-08-01T11:53:13.394987+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T02:25:49.903027+00:00`
+- Generated at: `2026-08-01T11:53:13.394987+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/scripts/whatsapp_toolcall_chunked_train.sh
+++ b/scripts/whatsapp_toolcall_chunked_train.sh
@@ -114,8 +114,15 @@ stop_ollama_guard() {
 # Confere que o modelo de produção carregou de verdade na GPU (não em CPU-
 # fallback) — dispara um /api/generate trivial (força load se preciso) e lê
 # size_vram em /api/ps. size_vram==0 com o modelo presente = CPU-fallback.
+#
+# Timeout de 220s (não 90s): medido um cold-load de 171.86s do trading-analyst
+# (8B Q4_K_M) logo após o treino liberar a VRAM — cache de disco frio +
+# handoff de driver com a GPU recém-liberada tornam o load bem mais lento que
+# um load "quente". Com 90s o script declarava CPU-fallback (e disparava
+# alerta falso no Telegram) enquanto o load ainda estava em andamento e
+# terminava com sucesso segundos depois, sem intervenção manual (2026-08-01).
 ollama_gpu_ok() {
-  curl -s -m 90 -X POST "$OLLAMA_URL/api/generate" \
+  curl -s -m 220 -X POST "$OLLAMA_URL/api/generate" \
     -d "{\"model\":\"$WARMUP_MODEL\",\"prompt\":\"ping\",\"stream\":false}" \
     -o /dev/null -w '' 2>/dev/null || true
   local vram

--- a/tests/test_position_reconstruction.py
+++ b/tests/test_position_reconstruction.py
@@ -86,6 +86,54 @@ def test_reconstruct_open_buys_shared_ambiguous_keeps_recent_buy_streak_only() -
     assert [trade["id"] for trade in open_buys] == [25, 24]
 
 
+def test_reconstruct_open_buys_shared_ambiguous_partial_slot_sell_keeps_older_entries() -> None:
+    """Regressão: um SELL por slot em conta compartilhada não pode "esquecer"
+    entradas mais antigas que ele não fechou — só um SELL cego (sem
+    slot_exit_reason) representa flatten global."""
+    trades = [
+        _trade(
+            33,
+            "sell",
+            110.0,
+            0.001,
+            metadata={
+                "slot_exit_reason": "PER_SLOT_TP",
+                "slot_buy_trade_id": 32,
+                "slot_entry_price": 103.0,
+            },
+        ),
+        _trade(32, "buy", 103.0, 0.001),
+        _trade(31, "buy", 102.0, 0.001),
+        _trade(30, "buy", 100.0, 0.001),
+    ]
+
+    open_buys = reconstruct_open_buys(trades, shared_profile_ambiguous=True)
+
+    assert [trade["id"] for trade in open_buys] == [31, 30]
+
+
+def test_reconstruct_open_buys_shared_ambiguous_disables_price_matching() -> None:
+    """Em conta compartilhada, sells por slot sem slot_buy_trade_id não podem
+    casar por preço — preços podem colidir com buys de outro profile na mesma
+    subconta. Nesse caso o slot vira 'blind' e consome a compra mais antiga
+    disponível na ordem de varredura, não uma por coincidência de preço."""
+    trades = [
+        _trade(
+            43,
+            "sell",
+            110.0,
+            0.001,
+            metadata={"slot_exit_reason": "PER_SLOT_TP", "slot_entry_price": 100.0},
+        ),
+        _trade(42, "buy", 103.0, 0.001),
+        _trade(41, "buy", 100.0, 0.001),
+    ]
+
+    open_buys = reconstruct_open_buys(trades, shared_profile_ambiguous=True)
+
+    assert [trade["id"] for trade in open_buys] == [41]
+
+
 def test_reconstruct_open_buys_preserves_dry_run_flag() -> None:
     """dry_run do BUY original deve ser propagado para o entry dict.
 


### PR DESCRIPTION
## Summary
- `reconstruct_open_buys()` (btc_trading_agent/position_reconstruction.py): em conta compartilhada (`shared_profile_ambiguous`, ex.: profiles `shadow`/`aggressive` dividindo a subconta KuCoin `BTCAgressive`), qualquer SELL era tratado como flatten global — esquecendo entradas BUY antigas que aquele SELL não fechou de fato. Agora um SELL por slot (`slot_exit_reason` + `slot_buy_trade_id`) só fecha a entrada específica que referencia; matching por preço fica desabilitado nesse modo (evita colisão entre profiles). Achado em auditoria: dezenas de posições do profile `shadow` abertas desde 2026-06-28 nunca reavaliadas para venda mesmo com o preço já tendo passado o `target_sell` várias vezes.
- `scripts/whatsapp_toolcall_chunked_train.sh`: `ollama_gpu_ok()` tinha timeout de 90s pra confirmar que o trading-analyst voltou pra GPU após o treino QLoRA liberar a VRAM. Medido cold-load real de 171.86s em 2026-08-01 — script declarava CPU-fallback (alerta falso no Telegram) enquanto o load ainda estava em andamento e terminava com sucesso segundos depois. Timeout aumentado para 220s, com margem, ainda dentro do `TimeoutStartSec=1500` da unit.

## Test plan
- [x] `pytest tests/test_position_reconstruction.py tests/test_ai_plan_db_position.py tests/test_main_transfer_and_dynamic_positions.py tests/test_position_sizing.py tests/test_trading_conversation.py` — 77/77 passando (2 testes novos de regressão cobrindo o cenário do bug)
- [x] `bash -n scripts/whatsapp_toolcall_chunked_train.sh` — sintaxe OK
- [ ] Deploy no homelab via `git pull` + confirmar hash do arquivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)