### PR TITLE
feat(trading): fallback de LLM usa trading-analyst na NAS, não lfm2.5 na GPU1

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T14:47:30.595898+00:00",
+  "generated_at": "2026-08-01T15:07:11.102639+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T14:47:30.595898+00:00`
+- Generated at: `2026-08-01T15:07:11.102639+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/crypto-agent/models.env
+++ b/deploy/crypto-agent/models.env
@@ -2,6 +2,11 @@
 # Snapshot de /etc/crypto-agent/models.env (homelab). EnvironmentFile dos
 # crypto-agent@*. GPU0 (RTX 3060 12GB) :11434 = trading-analyst;
 # GPU1 (GTX 1050 2GB) :11435 = lfm2.5-fast:gpu1 (GGUF Q4_0). Coordenador :11437.
+# NAS (RTX 2060 8GB) :11436 = trading-analyst (mesmo Modelfile do GPU0,
+# criado 2026-08-01) — fallback de trading. GPU1 fica reservado pra
+# persona/WhatsApp, não mistura com decisão de trade: se o coordenador cai
+# (ex.: pausado pelo job de fine-tune horário), o fallback vai pro MESMO
+# modelo em outra GPU, não degrada pra um modelo pequeno genérico.
 # 2026-07-30: GPU1 recriada em quantização explícita Q4_0 (antes Q4_K_M);
 # fallbacks leves também GGUF quant (gemma3 Q4_K_M, smollm2 IQ3_M). Sem LLM chinês.
 
@@ -9,12 +14,12 @@ OLLAMA_PRIMARY_MODEL=trading-analyst
 OLLAMA_SMALL_MODEL=lfm2.5-fast:gpu1
 
 OLLAMA_PLAN_MODEL=trading-analyst
-OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1
+OLLAMA_PLAN_FALLBACK_MODEL=trading-analyst
 
 OLLAMA_TRADE_PARAMS_MODEL=trading-analyst
 OLLAMA_TRADE_PARAMS_CONSERVATIVE_MODEL=trading-analyst
-OLLAMA_TRADE_PARAMS_FALLBACK_MODEL=lfm2.5-fast:gpu1
+OLLAMA_TRADE_PARAMS_FALLBACK_MODEL=trading-analyst
 
 OLLAMA_TRADE_WINDOW_MODEL=trading-analyst
 OLLAMA_TRADE_WINDOW_CONSERVATIVE_MODEL=trading-analyst
-OLLAMA_TRADE_WINDOW_FALLBACK_MODEL=lfm2.5-fast:gpu1
+OLLAMA_TRADE_WINDOW_FALLBACK_MODEL=trading-analyst

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -758,19 +758,21 @@ sudo systemctl restart ollama-gpu-coordinator.service
 sleep 2
 
 # Atualiza common.conf para rotear chamadas pelo coordenador (:11437).
-# FALLBACK_HOST fica em :11435 (ollama-gpu1.service, direto, sem passar pelo
+# FALLBACK_HOST fica na NAS (:11436, ollama direto, sem passar pelo
 # coordenador) de propósito — se apontasse pro mesmo :11437 do primário,
 # "fallback" nenhum ajudaria quando o coordenador cai (ex.: pausado pelo job
-# de fine-tune horário): primário e fallback morreriam juntos. ollama-gpu1
-# não é parado por esse job, então segue de pé como rota independente.
+# de fine-tune horário): primário e fallback morreriam juntos. A NAS não é
+# parada por esse job, então segue de pé como rota independente — e roda o
+# MESMO modelo trading-analyst (não um modelo pequeno genérico), preservando
+# qualidade de decisão. GPU1 fica reservado pra persona/WhatsApp.
 sudo sed -i \
   -e 's|^Environment=OLLAMA_PLAN_HOST=.*|Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437|' \
   -e 's|^Environment=OLLAMA_TRADE_PARAMS_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435|' \
+  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436|' \
   -e 's|^Environment=OLLAMA_TRADE_WINDOW_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435|' \
+  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436|' \
   /etc/systemd/system/crypto-agent@.service.d/common.conf 2>/dev/null || true
-echo "🔀 Routing: agents → coordenador :11437 (llama3.2:1b) | fallback → gpu1 :11435 direto"
+echo "🔀 Routing: agents → coordenador :11437 (llama3.2:1b) | fallback → NAS :11436 trading-analyst"
 
 # Habilita e reinicia RSS sentiment
 sudo systemctl enable rss-sentiment-exporter.service 2>/dev/null || true

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -26,13 +26,15 @@
 # Override por perfil exigiria um EnvironmentFile= dedicado — ver
 # docs/systemd/DROPIN_DEPLOY_PARITY.md antes de criar essa camada.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.4:11436
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435
-# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito: se
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436
+# FALLBACK_HOST na NAS (:11436, trading-analyst, direto) de propósito: se
 # apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
 # ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
-# fine-tune horário) — primário e fallback morreriam juntos.
+# fine-tune horário) — primário e fallback morreriam juntos. A NAS roda o
+# MESMO modelo (não degrada pra um modelo pequeno) e não é tocada por esse
+# job. GPU1 (11435) fica reservado pra persona/WhatsApp.
 # (sem Environment=OLLAMA_*_MODEL aqui — ver cabeçalho)

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
@@ -1,10 +1,10 @@
 [Service]
 # Roteamento via coordenador para serializar com os demais agentes.
 # Coordenador (11437) gerencia GPU0/GPU1 automaticamente.
-# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito — ver
+# FALLBACK_HOST na NAS (:11436, trading-analyst) de propósito — ver
 # zz-direct-ollama.conf neste mesmo diretório (essas chaves são shadowed por
 # ele, mas mantidas coerentes pra não confundir diagnóstico futuro).
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
@@ -3,13 +3,15 @@
 #   trading-analyst → GPU0 (11434, RTX 2060)
 #   gemma3-fast:gpu1 → GPU1 (11435, GTX 1050)
 # Coordenador serializa acessos e evita 503 em cascata.
-# FALLBACK_HOST em :11435 (ollama-gpu1.service, direto) de propósito: se
+# FALLBACK_HOST na NAS (:11436, trading-analyst, direto) de propósito: se
 # apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
 # ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
-# fine-tune horário) — primário e fallback morreriam juntos.
+# fine-tune horário) — primário e fallback morreriam juntos. A NAS roda o
+# MESMO modelo (não degrada pra um modelo pequeno) e não é tocada por esse
+# job. GPU1 (11435) fica reservado pra persona/WhatsApp.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.4:11436
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -18,12 +18,13 @@ def test_script_routes_ollama_fallback_host_away_from_coordinator() -> None:
     O coordenador (:11437) é pausado toda hora pelo job de fine-tune; se o
     fallback também apontar pra ele, primário e fallback caem juntos e os
     agentes ficam cegos ~10-15min/hora sem nenhum caminho alternativo.
-    ollama-gpu1.service (:11435) não é pausado por esse job — é o fallback
-    correto.
+    A NAS (:11436, roda trading-analyst — mesmo modelo do GPU0) não é
+    pausada por esse job — é o fallback correto. GPU1 (:11435) fica
+    reservado pra persona/WhatsApp, não é usado como fallback de trading.
     """
     content = _load_script()
-    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11435" in content
-    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11435" in content
+    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436" in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436" in content
     assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437" not in content
     assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437" not in content
     # Primário continua no coordenador — só o fallback muda.


### PR DESCRIPTION
## Summary
- Segue o PR #284 (fallback tirado do coordinator). Agora troca o alvo do fallback de GPU1 (`lfm2.5-fast:gpu1`, modelo pequeno genérico) para a NAS (`:11436`), rodando o mesmo `trading-analyst` do GPU0.
- Sugestão do usuário: não faz sentido degradar qualidade de decisão durante a janela em que o primário está indisponível — melhor rodar o mesmo modelo em outra GPU.
- Modelo `trading-analyst` criado na NAS a partir do `models/Modelfile.trading-analyst` existente (mesma base `llama3.1:8b` já presente lá) e pré-aquecido manualmente — validado com prompt real de trade window, JSON correto, 2s de latência já carregado.
- GPU1 fica livre pra sua função original (persona/WhatsApp), sem disputar com trading.

## Test plan
- [x] `pytest tests/test_systemd_dropin_parity.py tests/test_deploy_btc_trading_profiles_script.py` — 37/37 passando
- [x] Testado manualmente contra a NAS real: `curl http://192.168.15.4:11436/api/generate` com prompt de trade window → JSON válido
- [ ] Deploy no homelab + restart escalonado dos 14 crypto-agent@*

🤖 Generated with [Claude Code](https://claude.com/claude-code)