### PR TITLE
fix(trading): target_sell_price truncado a 2 casas escondia alvo real em ativos sub-$1

### DIFF
--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -1048,7 +1048,7 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                 ('btc_trading_open_position_count', 'open_position_count', 'Number of open BUY entries (multi-position)', 'gauge', '{v}'),
                 ('btc_trading_open_position_raw_entries', 'open_position_raw_entries', 'Number of raw BUY entries in the open position', 'gauge', '{v}'),
                 ('btc_trading_open_position_logical_slots', 'open_position_logical_slots', 'Logical slot occupancy for the open position', 'gauge', '{v}'),
-                ('btc_trading_avg_entry_price', 'avg_entry_price', 'Weighted avg entry price of open position', 'gauge', '{v:.2f}'),
+                ('btc_trading_avg_entry_price', 'avg_entry_price', 'Weighted avg entry price of open position', 'gauge', '{v:.8f}'),
             ]
 
             track_record_metrics = [
@@ -1326,9 +1326,9 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                         tw_age = max(time.time() - tw_ts, 0.0) if tw_ts > 0 else 0.0
                         tw_fresh = 1 if tw_valid_until > time.time() else 0
                         window_metrics = [
-                            ("btc_trade_window_entry_low", "Fresh AI trade window lower entry bound", tw.get("entry_low", 0), "{v:.2f}"),
-                            ("btc_trade_window_entry_high", "Fresh AI trade window upper entry bound", tw.get("entry_high", 0), "{v:.2f}"),
-                            ("btc_trade_window_target_sell", "Fresh AI trade window target sell", tw.get("target_sell", 0), "{v:.2f}"),
+                            ("btc_trade_window_entry_low", "Fresh AI trade window lower entry bound", tw.get("entry_low", 0), "{v:.8f}"),
+                            ("btc_trade_window_entry_high", "Fresh AI trade window upper entry bound", tw.get("entry_high", 0), "{v:.8f}"),
+                            ("btc_trade_window_target_sell", "Fresh AI trade window target sell", tw.get("target_sell", 0), "{v:.8f}"),
                             ("btc_trade_window_min_confidence", "Fresh AI trade window minimum confidence", tw.get("min_confidence", 0), "{v:.4f}"),
                             ("btc_trade_window_min_trade_interval", "Fresh AI trade window minimum trade interval (s)", tw.get("min_trade_interval", 0), "{v}"),
                             ("btc_trade_window_ttl_seconds", "Fresh AI trade window TTL in seconds", tw.get("ttl_seconds", 0), "{v}"),

--- a/btc_trading_agent/sell_target_mixin.py
+++ b/btc_trading_agent/sell_target_mixin.py
@@ -146,9 +146,13 @@ class SellTargetMixin:
         if self.state.target_sell_price <= 0:
             return {}
 
+        # 8 casas (não 2): round(x, 2) trunca qualquer preço sub-$1 (DOGE, XRP,
+        # ADA...) em degraus de 1 centavo — para um ativo de $0.07, isso é ~14%
+        # do preço e faz o target arredondar para BAIXO da entrada mesmo quando
+        # o valor calculado (entry × (1+ai_tp)) está corretamente acima dela.
         metadata: Dict[str, Any] = {
-            "target_sell_price": round(float(self.state.target_sell_price), 2),
-            "target_sell_trigger_price": round(float(self.state.target_sell_price), 2),
+            "target_sell_price": round(float(self.state.target_sell_price), 8),
+            "target_sell_trigger_price": round(float(self.state.target_sell_price), 8),
         }
         if self.state.target_sell_reason:
             metadata["target_sell_reason"] = self.state.target_sell_reason

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T17:11:25.982998+00:00",
+  "generated_at": "2026-08-01T18:13:57.138986+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T17:11:25.982998+00:00`
+- Generated at: `2026-08-01T18:13:57.138986+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -285,3 +285,30 @@ class TestSharedTrainingDatabase:
             "send_metrics não pode construir TrainingDatabase por scrape "
             "(cada construção abre um ThreadedConnectionPool que nunca é fechado)"
         )
+
+
+class TestSubDollarPricePrecision:
+    """Regressão do achado real de produção (2026-08-01, DOGE-USDT shadow
+    slot #3817): métricas de preço formatadas com '{v:.2f}' truncam
+    qualquer ativo sub-$1 (DOGE, XRP, ADA...) em degraus de 1 centavo —
+    ~14% do preço de um ativo de $0.07 — fazendo um target_sell calculado
+    corretamente acima da entrada aparecer como se estivesse abaixo dela
+    no dashboard/Prometheus. Preço precisa de 8 casas, como já usado em
+    btc_trading_open_position_btc."""
+
+    def test_price_scale_metrics_use_eight_decimal_precision(self, pe_module):
+        import inspect
+        source = inspect.getsource(pe_module)
+        for metric_name in (
+            "btc_trading_avg_entry_price",
+            "btc_trade_window_entry_low",
+            "btc_trade_window_entry_high",
+            "btc_trade_window_target_sell",
+        ):
+            idx = source.index(f"'{metric_name}'") if f"'{metric_name}'" in source else source.index(f'"{metric_name}"')
+            snippet = source[idx:idx + 200]
+            assert "{v:.2f}" not in snippet.split("\n")[0], (
+                f"{metric_name} não pode usar precisão de 2 casas — "
+                "trunca preços sub-$1 até parecerem abaixo da entrada"
+            )
+            assert "{v:.8f}" in snippet, f"{metric_name} deve usar {{v:.8f}}"

--- a/tests/unit/test_sell_target_mixin.py
+++ b/tests/unit/test_sell_target_mixin.py
@@ -227,6 +227,22 @@ class TestSerializeTargetSellMetadata:
         meta = agent._serialize_target_sell_metadata()
         assert "target_sell_reason" not in meta
 
+    def test_preserves_precision_for_sub_dollar_assets(self):
+        """Regressão do achado real de produção (2026-08-01, DOGE-USDT shadow
+        slot #3817): round(x, 2) trunca preços sub-$1 em degraus de 1 centavo
+        — pra um ativo de ~$0.07, isso é ~14% do preço e faz um alvo
+        calculado corretamente ACIMA da entrada (entry=0.07209, alvo
+        calculado=0.07389) ser persistido como 0.07, que parece ABAIXO da
+        entrada. round(x, 8) preserva a precisão real."""
+        entry = 0.07209
+        target = entry * 1.025  # ai_tp=2.5%, corretamente acima da entrada
+        agent = _make_agent(target_sell_price=target, target_sell_reason="ranging")
+        meta = agent._serialize_target_sell_metadata()
+        assert meta["target_sell_price"] == pytest.approx(target, abs=1e-6)
+        assert meta["target_sell_price"] > entry, (
+            "alvo persistido não pode parecer abaixo da entrada por arredondamento"
+        )
+
 
 # ── _build_trade_metadata ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Investigando por que a posição DOGE-USDT shadow #3817 (entrada $0.07209) "passava do alvo várias vezes e nunca vendia", encontrei que `_serialize_target_sell_metadata()` e 4 métricas Prometheus (`btc_trading_avg_entry_price`, `btc_trade_window_entry_low/_high/_target_sell`) arredondavam preço para **2 casas decimais** — correto para BTC (~$100k), mas para um ativo de ~$0.07 isso é ~14% do preço.

O alvo real calculado (`entry × (1 + ai_tp)` = 0.07209 × 1.025 ≈ **$0.0739**, corretamente ACIMA da entrada) era persistido/exposto como **$0.07** — que parece ABAIXO da entrada — fazendo o alvo parecer atingido repetidamente ao longo do dia quando na verdade nunca tinha sido.

**Fix**: 8 casas decimais (mesmo padrão já usado em `btc_trading_open_position_btc`), preservando a precisão real tanto para BTC quanto para ativos sub-$1 (DOGE, XRP, ADA).

**Nota importante**: a causa de a posição não ter vendido de fato *não é* essa truncagem — é o guardrail `guardrails_positive_only_sells` vetando a própria decisão de SELL da IA enquanto a posição estiver no vermelho (net -3.36% a -4.01% ao longo do dia hoje). Esse comportamento é mantido como está por decisão explícita — não alterado neste PR.

## Test plan
- [x] `tests/unit/test_sell_target_mixin.py` (19 testes, incl. 1 novo cobrindo o caso real do DOGE)
- [x] `tests/test_prometheus_exporter.py` (12 testes, incl. 1 novo verificando as 4 métricas de preço usam 8 casas)
- [x] `tests/test_grafana_dashboard_queries.py` (referência de nome de métrica, não afetada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)