### PR TITLE
fix(alerts): filtra session-*.scope como ruído no server-error-alert

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T11:53:13.394987+00:00",
+  "generated_at": "2026-08-01T14:27:16.135845+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T11:53:13.394987+00:00`
+- Generated at: `2026-08-01T14:27:16.135845+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/scripts/server_error_alert.py
+++ b/scripts/server_error_alert.py
@@ -80,6 +80,12 @@ _NOISE_UNITS = {
     "dbus", "systemd-", "rsyslog", "cron", "sshd",
     "smartmontools", "smartd", "accounts-daemon", "polkit",
     "rtkit-daemon", "udisks2", "avahi-daemon", "colord",
+    # session-<N>.scope: escopo de login SSH/PAM normal, não um serviço. O
+    # journal loga esses fechamentos em prioridade "err" quando o comando
+    # dentro da sessão sai com código != 0 (ex.: grep sem match) — nada
+    # quebrado, e o número da sessão muda a cada conexão, então o dedup por
+    # unit_base (session-<N>, sem o sufixo) não colapsa entradas repetidas.
+    "session-",
 }
 
 

--- a/tests/test_server_error_alert.py
+++ b/tests/test_server_error_alert.py
@@ -25,6 +25,22 @@ class _FakeResponse:
         return None
 
 
+def test_is_noisy_filters_ssh_login_session_scopes() -> None:
+    """session-<N>.scope é um login PAM normal, não um serviço quebrado.
+
+    O número muda a cada conexão SSH, então sem esse filtro o dedup por
+    unit_base nunca colapsa entradas repetidas — cada sessão vira um alerta
+    novo no Telegram.
+    """
+    assert sea._is_noisy("session-10673.scope") is True
+    assert sea._is_noisy("session-1.scope") is True
+
+
+def test_is_noisy_keeps_real_services_alertable() -> None:
+    assert sea._is_noisy("crypto-agent@BTC_USDT_shadow.service") is False
+    assert sea._is_noisy("grafana-selfheal.service") is False
+
+
 def test_glpi_api_url_accepts_public_index_entrypoint() -> None:
     assert sea._glpi_api_url("initSession", "https://auth.rpa4all.com/cmdb/glpi/index.php") == (
         "https://auth.rpa4all.com/cmdb/glpi/apirest.php/initSession"


### PR DESCRIPTION
## Summary
- `server-error-alert.service` (journalctl -f -p err) capturava fechamentos normais de sessão SSH/PAM (`session-<N>.scope`) como "erro" e disparava um Telegram por sessão — o dedup por `unit_base` não colapsava porque o número da sessão é único por conexão.
- Adiciona `"session-"` a `_NOISE_UNITS` (mesmo mecanismo já usado para `sshd`, `cron`, etc.)

## Test plan
- [x] `pytest tests/test_server_error_alert.py` — 7/7 passando (2 testes novos cobrindo o filtro)
- [ ] Deploy no host (`/apps/server-error-alert/server_error_alert.py`) + restart do `server-error-alert.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)