### PR TITLE
fix(trading): coordenador de GPUs nunca deve ser parado — corrige a causa raiz

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T15:07:11.102639+00:00",
+  "generated_at": "2026-08-01T15:50:40.527142+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T15:07:11.102639+00:00`
+- Generated at: `2026-08-01T15:50:40.527142+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/crypto-agent/models.env
+++ b/deploy/crypto-agent/models.env
@@ -1,12 +1,17 @@
 # === MODELOS OLLAMA — edite APENAS este arquivo para trocar de modelo ===
 # Snapshot de /etc/crypto-agent/models.env (homelab). EnvironmentFile dos
 # crypto-agent@*. GPU0 (RTX 3060 12GB) :11434 = trading-analyst;
-# GPU1 (GTX 1050 2GB) :11435 = lfm2.5-fast:gpu1 (GGUF Q4_0). Coordenador :11437.
-# NAS (RTX 2060 8GB) :11436 = trading-analyst (mesmo Modelfile do GPU0,
-# criado 2026-08-01) — fallback de trading. GPU1 fica reservado pra
-# persona/WhatsApp, não mistura com decisão de trade: se o coordenador cai
-# (ex.: pausado pelo job de fine-tune horário), o fallback vai pro MESMO
-# modelo em outra GPU, não degrada pra um modelo pequeno genérico.
+# GPU1 (GTX 1050 2GB) :11435 = lfm2.5-fast:gpu1 (GGUF Q4_0). Coordenador :11437
+# roteia tudo — HOST e FALLBACK_HOST apontam pro coordenador de propósito
+# (não pra GPU0/GPU1/NAS direto): ele é quem decide qual GPU usar por
+# modelo/saúde/carga, e faz failover interno sozinho (ex.: NAS tem
+# trading-analyst desde 2026-08-01, criado a partir do mesmo Modelfile do
+# GPU0 — se o GPU0 cai, o coordinator roteia pra lá automaticamente). Um
+# agente que vai direto numa GPU por fora do coordenador tira a
+# serialização anti-503-storm do incidente 2026-07-24 e quebra a
+# visibilidade centralizada — não fazer isso. O coordenador em si NUNCA
+# deve cair; se cair, é ele que precisa ser corrigido, não os agentes que
+# precisam de um desvio.
 # 2026-07-30: GPU1 recriada em quantização explícita Q4_0 (antes Q4_K_M);
 # fallbacks leves também GGUF quant (gemma3 Q4_K_M, smollm2 IQ3_M). Sem LLM chinês.
 
@@ -14,12 +19,12 @@ OLLAMA_PRIMARY_MODEL=trading-analyst
 OLLAMA_SMALL_MODEL=lfm2.5-fast:gpu1
 
 OLLAMA_PLAN_MODEL=trading-analyst
-OLLAMA_PLAN_FALLBACK_MODEL=trading-analyst
+OLLAMA_PLAN_FALLBACK_MODEL=lfm2.5-fast:gpu1
 
 OLLAMA_TRADE_PARAMS_MODEL=trading-analyst
 OLLAMA_TRADE_PARAMS_CONSERVATIVE_MODEL=trading-analyst
-OLLAMA_TRADE_PARAMS_FALLBACK_MODEL=trading-analyst
+OLLAMA_TRADE_PARAMS_FALLBACK_MODEL=lfm2.5-fast:gpu1
 
 OLLAMA_TRADE_WINDOW_MODEL=trading-analyst
 OLLAMA_TRADE_WINDOW_CONSERVATIVE_MODEL=trading-analyst
-OLLAMA_TRADE_WINDOW_FALLBACK_MODEL=trading-analyst
+OLLAMA_TRADE_WINDOW_FALLBACK_MODEL=lfm2.5-fast:gpu1

--- a/scripts/deploy_btc_trading_profiles.sh
+++ b/scripts/deploy_btc_trading_profiles.sh
@@ -757,22 +757,24 @@ sudo systemctl enable ollama-gpu-coordinator.service 2>/dev/null || true
 sudo systemctl restart ollama-gpu-coordinator.service
 sleep 2
 
-# Atualiza common.conf para rotear chamadas pelo coordenador (:11437).
-# FALLBACK_HOST fica na NAS (:11436, ollama direto, sem passar pelo
-# coordenador) de propósito — se apontasse pro mesmo :11437 do primário,
-# "fallback" nenhum ajudaria quando o coordenador cai (ex.: pausado pelo job
-# de fine-tune horário): primário e fallback morreriam juntos. A NAS não é
-# parada por esse job, então segue de pé como rota independente — e roda o
-# MESMO modelo trading-analyst (não um modelo pequeno genérico), preservando
-# qualidade de decisão. GPU1 fica reservado pra persona/WhatsApp.
+# Atualiza common.conf para rotear TODAS as chamadas (HOST e FALLBACK_HOST)
+# pelo coordenador (:11437) de propósito. O coordenador é quem decide qual
+# GPU usar por modelo/saúde/carga e faz failover interno sozinho (ex.: NAS
+# tem trading-analyst desde 2026-08-01 — se o GPU0 cai, ele roteia pra lá
+# automaticamente). Um agente com FALLBACK_HOST apontando direto pra uma
+# GPU (por fora do coordenador) tira a serialização anti-503-storm do
+# incidente 2026-07-24 e quebra a visibilidade centralizada — não fazer
+# isso. O coordenador em si nunca deve cair; se cair, conserte o que o
+# derrubou (ver whatsapp_toolcall_chunked_train.sh), não dê um desvio pros
+# agentes.
 sudo sed -i \
   -e 's|^Environment=OLLAMA_PLAN_HOST=.*|Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437|' \
   -e 's|^Environment=OLLAMA_TRADE_PARAMS_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436|' \
+  -e 's|^Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437|' \
   -e 's|^Environment=OLLAMA_TRADE_WINDOW_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437|' \
-  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436|' \
+  -e 's|^Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=.*|Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437|' \
   /etc/systemd/system/crypto-agent@.service.d/common.conf 2>/dev/null || true
-echo "🔀 Routing: agents → coordenador :11437 (llama3.2:1b) | fallback → NAS :11436 trading-analyst"
+echo "🔀 Routing: agents → coordenador :11437 (roteia GPU0/GPU1/NAS por saúde e modelo)"
 
 # Habilita e reinicia RSS sentiment
 sudo systemctl enable rss-sentiment-exporter.service 2>/dev/null || true

--- a/scripts/whatsapp_toolcall_chunked_train.sh
+++ b/scripts/whatsapp_toolcall_chunked_train.sh
@@ -5,7 +5,12 @@
 # Motivação: o treino precisa da RTX 3060, que é a mesma GPU do Ollama de
 # produção (trading + bot WhatsApp). Segurar produção parada por horas não é
 # aceitável; segurar por 10min de hora em hora é. Cada invocação:
-#   1. para ollama+coordinator (libera a 3060)
+#   1. para ollama.service (libera a 3060) — ollama-gpu-coordinator NUNCA é
+#      parado: é só um proxy HTTP, não retém VRAM, e ficando no ar detecta o
+#      GPU0 fora do ar sozinho e passa a rotear trading-analyst pra NAS
+#      (:11436) automaticamente. Coordenador cair é o problema em si (deixa
+#      os 14 crypto-agent@* sem NENHUM caminho pra IA), não uma consequência
+#      aceitável do treino — ver alerta dedicado se isso acontecer.
 #   2. sobe um guard em background que reforça o stop se algo externo religar
 #      o ollama durante a janela de treino (ver incidente 2026-07-31: um
 #      `systemctl start ollama.service` de fora, 2min30s após o pause, subiu
@@ -13,7 +18,7 @@
 #      preso porque o restore de fim de pacote só via "systemctl start" em
 #      serviço já "active" — no-op, nunca recarregava o modelo)
 #   3. treina por FT_TIME_BUDGET_SECONDS, salvando checkpoint
-#   4. RELIGA ollama+coordinator com stop+start forçado (nunca só "start" em
+#   4. RELIGA ollama.service com stop+start forçado (nunca só "start" em
 #      cima de um serviço que pode ter sido religado torto) + warmup que
 #      confere VRAM real via /api/ps antes de declarar sucesso (trap EXIT —
 #      sempre, mesmo em falha)
@@ -94,7 +99,6 @@ start_ollama_guard() {
       if [[ "$(systemctl is-active ollama.service 2>/dev/null || true)" == "active" ]]; then
         echo "[chunk] ⚠️ guard: algo religou ollama.service durante o treino — parando de novo"
         touch "$GUARD_TRIGGERED_FLAG"
-        sudo systemctl stop ollama-gpu-coordinator.service 2>/dev/null || true
         sudo systemctl stop ollama.service 2>/dev/null || true
       fi
     done
@@ -150,16 +154,21 @@ restore_ollama() {
     # dataset ausente) — ollama nunca foi pausado, não mexer nele.
     return 0
   fi
-  echo "--- [chunk] religando ollama+coordinator+dependentes ---"
+  echo "--- [chunk] religando ollama+dependentes (coordenador nunca foi parado) ---"
   # Stop+start forçado (nunca só "start"): se algo externo religou o ollama
   # torto durante a janela de treino, "start" em cima de um serviço já
   # "active" é um no-op e mantém o CPU-fallback — precisa derrubar e subir
   # de novo agora que a VRAM do treino já foi liberada.
+  #
+  # ollama-gpu-coordinator NÃO é reiniciado aqui porque nunca foi parado
+  # (ver pausa mais abaixo) — ele fica no ar o pacote inteiro, roteando
+  # trading-analyst pra NAS (:11436, mesmo Modelfile do GPU0) enquanto o
+  # GPU0 está de folga. O coordinator cair era o problema real: agentes
+  # perdiam TODO caminho pra IA, não só o GPU0.
   sudo systemctl stop ollama.service 2>/dev/null || true
   sleep 1
   sudo systemctl start ollama.service 2>/dev/null || true
   sleep 2
-  sudo systemctl start ollama-gpu-coordinator.service 2>/dev/null || true
   for unit in "${OLLAMA_PULLERS[@]}"; do
     sudo systemctl start "$unit" 2>/dev/null || true
   done
@@ -190,7 +199,12 @@ restore_ollama() {
     rm -f "$GUARD_TRIGGERED_FLAG"
   fi
 
-  if [[ "$st_ollama" != "active" ]]; then
+  if [[ "$st_coord" != "active" ]]; then
+    # O coordinator nunca é parado por este script — se caiu, foi por conta
+    # própria (crash/OOM/bug), e é o problema mais sério possível aqui: os
+    # agentes perdem TODO caminho pra IA, não só o GPU0. Nunca deve acontecer.
+    send_telegram "🚨 *Treino tool-calling*%0A%0Aollama-gpu-coordinator caiu (não foi este script que parou) — TODOS os agentes ficam sem IA, não só o GPU0. Verificar manualmente: systemctl status ollama-gpu-coordinator.service${guard_note}"
+  elif [[ "$st_ollama" != "active" ]]; then
     send_telegram "🚨 *Treino tool-calling*%0A%0AFalha ao religar ollama.service após o pacote de treino. Verificar manualmente no homelab.${guard_note}"
   elif [[ "$gpu_ok" != "1" ]]; then
     send_telegram "🚨 *Treino tool-calling*%0A%0Aollama.service religou mas *$WARMUP_MODEL* não carregou na GPU (CPU-fallback) mesmo após retry. Verificar manualmente (nvidia-smi / systemctl restart ollama.service).${guard_note}"
@@ -213,13 +227,20 @@ if [[ ! -f "$DATA_DIR/whatsapp_toolcall_train.jsonl" ]]; then
   exit 1
 fi
 
-echo "--- [chunk] pausando ollama+coordinator+dependentes p/ liberar a 3060 ---"
+echo "--- [chunk] pausando ollama+dependentes p/ liberar a 3060 (coordenador fica no ar) ---"
 PAUSED=1
+# ollama-gpu-coordinator NUNCA é parado: ele não retém VRAM da 3060 (é só um
+# proxy HTTP), então não precisa parar pra liberar GPU pro treino. Ficando
+# no ar, ele detecta o GPU0 indisponível sozinho (poll falha) e passa a
+# rotear trading-analyst pra NAS (:11436) automaticamente — os 14
+# crypto-agent@* continuam com IA o pacote inteiro, sem CPU-fallback e sem
+# precisar de nenhum bypass fora da arquitetura. Coordenador cair É o
+# problema (ver alerta em restore_ollama), não uma consequência aceitável
+# do treino.
 # Ordem importa: primeiro quem reergue o ollama, depois o ollama.
 for unit in "${OLLAMA_PULLERS[@]}"; do
   sudo systemctl stop "$unit" 2>/dev/null || true
 done
-sudo systemctl stop ollama-gpu-coordinator.service 2>/dev/null || true
 sudo systemctl stop ollama.service 2>/dev/null || true
 sleep 4
 

--- a/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_aggressive.service.d/zz-direct-ollama.conf
@@ -26,15 +26,15 @@
 # Override por perfil exigiria um EnvironmentFile= dedicado — ver
 # docs/systemd/DROPIN_DEPLOY_PARITY.md antes de criar essa camada.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436
-# FALLBACK_HOST na NAS (:11436, trading-analyst, direto) de propósito: se
-# apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
-# ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
-# fine-tune horário) — primário e fallback morreriam juntos. A NAS roda o
-# MESMO modelo (não degrada pra um modelo pequeno) e não é tocada por esse
-# job. GPU1 (11435) fica reservado pra persona/WhatsApp.
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
+# HOST e FALLBACK_HOST apontam os DOIS pro coordenador de propósito — ele
+# roteia sozinho pra NAS/GPU1 quando o GPU0 cai (ver models.env). Um
+# fallback direto numa GPU por fora do coordenador tira a serialização
+# anti-503-storm do incidente 2026-07-24. O coordenador nunca deve cair;
+# se cair, é ele que precisa ser corrigido (ver
+# whatsapp_toolcall_chunked_train.sh), não os agentes.
 # (sem Environment=OLLAMA_*_MODEL aqui — ver cabeçalho)

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/ollama-routing.conf
@@ -1,10 +1,10 @@
 [Service]
 # Roteamento via coordenador para serializar com os demais agentes.
 # Coordenador (11437) gerencia GPU0/GPU1 automaticamente.
-# FALLBACK_HOST na NAS (:11436, trading-analyst) de propósito — ver
+# FALLBACK_HOST também no coordenador de propósito — ver
 # zz-direct-ollama.conf neste mesmo diretório (essas chaves são shadowed por
 # ele, mas mantidas coerentes pra não confundir diagnóstico futuro).
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437

--- a/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
+++ b/systemd/crypto-agent@BTC_USDT_conservative.service.d/zz-direct-ollama.conf
@@ -3,15 +3,14 @@
 #   trading-analyst → GPU0 (11434, RTX 2060)
 #   gemma3-fast:gpu1 → GPU1 (11435, GTX 1050)
 # Coordenador serializa acessos e evita 503 em cascata.
-# FALLBACK_HOST na NAS (:11436, trading-analyst, direto) de propósito: se
-# apontasse pro mesmo :11437 do primário, um fallback pra si mesmo não
-# ajuda em nada quando o coordenador cai (ex.: pausado pelo job de
-# fine-tune horário) — primário e fallback morreriam juntos. A NAS roda o
-# MESMO modelo (não degrada pra um modelo pequeno) e não é tocada por esse
-# job. GPU1 (11435) fica reservado pra persona/WhatsApp.
+# HOST e FALLBACK_HOST apontam os DOIS pro coordenador de propósito — ele
+# roteia sozinho pra NAS/GPU1 quando o GPU0 cai (ver models.env). Um
+# fallback direto numa GPU por fora do coordenador tira a serialização
+# anti-503-storm do incidente 2026-07-24. O coordenador nunca deve cair;
+# se cair, é ele que precisa ser corrigido, não os agentes.
 Environment=OLLAMA_PLAN_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_PLAN_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437
 Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437
-Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436
+Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437

--- a/tests/test_deploy_btc_trading_profiles_script.py
+++ b/tests/test_deploy_btc_trading_profiles_script.py
@@ -12,23 +12,21 @@ def _load_script() -> str:
     return SCRIPT_PATH.read_text(encoding="utf-8")
 
 
-def test_script_routes_ollama_fallback_host_away_from_coordinator() -> None:
-    """FALLBACK_HOST não pode apontar pro mesmo endereço do HOST primário.
+def test_script_routes_ollama_fallback_host_through_coordinator() -> None:
+    """FALLBACK_HOST tem que apontar pro MESMO coordenador do HOST primário.
 
-    O coordenador (:11437) é pausado toda hora pelo job de fine-tune; se o
-    fallback também apontar pra ele, primário e fallback caem juntos e os
-    agentes ficam cegos ~10-15min/hora sem nenhum caminho alternativo.
-    A NAS (:11436, roda trading-analyst — mesmo modelo do GPU0) não é
-    pausada por esse job — é o fallback correto. GPU1 (:11435) fica
-    reservado pra persona/WhatsApp, não é usado como fallback de trading.
+    O coordenador (:11437) nunca deve ser derrubado (ver
+    whatsapp_toolcall_chunked_train.sh) — ele decide sozinho qual GPU usar
+    por modelo/saúde/carga e faz failover interno pra NAS/GPU1 quando o
+    GPU0 cai (NAS tem trading-analyst desde 2026-08-01, mesmo Modelfile do
+    GPU0). Um FALLBACK_HOST apontando direto numa GPU por fora do
+    coordenador tira a serialização anti-503-storm do incidente 2026-07-24.
     """
     content = _load_script()
-    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.4:11436" in content
-    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.4:11436" in content
-    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437" not in content
-    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437" not in content
-    # Primário continua no coordenador — só o fallback muda.
+    assert "Environment=OLLAMA_TRADE_PARAMS_FALLBACK_HOST=http://192.168.15.2:11437" in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_FALLBACK_HOST=http://192.168.15.2:11437" in content
     assert "Environment=OLLAMA_TRADE_PARAMS_HOST=http://192.168.15.2:11437" in content
+    assert "Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437" in content
     assert "Environment=OLLAMA_TRADE_WINDOW_HOST=http://192.168.15.2:11437" in content
 
 

--- a/tests/test_systemd_dropin_parity.py
+++ b/tests/test_systemd_dropin_parity.py
@@ -446,15 +446,17 @@ def test_dropin_environment_never_shadowed_by_models_env() -> None:
     )
 
 
-def test_ollama_fallback_host_never_matches_primary_host_in_dropins() -> None:
-    """`*_FALLBACK_HOST` não pode apontar pro mesmo endereço do `*_HOST` primário.
+def test_ollama_fallback_host_always_routes_through_coordinator_in_dropins() -> None:
+    """`*_FALLBACK_HOST` tem que apontar pro MESMO coordenador (:11437) do `*_HOST`.
 
-    O coordenador (:11437) é pausado toda hora pelo job de fine-tune
-    (whatsapp_toolcall_chunked_train.sh). Se o fallback também apontar pra
-    ele, primário e fallback caem juntos e os crypto-agent@* ficam sem
-    nenhum caminho pra IA durante a pausa — o "fallback" nunca ajuda.
-    ollama-gpu1.service (:11435) não é parado por esse job; é o fallback
-    correto (ver deploy_btc_trading_profiles.sh e zz-direct-ollama.conf).
+    O coordenador decide sozinho qual GPU usar por modelo/saúde/carga e faz
+    failover interno (ex.: NAS tem trading-analyst desde 2026-08-01 — se o
+    GPU0 cai, ele roteia pra lá automaticamente). Um agente com
+    FALLBACK_HOST apontando direto pra uma GPU, por fora do coordenador,
+    tira a serialização anti-503-storm do incidente 2026-07-24 e quebra a
+    visibilidade centralizada. O coordenador em si nunca deve cair — se
+    cair, conserte quem o derrubou (ver whatsapp_toolcall_chunked_train.sh),
+    não dê um desvio pros agentes.
     """
     offenders: list[str] = []
     for rel_dir in _allowed_dirs():
@@ -462,6 +464,13 @@ def test_ollama_fallback_host_never_matches_primary_host_in_dropins() -> None:
             continue
         for conf in sorted((REPO_ROOT / "systemd" / rel_dir).glob("*.conf")):
             text = conf.read_text(encoding="utf-8")
+            if "<from_bitwarden>" in text:
+                # Template não instalado pelo deploy (contém segredos
+                # placeholder) — deploy_btc_trading_profiles.sh reescreve os
+                # OLLAMA_*_HOST via sed no arquivo vivo do host, então os
+                # valores literais aqui divergem de propósito. Ver header do
+                # próprio common.conf.
+                continue
             hosts: dict[str, str] = {}
             for name, value in re.findall(
                 r'^Environment="?(OLLAMA_[A-Z_]*_HOST)="?([^"\s]+)"?\s*$',
@@ -474,10 +483,13 @@ def test_ollama_fallback_host_never_matches_primary_host_in_dropins() -> None:
                     continue
                 primary_name = name.replace("_FALLBACK_HOST", "_HOST")
                 primary_value = hosts.get(primary_name)
-                if primary_value is not None and primary_value == value:
-                    offenders.append(f"{rel_dir}/{conf.name}: {name}={value} == {primary_name}")
+                if primary_value is not None and primary_value != value:
+                    offenders.append(
+                        f"{rel_dir}/{conf.name}: {name}={value} != {primary_name}={primary_value}"
+                    )
 
     assert not offenders, (
-        "FALLBACK_HOST igual ao HOST primário — fallback inútil quando o "
-        "primário cai. Offenders: " + "; ".join(offenders)
+        "FALLBACK_HOST diferente do HOST primário — tira o roteamento do "
+        "coordenador central e reabre o risco de 503-storm do incidente "
+        "2026-07-24. Offenders: " + "; ".join(offenders)
     )

--- a/tests/test_whatsapp_toolcall_chunked_train_script.py
+++ b/tests/test_whatsapp_toolcall_chunked_train_script.py
@@ -1,0 +1,57 @@
+"""Regression checks for the hourly QLoRA chunk-training script.
+
+O coordenador (ollama-gpu-coordinator.service) NUNCA pode ser parado por
+esse job. Ele não retém VRAM da 3060 (é só um proxy HTTP) e ficando no ar
+detecta o GPU0 indisponível sozinho, roteando trading-analyst pra NAS
+(:11436) automaticamente — os 14 crypto-agent@* continuam com IA durante o
+pacote de treino inteiro. Derrubar o coordenador tira TODO caminho pra IA
+dos agentes, não só o GPU0; é o problema em si, não uma consequência
+aceitável do treino.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "whatsapp_toolcall_chunked_train.sh"
+)
+
+
+def _load_script() -> str:
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def test_script_never_stops_the_gpu_coordinator() -> None:
+    content = _load_script()
+    assert "systemctl stop ollama-gpu-coordinator.service" not in content
+    assert "systemctl start ollama-gpu-coordinator.service" not in content
+
+
+def test_script_still_pauses_ollama_service_and_selfheal() -> None:
+    """A pausa continua existindo — só não inclui mais o coordenador.
+
+    ollama.service (GPU0) precisa parar de verdade pra liberar VRAM pro
+    treino. ollama-gpu-selfheal precisa ser pausado junto porque ELE
+    monitora ollama.service diretamente e o religaria sem saber que a
+    pausa é intencional (ver OLLAMA_PULLERS no script).
+    """
+    content = _load_script()
+    assert "systemctl stop ollama.service" in content
+    assert "systemctl start ollama.service" in content
+    assert "ollama-gpu-selfheal.service" in content
+    assert "OLLAMA_PULLERS=(eddie-calendar.service llm-optimizer.service ollama-gpu-selfheal.service)" in content
+
+
+def test_script_alerts_if_coordinator_ever_found_down() -> None:
+    """Se o coordenador cair por conta própria (nunca por este script), alerta.
+
+    Isso só pode acontecer por crash/OOM/bug — nunca pela pausa em si — e é
+    o alerta mais sério possível: todos os agentes ficam sem IA, não só o
+    GPU0.
+    """
+    content = _load_script()
+    assert '"$st_coord" != "active"' in content
+    assert "ollama-gpu-coordinator caiu" in content


### PR DESCRIPTION
## Summary
Correção arquitetural apontada pelo usuário: reverte os PRs #284/#285 (fallback de trading direto pra GPU1/NAS, por fora do coordenador) e ataca a causa real.

- **Causa raiz**: `whatsapp_toolcall_chunked_train.sh` parava `ollama-gpu-coordinator.service` toda hora, junto com `ollama.service`, achando que precisava liberar VRAM da 3060 — mas o coordenador é só um proxy HTTP, não retém VRAM nenhuma. Ao pausá-lo, os 14 `crypto-agent@*` ficavam sem NENHUM caminho pra IA (não só sem o GPU0).
- **Fix**: o script agora só para `ollama.service` (GPU0) + selfheal/eddie-calendar/llm-optimizer. O coordenador fica no ar o pacote inteiro; ao detectar o GPU0 indisponível, passa a rotear `trading-analyst` pra NAS (`:11436`, mesmo Modelfile do GPU0) automaticamente — usando a lógica de failover/catálogo dinâmico que ele já tinha.
- Reverte `HOST`/`FALLBACK_HOST` dos `crypto-agent@*` de volta pro coordenador (`:11437`) em ambos — um fallback por fora do coordenador tira a serialização anti-503-storm do incidente 2026-07-24 e quebra a visibilidade centralizada.
- Adiciona alerta dedicado se o coordenador for encontrado fora do ar por qualquer outro motivo (crash/OOM/bug) — isso sim é o problema em si.

## Test plan
- [x] `pytest tests/test_systemd_dropin_parity.py tests/test_deploy_btc_trading_profiles_script.py tests/test_whatsapp_toolcall_chunked_train_script.py` — 40/40 passando
- [x] `pytest tests/test_ollama_gpu_coordinator_availability.py` — 26/26 passando
- [ ] Deploy no homelab + restart escalonado dos 14 crypto-agent@* + validar no próximo ciclo horário do fine-tune que o coordenador permanece ativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)