### PR TITLE
fix(trading): dedup de ordem duplicada, reconciliação bidirecional e rebuy lock fail-closed

### DIFF
--- a/btc_trading_agent/kucoin_api.py
+++ b/btc_trading_agent/kucoin_api.py
@@ -1083,7 +1083,6 @@ def _floor_to_increment(value: float, increment: str) -> str:
     return format(quantized.normalize(), "f")
 
 
-@retry_on_failure(max_retries=3)
 def place_market_order(symbol: str, side: str, funds: float = None,
                        size: float = None,
                        notify_extra: Dict[str, float] = None) -> Dict[str, Any]:
@@ -1091,6 +1090,14 @@ def place_market_order(symbol: str, side: str, funds: float = None,
 
     notify_extra: contexto opcional para a notificação Telegram
     (invested, proceeds, pnl, pnl_pct) — usado nos SELLs.
+
+    client_oid é gerado uma única vez e reaproveitado em todas as
+    tentativas de retry (nunca use @retry_on_failure aqui, que re-executa
+    a função inteira e geraria um clientOid novo por tentativa). Se uma
+    tentativa anterior chegou a criar a ordem na KuCoin mas a resposta se
+    perdeu por erro de rede, reenviar o clientOid original faz a KuCoin
+    deduplicar; antes de cada reenvio checamos via clientOid se a ordem já
+    existe, para nunca duplicar uma ordem de dinheiro real.
     """
     validate_credentials()
 
@@ -1115,11 +1122,52 @@ def place_market_order(symbol: str, side: str, funds: float = None,
 
     body_str = json.dumps(payload, separators=(",", ":"))
 
-    logger.info(f"📤 {side.upper()} {symbol} - funds={funds}, size={size}")
+    max_attempts = 3
+    last_error: Optional[Exception] = None
+    result: Optional[Dict[str, Any]] = None
 
-    r = _signed_request("POST", endpoint, body_str=body_str, timeout=15)
+    for attempt in range(max_attempts):
+        if attempt > 0:
+            existing = get_order_by_client_oid(client_oid)
+            if existing:
+                logger.warning(
+                    "⚠️ Ordem clientOid=%s já existe na KuCoin (id=%s) — "
+                    "resposta da tentativa anterior deve ter se perdido; "
+                    "reaproveitando em vez de reenviar",
+                    client_oid, existing.get("id"),
+                )
+                result = {"code": "200000", "data": existing}
+                break
+        try:
+            logger.info(
+                f"📤 {side.upper()} {symbol} - funds={funds}, size={size} "
+                f"(tentativa {attempt + 1}/{max_attempts}, clientOid={client_oid})"
+            )
+            r = _signed_request("POST", endpoint, body_str=body_str, timeout=15)
+            result = r.json()
+            break
+        except Exception as e:
+            last_error = e
+            logger.warning(
+                f"⚠️ Falha de rede ao enviar ordem (tentativa {attempt + 1}/{max_attempts}): {e}"
+            )
+            if attempt < max_attempts - 1:
+                time.sleep(0.5 * (attempt + 1))
 
-    result = r.json()
+    if result is None:
+        # Todas as tentativas falharam por exceção — checa uma última vez
+        # se a ordem foi criada mesmo assim antes de desistir de vez.
+        existing = get_order_by_client_oid(client_oid)
+        if existing:
+            logger.warning(
+                "⚠️ Ordem clientOid=%s foi criada apesar das exceções de rede "
+                "(id=%s) — usando ordem existente",
+                client_oid, existing.get("id"),
+            )
+            result = {"code": "200000", "data": existing}
+        else:
+            raise last_error
+
     if result.get("code") != "200000":
         logger.error(f"❌ Order failed: {result}")
         error_msg = result.get("msg", "Unknown")
@@ -1135,7 +1183,10 @@ def place_market_order(symbol: str, side: str, funds: float = None,
         )
         return {"success": False, "error": error_msg, "raw": result}
 
-    order_id = result.get("data", {}).get("orderId")
+    # POST /api/v1/orders devolve "orderId"; GET .../client-order/{clientOid}
+    # (usado no caminho de reconciliação acima) devolve "id" para o mesmo campo.
+    order_data = result.get("data", {})
+    order_id = order_data.get("orderId") or order_data.get("id")
     logger.info(f"✅ Order placed: {order_id}")
     _send_telegram_alert(
         _format_market_order_notification(
@@ -1504,6 +1555,20 @@ def get_trade_fees(symbols: str) -> List[Dict[str, Any]]:
 def get_order_details(order_id: str) -> Optional[Dict[str, Any]]:
     """Obtém detalhes de uma ordem"""
     endpoint = f"/api/v1/orders/{order_id}"
+    r = _signed_request("GET", endpoint, timeout=10)
+    if r.status_code == 200 and r.json().get("code") == "200000":
+        return r.json().get("data")
+    return None
+
+@retry_on_failure(max_retries=2)
+def get_order_by_client_oid(client_oid: str) -> Optional[Dict[str, Any]]:
+    """Obtém detalhes de uma ordem pelo clientOid (idempotency token).
+
+    Usado para checar se uma ordem já foi criada antes de reenviar o mesmo
+    clientOid após falha de rede — evita duplicar ordem quando a resposta
+    da tentativa anterior se perdeu mas a ordem chegou a ser aceita.
+    """
+    endpoint = f"/api/v1/order/client-order/{client_oid}"
     r = _signed_request("GET", endpoint, timeout=10)
     if r.status_code == 200 and r.json().get("code") == "200000":
         return r.json().get("data")

--- a/btc_trading_agent/position_manager_mixin.py
+++ b/btc_trading_agent/position_manager_mixin.py
@@ -16,7 +16,7 @@ import threading
 import time
 from typing import Any, Dict
 
-from kucoin_api import place_market_order
+from kucoin_api import place_market_order, _send_telegram_alert
 from slot_exit_policy import (
     PerSlotExitPlanner,
     SignalSellContext,
@@ -521,9 +521,15 @@ class PositionManagerMixin:
         que o conservative acredita ser seu, o conservative fica com posição
         registrada no DB mas sem BTC na exchange.
 
-        Ao detectar a divergência, fecha os slots excedentes com uma venda
-        sintética (metadata.source = "reconciled"), do slot mais recente para
+        Ao detectar essa divergência (DB > exchange), fecha os slots excedentes
+        do state (sem gravar sell sintético no DB), do slot mais recente para
         o mais antigo, até que DB == saldo real ± tolerância.
+
+        Na direção oposta (exchange > DB — a exchange tem MAIS moeda do que o
+        DB conhece), NÃO criamos entries sintéticas automaticamente: em conta
+        compartilhada entre profiles, atribuir esse saldo ao profile errado
+        corrompe PnL/histórico de outro agente. Esse caso só dispara um alerta
+        Telegram para investigação manual.
 
         Chamado:
         - Em background quando sell falha com código 200004 (Balance insufficient)
@@ -531,7 +537,8 @@ class PositionManagerMixin:
         - Em background após cada compra bem-sucedida
 
         Returns:
-            Número de slots fechados por reconciliação (0 = tudo consistente).
+            Número de slots fechados por reconciliação (0 = tudo consistente,
+            ou exchange > DB — nesse caso apenas alertado, não contado aqui).
         """
         if self.state.dry_run:
             return 0
@@ -549,20 +556,38 @@ class PositionManagerMixin:
             logger.warning("⚠️ Reconciliação: falha ao consultar saldo KuCoin — %s", exc)
             return 0
 
+        profile = self._current_profile() if callable(getattr(self, "_current_profile", None)) else "default"
+
         db_position = sum(float(e.get("size", 0) or 0) for e in entries)
         # Tolerância de 0.5% ou 1 satoshi — evita falsos positivos por arredondamento
         tolerance = max(db_position * 0.005, 0.000_000_01)
 
+        if real_balance > db_position + tolerance:
+            excess = real_balance - db_position
+            logger.warning(
+                "⚠️ [reconcile] Exchange tem mais %s do que o DB conhece (%s/%s): "
+                "DB=%.8f | Exchange=%.8f | excesso=%.8f — alertando, sem ação automática",
+                base_currency, self.symbol, profile, db_position, real_balance, excess,
+            )
+            _send_telegram_alert(
+                f"⚠️ *Reconciliação* `{self.symbol}`/`{profile}`\n"
+                f"Exchange tem *mais* {base_currency} do que o DB sabe:\n"
+                f"DB: `{db_position:.8f}` | Exchange: `{real_balance:.8f}` | "
+                f"excesso: `{excess:.8f}`\n"
+                f"Sem ação automática (risco de atribuir saldo de outro profile "
+                f"na mesma subconta) — verificar manualmente."
+            )
+            return 0
+
         if real_balance >= db_position - tolerance:
             return 0  # consistente, nada a fazer
 
-        phantom_btc = db_position - real_balance
         logger.warning(
-            "⚠️ [reconcile] Divergência detectada: DB=%.8f %s | Exchange=%.8f %s | "
-            "phantom=%.8f %s — fechando slots excedentes",
+            "⚠️ [reconcile] Divergência detectada (pré-lock): DB=%.8f %s | Exchange=%.8f %s | "
+            "phantom~%.8f %s — confirmando dentro do lock antes de fechar slots",
             db_position, base_currency,
             real_balance, base_currency,
-            phantom_btc, base_currency,
+            db_position - real_balance, base_currency,
         )
 
         if not current_price or current_price <= 0:
@@ -573,12 +598,32 @@ class PositionManagerMixin:
                 pass
 
         fee_pct = getattr(self, "_trading_fee_pct", _TRADING_FEE_PCT)
-        profile = self._current_profile() if callable(getattr(self, "_current_profile", None)) else "default"
 
         closed = 0
-        # Fecha do slot mais recente para o mais antigo até eliminar o excesso
+        # Fecha do slot mais recente para o mais antigo até eliminar o excesso.
         with self._trade_lock:
+            # Recomputa db_position/tolerance/phantom a partir de uma leitura
+            # FRESCA de entries feita já dentro do lock — os valores calculados
+            # acima (pré-lock) só servem para decidir se vale a pena buscar
+            # current_price e entrar aqui. Usá-los para a decisão de quais/quantos
+            # slots fechar seria uma condição de corrida (TOCTOU): outro trade
+            # pode ter mutado self.state.entries entre aquela leitura e a
+            # aquisição do lock, tornando phantom_btc/tolerance obsoletos.
             entries = list(getattr(self.state, "entries", []) or [])
+            db_position = sum(float(e.get("size", 0) or 0) for e in entries)
+            tolerance = max(db_position * 0.005, 0.000_000_01)
+            phantom_btc = db_position - real_balance
+
+            if phantom_btc <= tolerance:
+                return 0  # já consistente no momento em que o lock foi obtido
+
+            logger.warning(
+                "⚠️ [reconcile] Divergência confirmada dentro do lock: DB=%.8f %s | "
+                "Exchange=%.8f %s | phantom=%.8f %s — fechando slots excedentes",
+                db_position, base_currency, real_balance, base_currency,
+                phantom_btc, base_currency,
+            )
+
             for idx in range(len(entries) - 1, -1, -1):
                 if phantom_btc <= tolerance:
                     break

--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -4582,9 +4582,32 @@ class BitcoinTradingAgent(
             min_confidence = max(0.45, min_confidence - 0.05)
 
         # REBUY lock: envelope determinístico (grace→decay→expired) + margem IA dentro.
+        # Guardrail de segurança (dinheiro real): se algo falhar ao AVALIAR o
+        # envelope, o comportamento correto é falhar FECHADO (bloquear a
+        # compra), nunca aberto — o docstring de _resolve_rebuy_envelope
+        # promete que o freio "é mecânico e SEMPRE ativo"; um `except: pass`
+        # que deixa passar a compra silenciosamente viola exatamente essa
+        # garantia sempre que a config tiver um valor malformado ou algum
+        # atributo inesperado faltar.
         if signal.action == "BUY":
             try:
                 env = self._resolve_rebuy_envelope(rag_adj, controls)
+            except Exception as exc:
+                last_sell_fallback = float(getattr(self.state, "last_sell_entry_price", 0.0) or 0.0)
+                if last_sell_fallback > 0:
+                    logger.error(
+                        f"❌ Erro ao avaliar rebuy envelope ({exc!r}) com venda "
+                        f"registrada (${last_sell_fallback:,.2f}) — bloqueando por "
+                        f"segurança (fail-closed) em vez de ignorar o lock"
+                    )
+                    return self._block_trade(
+                        "buy_rebuy_lock_evaluation_error",
+                        price=float(getattr(signal, "price", 0.0) or 0.0),
+                        last_sell_entry_price=last_sell_fallback,
+                        rebuy_error=repr(exc),
+                    )
+                logger.debug(f"Erro ao aplicar rebuy envelope (sem venda registrada; ignorando): {exc!r}")
+            else:
                 if env["active"]:
                     price = float(getattr(signal, "price", 0.0) or 0.0)
                     if price >= env["ceiling"]:
@@ -4605,8 +4628,6 @@ class BitcoinTradingAgent(
                             rebuy_elapsed_hours=round(env["elapsed_hours"], 2),
                             rebuy_source=env["source"],
                         )
-            except Exception:
-                logger.debug("Erro ao aplicar rebuy envelope; ignorando bloqueio")
 
         if signal.action == "SELL":
             guardrail_sell = self._get_guardrail_sell_verdict(signal.price)

--- a/clear_trading_agent/mt5_api.py
+++ b/clear_trading_agent/mt5_api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+import uuid
 from functools import wraps
 from pathlib import Path
 from typing import Any, Optional
@@ -260,7 +261,98 @@ def get_active_orders(symbol: Optional[str] = None) -> list[dict[str, Any]]:
 
 
 # ====================== TRADING ======================
-@retry_on_failure(max_retries=3)
+def _tagged_comment(comment: str) -> str:
+    """Anexa um sufixo aleatório único ao comentário da ordem.
+
+    O bridge MT5 (mt5_bridge/bridge_api.py) não suporta um idempotency
+    token nativo como o clientOid da KuCoin — mas o campo `comment` da
+    ordem é ecoado de volta em cada deal executado (DealInfo.comment) e
+    fica disponível via get_history_deals(). Usamos essa tag como
+    substituto de idempotency key: antes de reenviar após uma exceção de
+    rede, checamos se já existe um deal recente com essa tag exata antes
+    de disparar uma segunda ordem real na Clear. MT5 limita comment a 31
+    bytes, daí o truncamento.
+    """
+    tag = uuid.uuid4().hex[:10]
+    return f"{comment[:20]}#{tag}"[:31]
+
+
+def _find_recent_deal_by_comment(symbol: str, tagged_comment: str) -> Optional[dict[str, Any]]:
+    """Procura um deal já executado com o comment tag exato (janela de 1 dia)."""
+    try:
+        deals = get_history_deals(days=1, symbol=symbol)
+    except Exception as e:
+        logger.warning("⚠️ Falha ao checar histórico de deals p/ dedup: %s", e)
+        return None
+    for deal in deals:
+        if deal.get("comment") == tagged_comment:
+            return deal
+    return None
+
+
+def _place_order_with_dedup(
+    endpoint_payload: dict[str, Any],
+    *,
+    symbol: str,
+    tagged_comment: str,
+    max_attempts: int = 3,
+) -> dict[str, Any]:
+    """Envia a ordem ao bridge, reaproveitando a mesma comment tag entre
+    tentativas e checando o histórico de deals antes de reenviar — nunca
+    use @retry_on_failure aqui, que re-executaria a função inteira sem
+    checar se a ordem anterior já tinha sido aceita pela Clear."""
+    last_error: Optional[Exception] = None
+    result: Optional[dict[str, Any]] = None
+
+    for attempt in range(max_attempts):
+        if attempt > 0:
+            existing = _find_recent_deal_by_comment(symbol, tagged_comment)
+            if existing:
+                logger.warning(
+                    "⚠️ Deal com comment=%s já existe na Clear (ticket=%s) — "
+                    "resposta da tentativa anterior deve ter se perdido; "
+                    "reaproveitando em vez de reenviar",
+                    tagged_comment, existing.get("ticket"),
+                )
+                result = {
+                    "success": True,
+                    "order_id": existing.get("order"),
+                    "price": existing.get("price"),
+                    "volume": existing.get("volume"),
+                }
+                break
+        try:
+            result = _post("/order", endpoint_payload)
+            break
+        except Exception as e:
+            last_error = e
+            logger.warning(
+                "⚠️ Falha de rede ao enviar ordem (tentativa %d/%d): %s",
+                attempt + 1, max_attempts, e,
+            )
+            if attempt < max_attempts - 1:
+                time.sleep(0.5 * (attempt + 1))
+
+    if result is None:
+        existing = _find_recent_deal_by_comment(symbol, tagged_comment)
+        if existing:
+            logger.warning(
+                "⚠️ Deal com comment=%s foi criado apesar das exceções de rede "
+                "(ticket=%s) — usando deal existente",
+                tagged_comment, existing.get("ticket"),
+            )
+            result = {
+                "success": True,
+                "order_id": existing.get("order"),
+                "price": existing.get("price"),
+                "volume": existing.get("volume"),
+            }
+        else:
+            raise last_error
+
+    return result
+
+
 def place_market_order(
     symbol: str,
     side: str,
@@ -282,6 +374,7 @@ def place_market_order(
     Returns:
         Dict com success, order_id, price, volume, error.
     """
+    tagged_comment = _tagged_comment(comment)
     payload = {
         "symbol": symbol,
         "side": side.lower(),
@@ -289,15 +382,15 @@ def place_market_order(
         "order_type": "market",
         "deviation": deviation,
         "magic": magic,
-        "comment": comment,
+        "comment": tagged_comment,
     }
 
     logger.info(
-        "📤 %s %s %.2f lotes (slippage=%d pts)",
-        side.upper(), symbol, volume, deviation,
+        "📤 %s %s %.2f lotes (slippage=%d pts, comment=%s)",
+        side.upper(), symbol, volume, deviation, tagged_comment,
     )
 
-    result = _post("/order", payload)
+    result = _place_order_with_dedup(payload, symbol=symbol, tagged_comment=tagged_comment)
 
     if result.get("success"):
         logger.info(
@@ -310,7 +403,6 @@ def place_market_order(
     return result
 
 
-@retry_on_failure(max_retries=3)
 def place_limit_order(
     symbol: str,
     side: str,
@@ -332,6 +424,7 @@ def place_limit_order(
     Returns:
         Dict com success, order_id, error.
     """
+    tagged_comment = _tagged_comment(comment)
     payload = {
         "symbol": symbol,
         "side": side.lower(),
@@ -339,15 +432,15 @@ def place_limit_order(
         "order_type": "limit",
         "price": price,
         "magic": magic,
-        "comment": comment,
+        "comment": tagged_comment,
     }
 
     logger.info(
-        "📤 LIMIT %s %s %.2f @ %.4f",
-        side.upper(), symbol, volume, price,
+        "📤 LIMIT %s %s %.2f @ %.4f (comment=%s)",
+        side.upper(), symbol, volume, price, tagged_comment,
     )
 
-    result = _post("/order", payload)
+    result = _place_order_with_dedup(payload, symbol=symbol, tagged_comment=tagged_comment)
 
     if result.get("success"):
         logger.info("✅ Ordem limitada: id=%s", result.get("order_id"))

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T16:07:08.589717+00:00",
+  "generated_at": "2026-08-01T17:11:25.982998+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T16:07:08.589717+00:00`
+- Generated at: `2026-08-01T17:11:25.982998+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/tests/test_ai_plan_fallback.py
+++ b/tests/test_ai_plan_fallback.py
@@ -37,6 +37,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_ai_trade_window.py
+++ b/tests/test_ai_trade_window.py
@@ -52,6 +52,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_buy_profitability_guard.py
+++ b/tests/test_buy_profitability_guard.py
@@ -29,6 +29,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_buy_target_tolerance.py
+++ b/tests/test_buy_target_tolerance.py
@@ -29,6 +29,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_clear_trading.py
+++ b/tests/test_clear_trading.py
@@ -300,6 +300,75 @@ class TestMt5ApiClient:
         result = place_limit_order("PETR4", "buy", 100, 28.00)
         assert result["success"] is True
 
+    @patch("clear_trading_agent.mt5_api.uuid.uuid4")
+    @patch("clear_trading_agent.mt5_api.requests.post")
+    def test_place_market_order_reusa_comment_tag_entre_tentativas(
+        self, mock_post: MagicMock, mock_uuid: MagicMock,
+    ) -> None:
+        """Regressão: place_market_order não pode gerar uma comment tag
+        (idempotency key do MT5 bridge, já que MT5 não tem clientOid) nova
+        a cada retry. @retry_on_failure re-executava a função inteira,
+        inclusive a geração da tag, arriscando ordem duplicada na Clear se
+        a 1ª tentativa tivesse sido aceita mas a resposta se perdesse."""
+        mock_uuid.return_value = MagicMock(hex="abc123def456")
+        mock_post.side_effect = [
+            ConnectionError("network reset"),
+            MagicMock(
+                status_code=200,
+                json=lambda: {"success": True, "order_id": 555, "price": 28.5, "volume": 100},
+                raise_for_status=MagicMock(),
+            ),
+        ]
+        with patch(
+            "clear_trading_agent.mt5_api._find_recent_deal_by_comment",
+            return_value=None,
+        ) as mock_lookup:
+            result = place_market_order("PETR4", "buy", 100)
+
+        assert result["success"] is True
+        assert mock_post.call_count == 2
+        comments = [call.kwargs["json"]["comment"] for call in mock_post.call_args_list]
+        assert comments[0] == comments[1], "comment tag mudou entre tentativas"
+        mock_lookup.assert_called_once()
+
+    @patch("clear_trading_agent.mt5_api.requests.post")
+    def test_place_market_order_nao_duplica_se_deal_ja_existe(
+        self, mock_post: MagicMock,
+    ) -> None:
+        """Se a 1ª tentativa falhar por exceção de rede mas o deal já
+        tiver sido executado na Clear, a 2ª tentativa deve reaproveitar o
+        deal existente (achado via comment tag) em vez de enviar outra
+        ordem real."""
+        mock_post.side_effect = [ConnectionError("network reset")]
+        existing_deal = {"ticket": 777, "order": 999, "price": 28.4, "volume": 100}
+        with patch(
+            "clear_trading_agent.mt5_api._find_recent_deal_by_comment",
+            return_value=existing_deal,
+        ) as mock_lookup:
+            result = place_market_order("PETR4", "buy", 100)
+
+        assert result["success"] is True
+        assert result["order_id"] == 999
+        assert mock_post.call_count == 1
+        mock_lookup.assert_called_once()
+
+    @patch("clear_trading_agent.mt5_api.time.sleep")
+    @patch("clear_trading_agent.mt5_api.requests.post")
+    def test_place_market_order_relanca_erro_sem_deal_e_tentativas_esgotadas(
+        self, mock_post: MagicMock, mock_sleep: MagicMock,
+    ) -> None:
+        """Sem deal encontrado e todas as tentativas esgotadas por
+        exceção, o erro original deve propagar — nunca ser engolido."""
+        mock_post.side_effect = [
+            ConnectionError("a"), ConnectionError("b"), ConnectionError("c"),
+        ]
+        with patch(
+            "clear_trading_agent.mt5_api._find_recent_deal_by_comment",
+            return_value=None,
+        ):
+            with pytest.raises(ConnectionError):
+                place_market_order("PETR4", "buy", 100)
+
     @patch("clear_trading_agent.mt5_api.requests.get")
     def test_is_bridge_healthy(self, mock_get: MagicMock) -> None:
         """is_bridge_healthy retorna True quando bridge responde."""

--- a/tests/test_kucoin_api.py
+++ b/tests/test_kucoin_api.py
@@ -625,6 +625,89 @@ class TestSignedRequestTimestampRecovery:
         assert "Invalid KC-API-TIMESTAMP" in message
 
 
+# ============ TESTES: dedup de clientOid ao reenviar ordem ============
+
+class TestPlaceMarketOrderClientOidStability:
+    """Regressão: place_market_order não pode gerar um clientOid novo a
+    cada retry. Antes desse fix, place_market_order era decorada com
+    @retry_on_failure, que re-executa a função inteira (inclusive a linha
+    que gera client_oid) — uma falha de rede DEPOIS da KuCoin aceitar a
+    ordem, mas ANTES da resposta HTTP chegar, causava reenvio com um
+    clientOid diferente e uma ordem de dinheiro real duplicada."""
+
+    def test_reusa_o_mesmo_client_oid_entre_tentativas(self) -> None:
+        """O clientOid enviado deve ser idêntico em todas as tentativas."""
+        timeout_error = TimeoutError("connection reset")
+
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            "code": "200000",
+            "data": {"orderId": "order-999"},
+        }
+
+        with (
+            patch("kucoin_api.rate_limit"),
+            patch(
+                "kucoin_api.requests.request",
+                side_effect=[timeout_error, success],
+            ) as mock_request,
+            patch("kucoin_api.get_order_by_client_oid", return_value=None) as mock_lookup,
+            patch("kucoin_api._send_telegram_alert"),
+        ):
+            result = kucoin_api.place_market_order("BTC-USDT", "sell", size=0.001)
+
+        assert result["success"] is True
+        assert result["orderId"] == "order-999"
+        assert mock_request.call_count == 2
+        bodies = [call.kwargs["data"] for call in mock_request.call_args_list]
+        assert bodies[0] == bodies[1], "clientOid mudou entre tentativas"
+        mock_lookup.assert_called_once()
+
+    def test_nao_duplica_ordem_se_a_anterior_ja_foi_aceita(self) -> None:
+        """Se a 1ª tentativa falhar por exceção de rede mas a ordem já
+        tiver sido criada na KuCoin, a 2ª tentativa deve reaproveitar a
+        ordem existente (via clientOid) em vez de enviar um novo POST."""
+        timeout_error = TimeoutError("connection reset")
+        existing_order = {"id": "order-existing-1", "clientOid": "whatever"}
+
+        with (
+            patch("kucoin_api.rate_limit"),
+            patch(
+                "kucoin_api.requests.request",
+                side_effect=[timeout_error],
+            ) as mock_request,
+            patch("kucoin_api.get_order_by_client_oid", return_value=existing_order) as mock_lookup,
+            patch("kucoin_api._send_telegram_alert"),
+        ):
+            result = kucoin_api.place_market_order("BTC-USDT", "sell", size=0.001)
+
+        assert result["success"] is True
+        assert result["orderId"] == "order-existing-1"
+        # Só a 1ª tentativa chegou a bater na rede — a 2ª foi resolvida via lookup
+        assert mock_request.call_count == 1
+        mock_lookup.assert_called_once()
+
+    def test_relanca_erro_se_nao_houver_ordem_e_tentativas_se_esgotarem(self) -> None:
+        """Se todas as tentativas falharem por exceção E o lookup por
+        clientOid não encontrar nada, o erro original deve propagar (não
+        deve ser engolido silenciosamente)."""
+        conn_error = ConnectionError("network unreachable")
+
+        with (
+            patch("kucoin_api.rate_limit"),
+            patch("kucoin_api.time.sleep"),
+            patch(
+                "kucoin_api.requests.request",
+                side_effect=[conn_error, conn_error, conn_error],
+            ),
+            patch("kucoin_api.get_order_by_client_oid", return_value=None),
+            patch("kucoin_api._send_telegram_alert"),
+        ):
+            with pytest.raises(ConnectionError):
+                kucoin_api.place_market_order("BTC-USDT", "sell", size=0.001)
+
+
 # ================ TESTES: Withdrawal / Deposit / Fees ================
 
 class TestGetWithdrawalQuotas:

--- a/tests/test_main_transfer_and_dynamic_positions.py
+++ b/tests/test_main_transfer_and_dynamic_positions.py
@@ -29,6 +29,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
         _resolve_telegram_bot_token=lambda: "",
         _resolve_telegram_chat_id=lambda: "",
+        _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_multi_entry_sell_behavior.py
+++ b/tests/test_multi_entry_sell_behavior.py
@@ -32,6 +32,7 @@ sys.modules.setdefault(
         _has_keys=lambda: False,
         _resolve_telegram_bot_token=lambda: "",
         _resolve_telegram_chat_id=lambda: "",
+        _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_ollama_startup_jitter.py
+++ b/tests/test_ollama_startup_jitter.py
@@ -54,6 +54,7 @@ for _mod in (
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
         FastTradingModel=lambda *a, **kw: types.SimpleNamespace(save=lambda: None, load=lambda: None),
         MarketState=object,
         Signal=object,

--- a/tests/test_profile_trade_guards.py
+++ b/tests/test_profile_trade_guards.py
@@ -29,6 +29,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_rebuy_lock_enforcement.py
+++ b/tests/test_rebuy_lock_enforcement.py
@@ -30,6 +30,7 @@ sys.modules.setdefault("kucoin_api", types.SimpleNamespace(
     get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
 ))
 sys.modules.setdefault("fast_model", types.SimpleNamespace(
     FastTradingModel=object, MarketState=object, Signal=object))
@@ -368,3 +369,38 @@ def test_block_context_reports_phase_and_ceiling():
     assert ctx["rebuy_max_price"] > 70000.0            # teto decaído acima do last_sell
     assert ctx["rebuy_envelope_ceiling"] >= ctx["rebuy_max_price"]
     assert 5.5 < ctx["rebuy_elapsed_hours"] < 6.5
+
+
+# ── Achado #4 (revisão 2026-08-01): fail-closed em erro de avaliação ────────
+
+def test_rebuy_envelope_evaluation_error_fails_closed_when_sell_registered():
+    """Config malformada (não numérica) faz _resolve_rebuy_envelope lançar
+    ValueError. Antes do fix, um `except Exception: pass` no call site
+    deixava a compra passar silenciosamente — violando a garantia do
+    próprio docstring de que o freio é "SEMPRE ativo" enquanto houver
+    venda registrada. Preço abaixo do last_sell (que normalmente SERIA
+    liberado pela lógica correta do envelope) prova que o bloqueio aqui é
+    por segurança/fail-closed, não pela regra normal de preço."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=70000.0,
+        rebuy_envelope={"grace_hours": "not_a_number"},
+    )
+    sig = SimpleNamespace(action="BUY", price=69000.0, confidence=0.9, reason="unit")
+    result = agent._check_can_trade(sig)
+    assert result is False
+    assert agent.state.last_trade_block_reason == "buy_rebuy_lock_evaluation_error"
+
+
+def test_rebuy_envelope_evaluation_error_does_not_block_fresh_buy_without_sell_history():
+    """Sem venda registrada (last_sell_entry_price=0), _resolve_rebuy_envelope
+    retorna cedo (antes de tocar a config) e nunca lança — então mesmo com
+    config malformada, um BUY fresco continua livre. O fail-closed só se
+    aplica quando existe um lock que de fato deveria estar protegendo algo."""
+    agent = _make_agent(
+        position=0.0,
+        last_sell_entry_price=0.0,
+        rebuy_envelope={"grace_hours": "not_a_number"},
+    )
+    sig = SimpleNamespace(action="BUY", price=69000.0, confidence=0.9, reason="unit")
+    assert agent._check_can_trade(sig) is True

--- a/tests/test_runtime_safety_guards.py
+++ b/tests/test_runtime_safety_guards.py
@@ -35,6 +35,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/test_track_record_agent_integration.py
+++ b/tests/test_track_record_agent_integration.py
@@ -41,6 +41,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
         _resolve_telegram_bot_token=lambda: "",
         _resolve_telegram_chat_id=lambda: "",
+        _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 

--- a/tests/test_trade_metadata_targets.py
+++ b/tests/test_trade_metadata_targets.py
@@ -56,6 +56,7 @@ sys.modules.setdefault(
         get_fills_for_order=lambda *a, **kw: {},
     _resolve_telegram_bot_token=lambda: "",
     _resolve_telegram_chat_id=lambda: "",
+    _send_telegram_alert=lambda *a, **kw: None,
     ),
 )
 sys.modules.setdefault(

--- a/tests/unit/test_position_manager_mixin.py
+++ b/tests/unit/test_position_manager_mixin.py
@@ -11,6 +11,8 @@ import pytest
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent.parent / "btc_trading_agent"))
 
+import kucoin_api
+import position_manager_mixin
 from position_manager_mixin import PositionManagerMixin
 
 _FEE = 0.001
@@ -599,3 +601,112 @@ class TestMixinInheritance:
 
         for method in expected_methods:
             assert method in all_mixin_attrs, f"Método ausente nos mixins: {method}"
+
+
+# ── _reconcile_position_with_exchange ──────────────────────────────────────
+
+class TestReconcilePositionWithExchange:
+    """Cobre os 3 achados da revisão 2026-08-01:
+
+    1. Direção reversa (exchange > DB) não pode criar entries sintéticas
+       (risco de atribuir saldo de outro profile) — deve só alertar.
+    2. TOCTOU: os números usados para decidir QUAIS/QUANTOS slots fechar
+       devem vir de uma leitura de `entries` feita já dentro do lock, não
+       da leitura pré-lock (que pode estar obsoleta se outro trade mutou
+       `self.state.entries` entre a checagem inicial e a aquisição do lock).
+    3. (Comportamento pré-existente, preservado) fecha do slot mais
+       recente para o mais antigo até eliminar o excesso.
+    """
+
+    def test_dry_run_returns_zero_without_querying_exchange(self):
+        agent = _make_agent(entries=[_entry(90_000, 0.001)], dry_run=True)
+        with patch.object(kucoin_api, "get_balance") as mock_balance:
+            result = agent._reconcile_position_with_exchange()
+        assert result == 0
+        mock_balance.assert_not_called()
+
+    def test_no_entries_returns_zero(self):
+        agent = _make_agent(entries=[], dry_run=False)
+        with patch.object(kucoin_api, "get_balance") as mock_balance:
+            result = agent._reconcile_position_with_exchange()
+        assert result == 0
+        mock_balance.assert_not_called()
+
+    def test_consistent_within_tolerance_returns_zero_no_alert(self):
+        entries = [_entry(90_000, 0.001), _entry(89_000, 0.001)]
+        agent = _make_agent(entries=entries, dry_run=False)
+        with (
+            patch.object(kucoin_api, "get_balance", return_value=0.002),
+            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
+        ):
+            result = agent._reconcile_position_with_exchange()
+        assert result == 0
+        assert len(agent.state.entries) == 2
+        mock_alert.assert_not_called()
+
+    def test_exchange_greater_than_db_alerts_and_does_not_mutate_entries(self):
+        """Achado #2: exchange com MAIS moeda do que o DB só alerta — nunca
+        cria uma entry sintética automaticamente."""
+        entries = [_entry(90_000, 0.001)]
+        agent = _make_agent(entries=entries, dry_run=False)
+        with (
+            patch.object(kucoin_api, "get_balance", return_value=0.010),
+            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
+        ):
+            result = agent._reconcile_position_with_exchange()
+        assert result == 0
+        assert len(agent.state.entries) == 1  # nada mudou no state
+        mock_alert.assert_called_once()
+        message = mock_alert.call_args.args[0]
+        assert "mais" in message.lower()
+        assert "BTC" in message
+
+    def test_db_greater_than_exchange_closes_most_recent_slots_first(self):
+        entries = [
+            _entry(88_000, 0.001),  # mais antigo — deve sobreviver
+            _entry(90_000, 0.001),  # mais recente — deve ser fechado
+        ]
+        agent = _make_agent(entries=entries, dry_run=False)
+        with (
+            patch.object(kucoin_api, "get_balance", return_value=0.001),
+            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
+        ):
+            result = agent._reconcile_position_with_exchange(current_price=90_000.0)
+        assert result == 1
+        assert len(agent.state.entries) == 1
+        assert agent.state.entries[0]["price"] == 88_000
+        mock_alert.assert_not_called()
+
+    def test_toctou_uses_fresh_entries_read_inside_lock_not_stale_prelock_snapshot(self):
+        """Regressão do achado #3: simula um trade concorrente que remove
+        um entry (via efeito colateral no get_price, chamado ENTRE a
+        checagem pré-lock e a aquisição do lock) tornando a posição já
+        consistente. Se o código (incorretamente) confiasse nos números
+        pré-lock, fecharia o entry restante (fantasma calculado com dados
+        obsoletos); com o fix, a releitura dentro do lock detecta que já
+        está tudo consistente e não fecha nada."""
+        entry_a = _entry(88_000, 0.001)
+        entry_b = _entry(90_000, 0.001)
+        agent = _make_agent(entries=[entry_a, entry_b], dry_run=False)
+        # real_balance fixo em 0.001: no snapshot pré-lock (2 entries =
+        # 0.002 db_position) isso pareceria phantom=0.001 (1 entry sobra).
+        # Mas um "trade concorrente" remove entry_b antes do lock ser
+        # adquirido — deixando db_position real = 0.001 == real_balance.
+        def _simulate_concurrent_trade_removing_entry_b(*_a, **_kw):
+            agent.state.entries = [entry_a]
+            return 90_000.0
+
+        with (
+            patch.object(kucoin_api, "get_balance", return_value=0.001),
+            patch.object(
+                kucoin_api, "get_price",
+                side_effect=_simulate_concurrent_trade_removing_entry_b,
+            ),
+            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
+        ):
+            result = agent._reconcile_position_with_exchange()
+
+        assert result == 0, "TOCTOU: fechou um slot usando phantom_btc obsoleto (pré-lock)"
+        assert len(agent.state.entries) == 1
+        assert agent.state.entries[0] is entry_a
+        mock_alert.assert_not_called()


### PR DESCRIPTION
## Summary
Aplica as 4 correções da revisão de código do sistema de trading (2026-08-01), em ordem de severidade:

1. **Crítico — ordem duplicada em retry** (`kucoin_api.py` / `mt5_api.py`): `place_market_order` gerava um novo idempotency token (`clientOid` na KuCoin, comment tag na Clear/MT5) a cada tentativa de retry. Uma falha de rede DEPOIS da exchange aceitar a ordem mas ANTES da resposta HTTP chegar causava reenvio com token diferente → ordem real duplicada. Agora o token é gerado uma única vez e reaproveitado entre tentativas; antes de reenviar, checa se a ordem/deal já existe (novo helper `get_order_by_client_oid` na KuCoin; busca por comment tag no histórico de deals na Clear, já que MT5 não tem um idempotency token nativo).
2. **Reconciliação — direção reversa não tratada** (`position_manager_mixin.py`): `_reconcile_position_with_exchange` só tratava DB > exchange (fecha slots fantasma). O caso oposto (exchange > DB) não gerava nenhuma ação nem alerta. Não criamos entry sintética automática — risco de atribuir saldo de outro profile na mesma subconta KuCoin — mas agora dispara alerta Telegram para investigação manual.
3. **TOCTOU na mesma função**: os números usados pra decidir quais/quantos slots fechar vinham de uma leitura de `entries` pré-lock, que podia estar obsoleta se outro trade tivesse mutado `self.state.entries` entre a checagem inicial e a aquisição do lock. Agora `db_position`/`tolerance`/`phantom` são recomputados a partir de uma leitura fresca de `entries` já dentro do lock.
4. **Rebuy lock silenciosamente bypassável** (`trading_agent.py`): o envelope de recompra documenta ser "SEMPRE ativo" enquanto houver venda registrada, mas o call site tinha um `except Exception: pass` que deixava a compra passar silenciosamente se a avaliação do envelope lançasse (ex.: config com valor não numérico). Agora, com venda registrada, um erro de avaliação bloqueia a compra por segurança (fail-closed) em vez de ignorar o lock.

## Test plan
- [x] `tests/test_kucoin_api.py` (61 testes, incl. 3 novos de dedup de clientOid)
- [x] `tests/test_clear_trading.py` (76 testes, incl. 3 novos de dedup de comment tag)
- [x] `tests/test_clear_failure_scenarios.py` (39 testes)
- [x] `tests/unit/test_position_manager_mixin.py` (50 testes, incl. 6 novos de reconciliação bidirecional + TOCTOU)
- [x] `tests/test_rebuy_lock_enforcement.py` (22 testes, incl. 2 novos de fail-closed)
- [x] 12 arquivos de teste que stubavam `kucoin_api` via `sys.modules` precisaram do atributo `_send_telegram_alert` adicionado ao stub (novo import em `position_manager_mixin.py`) — todos verificados passando individualmente
- [x] Auditados (não regredidos) todos os call sites de `place_market_order` fora do módulo (`hop_executor.py`, `clear_trading_agent/trading_agent.py`, `tools/trading_agent_mega_patch.py`, `tools/trading_guardrails_control.py`) — assinatura preservada
- Nota: `test_runtime_safety_guards.py::test_detect_external_deposits_*` e `test_btc_cenario3_integration.py` têm um hang pré-existente (confirmado reproduzindo em worktree limpo do HEAD, antes de qualquer mudança deste PR) — não relacionado a essas correções, fora de escopo aqui

🤖 Generated with [Claude Code](https://claude.com/claude-code)