### PR TITLE
fix(trading): fallback de LLM não pode apontar pro mesmo host do primário

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T14:27:16.135845+00:00",
+  "generated_at": "2026-08-01T14:47:30.595898+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T14:27:16.135845+00:00`
+- Generated at: `2026-08-01T14:47:30.595898+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -757,15 +757,20 @@ sudo systemctl enable ollama-gpu-coordinator.service 2>/dev/null || true
 sudo systemctl restart ollama-gpu-coordinator.service
 sleep 2
 
-# Atualiza common.conf para rotear chamadas pelo coordenador (:11437)
+# Atualiza common.conf para rotear chamadas pelo coordenador (:11437).
+# FALLBACK_HOST fica em :11435 (ollama-gpu1.service, direto, sem passar pelo
+# coordenador) de propósito — se apontasse pro mesmo :11437 do primário,
+# "fallback" nenhum ajudaria quando o coordenador cai (ex.: pausado pelo job
+# de fine-tune horário): primário e fallback morreriam juntos. ollama-gpu1
+# não é parado por esse job, então segue de pé como rota independente.
 sudo sed -i \
   -e 's|^Environment=OLLAMA_PLAN_HOST=.*|Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437|' \
   -e 's|^Environment=OLLAMA_TRADE_PARAMS_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437|' \
+  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435|' \
   -e 's|^Environment=OLLAMA_TRADE_WINDOW_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437|' \
+  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435|' \
   /etc/systemd/system/crypto-agent@.service.d/common.conf 2>/dev/null || true
-echo "🔀 Routing: agents → coordenador :11437 (llama3.2:1b)"
+echo "🔀 Routing: agents → coordenador :11437 (llama3.2:1b) | fallback → gpu1 :11435 direto"
 
 # Habilita e reinicia RSS sentiment
 sudo systemctl enable rss-sentiment-exporter.service 2>/dev/null || true

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -26,9 +26,13 @@
 # Override por perfil exigiria um EnvironmentFile= dedicado — ver
 # docs/systemd/DROPIN_DEPLOY_PARITY.md antes de criar essa camada.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11435
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435
+# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito: se
+# apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
+# ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
+# fine-tune horário) — primário e fallback morreriam juntos.
 # (sem Environment=OLLAMA_*_MODEL aqui — ver cabeçalho)

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
@@ -1,7 +1,10 @@
 [Service]
 # Roteamento via coordenador para serializar com os demais agentes.
 # Coordenador (11437) gerencia GPU0/GPU1 automaticamente.
+# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito — ver
+# zz-direct-ollama.conf neste mesmo diretório (essas chaves são shadowed por
+# ele, mas mantidas coerentes pra não confundir diagnóstico futuro).
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
@@ -3,9 +3,13 @@
 #   trading-analyst → GPU0 (11434, RTX 2060)
 #   gemma3-fast:gpu1 → GPU1 (11435, GTX 1050)
 # Coordenador serializa acessos e evita 503 em cascata.
+# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito: se
+# apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
+# ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
+# fine-tune horário) — primário e fallback morreriam juntos.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11435
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -12,6 +12,25 @@ def _load_script() -> str:
     return SCRIPT_PATH.read_text(encoding="utf-8")
 
 
+def test_script_routes_ollama_fallback_host_away_from_coordinator() -> None:
+    """FALLBACK_HOST não pode apontar pro mesmo endereço do HOST primário.
+
+    O coordenador (:11437) é pausado toda hora pelo job de fine-tune; se o
+    fallback também apontar pra ele, primário e fallback caem juntos e os
+    agentes ficam cegos ~10-15min/hora sem nenhum caminho alternativo.
+    ollama-gpu1.service (:11435) não é pausado por esse job — é o fallback
+    correto.
+    """
+    content = _load_script()
+    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435" in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435" in content
+    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437" not in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437" not in content
+    # Primário continua no coordenador — só o fallback muda.
+    assert "Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437" in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437" in content
+
+
 def test_script_syncs_btc_dashboard_to_canonical_remote_filename() -> None:
     content = _load_script()
     assert 'BTC_DASHBOARD_SRC="${REPO_ROOT}/grafana/dashboards/btc-trading-monitor.json"' in content

--- a/tests/test_systemd_dropin_parity.py
+++ b/tests/test_systemd_dropin_parity.py
@@ -444,3 +444,40 @@ def test_dropin_environment_never_shadowed_by_models_env() -> None:
         "(vale para os 14 agentes) ou use um EnvironmentFile= por perfil, que é "
         "mesclado depois. Linhas mortas: " + "; ".join(dead)
     )
+
+
+def test_ollama_fallback_host_never_matches_primary_host_in_dropins() -> None:
+    """`*_FALLBACK_HOST` não pode apontar pro mesmo endereço do `*_HOST` primário.
+
+    O coordenador (:11437) é pausado toda hora pelo job de fine-tune
+    (whatsapp_toolcall_chunked_train.sh). Se o fallback também apontar pra
+    ele, primário e fallback caem juntos e os crypto-agent@* ficam sem
+    nenhum caminho pra IA durante a pausa — o "fallback" nunca ajuda.
+    ollama-gpu1.service (:11435) não é parado por esse job; é o fallback
+    correto (ver deploy_btc_trading_profiles.sh e zz-direct-ollama.conf).
+    """
+    offenders: list[str] = []
+    for rel_dir in _allowed_dirs():
+        if not rel_dir.startswith("crypto-agent@"):
+            continue
+        for conf in sorted((REPO_ROOT / "systemd" / rel_dir).glob("*.conf")):
+            text = conf.read_text(encoding="utf-8")
+            hosts: dict[str, str] = {}
+            for name, value in re.findall(
+                r'^Environment="?(OLLAMA_[A-Z_]*_HOST)="?([^"\s]+)"?\s*$',
+                text,
+                flags=re.MULTILINE,
+            ):
+                hosts[name] = value
+            for name, value in hosts.items():
+                if not name.endswith("_FALLBACK_HOST"):
+                    continue
+                primary_name = name.replace("_FALLBACK_HOST", "_HOST")
+                primary_value = hosts.get(primary_name)
+                if primary_value is not None and primary_value == value:
+                    offenders.append(f"{rel_dir}/{conf.name}: {name}={value} == {primary_name}")
+
+    assert not offenders, (
+        "FALLBACK_HOST igual ao HOST primário — fallback inútil quando o "
+        "primário cai. Offenders: " + "; ".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- `OLLAMA_TRADE_PARAMS_FALLBACK_HOST`/`OLLAMA_TRADE_WINDOW_FALLBACK_HOST`/`OLLAMA_PLAN_FALLBACK_HOST` apontavam pro mesmo host do primário (`:11437`, o `ollama-gpu-coordinator`), tanto no sed de `deploy_btc_trading_profiles.sh` quanto nos drop-ins de instância BTC aggressive/conservative.
- Como o coordenador é pausado toda hora pelo job de fine-tune (`whatsapp_toolcall_chunked_train.sh`), fallback==primário significava que os 12 `crypto-agent@*` ficavam ~10-15min/hora sem nenhum caminho pra IA — o fallback nunca ajudava.
- Fix: fallback agora aponta pra `:11435` (`ollama-gpu1.service`), serviço independente que não é parado por esse job. Primário continua no coordenador (`:11437`) — preserva a proteção anti-503-storm do incidente 2026-07-24.

## Test plan
- [x] `pytest tests/test_systemd_dropin_parity.py tests/test_deploy_btc_trading_profiles_script.py` — 37/37 passando (2 testes novos, incluindo guarda geral que varre todos os drop-ins de `crypto-agent@*` procurando `FALLBACK_HOST == HOST`)
- [ ] Deploy no homelab (`scripts/deploy_btc_trading_profiles.sh` + reaplicar drop-ins via `daemon-reload` + restart escalonado dos agentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)