### PR TITLE
fix(trading): regime_adjustments e trade_window compartilhados entre símbolos do mesmo profile

### DIFF
--- a/btc_trading_agent/market_rag.py
+++ b/btc_trading_agent/market_rag.py
@@ -1358,7 +1358,13 @@ class MarketRAG:
         self.recalibrate_interval = recalibrate_interval
         self.snapshot_interval = snapshot_interval
         suffix = "" if self.profile == "default" else f"_{self.profile}"
-        self.adjustments_file = RAG_DIR / f"regime_adjustments{suffix}.json"
+        # Per-symbol (não só per-profile): regime_adjustments_{profile}.json
+        # legado era compartilhado por todos os símbolos que dividem o mesmo
+        # profile (BTC/ETH/SOL/DOGE em "shadow" gravavam no mesmo arquivo),
+        # contaminando regime/target de um símbolo com o de outro — mesma
+        # classe de bug do index.pkl legado corrigida abaixo em 2026-07-13,
+        # mas que nunca tinha sido aplicada aqui.
+        self.adjustments_file = RAG_DIR / f"regime_adjustments_{self.symbol}{suffix}.json"
         # Índice per-symbol: o index.pkl legado era compartilhado por todos os
         # agentes (BTC/ETH/SOL/...), contaminando os cálculos de buy target
         # com preços de outros símbolos.

--- a/btc_trading_agent/prometheus_exporter.py
+++ b/btc_trading_agent/prometheus_exporter.py
@@ -1251,8 +1251,20 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
             # ═══════════════ MARKET RAG (AI Output) ═══════════════
             try:
                 rag_dir = BASE_DIR / "data" / "market_rag"
-                profile_file = rag_dir / f"regime_adjustments_{_profile}.json"
-                rag_file = profile_file if profile_file.exists() else rag_dir / "regime_adjustments.json"
+                # Per-symbol (não só per-profile): regime_adjustments_{profile}.json
+                # sozinho é compartilhado por todos os símbolos que dividem o mesmo
+                # profile (BTC/ETH/SOL/DOGE em "shadow" liam o mesmo arquivo),
+                # contaminando o regime exibido de um símbolo com o de outro. Sufixo
+                # espelha exatamente MarketRAG.__init__ (market_rag.py).
+                _profile_suffix = "" if _profile == "default" else f"_{_profile}"
+                symbol_profile_file = rag_dir / f"regime_adjustments_{_sym}{_profile_suffix}.json"
+                profile_file = rag_dir / f"regime_adjustments{_profile_suffix}.json"
+                if symbol_profile_file.exists():
+                    rag_file = symbol_profile_file
+                elif profile_file.exists():
+                    rag_file = profile_file
+                else:
+                    rag_file = rag_dir / "regime_adjustments.json"
                 if rag_file.exists():
                     with open(rag_file) as _rf:
                         rag_data = json.load(_rf)
@@ -1315,8 +1327,19 @@ body {{ font-family: -apple-system, sans-serif; background: #1a1a2e; color: #eee
                     output.append(f'btc_rag_ollama_mode_info{{mode="{ollama_mode}",{_cl}}} 1')
                     output.append("")
 
+                    # Per-symbol (não só per-profile): trade_window_{profile}.json
+                    # sozinho é compartilhado por todos os símbolos que dividem o
+                    # mesmo profile — mesma contaminação do regime_adjustments
+                    # acima. Sufixo espelha exatamente
+                    # BitcoinTradingAgent._get_trade_window_file (trading_agent.py).
                     suffix = "" if _profile == "default" else f"_{_profile}"
-                    trade_window_file = rag_dir / f"trade_window{suffix}.json"
+                    symbol_trade_window_file = rag_dir / f"trade_window_{_sym}{suffix}.json"
+                    legacy_trade_window_file = rag_dir / f"trade_window{suffix}.json"
+                    trade_window_file = (
+                        symbol_trade_window_file
+                        if symbol_trade_window_file.exists()
+                        else legacy_trade_window_file
+                    )
                     if trade_window_file.exists():
                         with open(trade_window_file) as _twf:
                             trade_window_data = json.load(_twf)

--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -1130,12 +1130,20 @@ class BitcoinTradingAgent(
         }
 
     def _get_trade_window_file(self) -> Path:
-        """Arquivo local do cache quente da janela operacional."""
+        """Arquivo local do cache quente da janela operacional.
+
+        Per-symbol (não só per-profile): trade_window_{profile}.json sozinho
+        era compartilhado por todos os símbolos que dividem o mesmo profile
+        (BTC/ETH/SOL/DOGE em "shadow" gravavam no mesmo arquivo),
+        contaminando a janela de um símbolo com a de outro — mesma classe de
+        bug do index.pkl legado corrigida em 2026-07-13 para o Market RAG,
+        que nunca tinha sido aplicada aqui.
+        """
         trade_dir = Path(__file__).parent / "data" / "market_rag"
         trade_dir.mkdir(parents=True, exist_ok=True)
         profile = self._current_profile()
         suffix = "" if profile == "default" else f"_{profile}"
-        return trade_dir / f"trade_window{suffix}.json"
+        return trade_dir / f"trade_window_{self.symbol}{suffix}.json"
 
     def _has_min_structured_ollama_evidence(self, rag_adj, rag_stats: Dict[str, Any]) -> tuple[bool, str]:
         """Valida evidência mínima para aceitar análises estruturadas do Ollama.

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T18:13:57.138986+00:00",
+  "generated_at": "2026-08-01T19:03:04.430893+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T18:13:57.138986+00:00`
+- Generated at: `2026-08-01T19:03:04.430893+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/tests/test_ai_trade_window.py
+++ b/tests/test_ai_trade_window.py
@@ -226,6 +226,28 @@ def test_parse_ai_trade_controls_min_sell_pnl_fallback_when_missing() -> None:
     assert 0.002 <= suggestion.min_sell_pnl_pct <= 0.010
 
 
+def test_get_trade_window_file_is_scoped_by_symbol_and_profile() -> None:
+    """Regressão (2026-08-01): trade_window_{profile}.json sozinho era
+    compartilhado por todos os símbolos que dividem o mesmo profile
+    (BTC/ETH/SOL/DOGE em "shadow" gravavam/liam o mesmo arquivo),
+    contaminando a janela operacional de um símbolo com a de outro — mesma
+    classe de bug do index.pkl legado, corrigida em 2026-07-13 só pro
+    Market RAG. O nome do arquivo precisa incluir o symbol."""
+    btc_agent = _agent("shadow")
+    btc_agent.symbol = "BTC-USDT"
+    doge_agent = _agent("shadow")
+    doge_agent.symbol = "DOGE-USDT"
+
+    btc_file = btc_agent._get_trade_window_file()
+    doge_file = doge_agent._get_trade_window_file()
+
+    assert btc_file != doge_file, "BTC e DOGE no mesmo profile não podem compartilhar arquivo"
+    assert "BTC-USDT" in btc_file.name
+    assert "DOGE-USDT" in doge_file.name
+    assert "shadow" in btc_file.name
+    assert "shadow" in doge_file.name
+
+
 def test_get_fresh_ai_trade_window_returns_none_when_stale(tmp_path: Path) -> None:
     agent = _agent("conservative")
     window_file = tmp_path / "trade_window_conservative.json"

--- a/tests/test_market_rag_symbol_isolation.py
+++ b/tests/test_market_rag_symbol_isolation.py
@@ -147,6 +147,24 @@ def test_marketrag_migrates_legacy_shared_index(tmp_path, monkeypatch):
     assert reloaded.size == 18
 
 
+def test_marketrag_adjustments_file_scoped_by_symbol_and_profile(tmp_path, monkeypatch):
+    """Regressão (2026-08-01): regime_adjustments_{profile}.json sozinho era
+    compartilhado por todos os símbolos que dividem o mesmo profile (BTC/
+    ETH/SOL/DOGE em "shadow" gravavam/liam o mesmo arquivo), contaminando o
+    regime/target de um símbolo com o de outro — mesma classe de bug do
+    index.pkl legado (corrigido acima em 2026-07-13), mas nunca aplicada ao
+    arquivo irmão adjustments_file até agora."""
+    monkeypatch.setattr(market_rag, "RAG_DIR", tmp_path)
+    monkeypatch.setattr(market_rag, "INDEX_FILE", tmp_path / "index.pkl")
+
+    btc_rag = MarketRAG(symbol="BTC-USDT", profile="shadow")
+    doge_rag = MarketRAG(symbol="DOGE-USDT", profile="shadow")
+
+    assert btc_rag.adjustments_file != doge_rag.adjustments_file
+    assert btc_rag.adjustments_file == tmp_path / "regime_adjustments_BTC-USDT_shadow.json"
+    assert doge_rag.adjustments_file == tmp_path / "regime_adjustments_DOGE-USDT_shadow.json"
+
+
 def test_marketrag_prefers_per_symbol_index(tmp_path, monkeypatch):
     monkeypatch.setattr(market_rag, "RAG_DIR", tmp_path)
     monkeypatch.setattr(market_rag, "INDEX_FILE", tmp_path / "index.pkl")

--- a/tests/test_ollama_trade_controls.py
+++ b/tests/test_ollama_trade_controls.py
@@ -51,7 +51,10 @@ def rag(monkeypatch):
 
 
 def test_profile_uses_isolated_adjustments_file(rag):
-    assert rag.adjustments_file.name == "regime_adjustments_aggressive.json"
+    """Scoped por symbol+profile (2026-08-01) — regime_adjustments_aggressive.json
+    sozinho era compartilhado por todos os símbolos no profile "aggressive"
+    (BTC/ETH/SOL/DOGE), contaminando regime/target entre eles."""
+    assert rag.adjustments_file.name == "regime_adjustments_BTC-USDT_aggressive.json"
 
 
 def test_shadow_mode_preserves_baseline(rag):

--- a/tests/test_prometheus_exporter.py
+++ b/tests/test_prometheus_exporter.py
@@ -312,3 +312,30 @@ class TestSubDollarPricePrecision:
                 "trunca preços sub-$1 até parecerem abaixo da entrada"
             )
             assert "{v:.8f}" in snippet, f"{metric_name} deve usar {{v:.8f}}"
+
+
+class TestMarketRagFileSymbolScoping:
+    """Regressão do achado real de produção (2026-08-01): regime_adjustments
+    e trade_window eram lidos por um caminho scoped só por profile
+    (shadow/aggressive/conservative), compartilhado por todos os símbolos
+    que dividem o mesmo profile (BTC/ETH/SOL/DOGE em "shadow" liam o mesmo
+    arquivo) — o exporter da DOGE-USDT shadow chegou a expor
+    target_sell=63015 (preço de BTC). Mesma classe de bug do index.pkl
+    legado, nunca corrigida nos arquivos irmãos até agora."""
+
+    def test_send_metrics_reads_symbol_scoped_regime_adjustments_first(self, pe_module):
+        import inspect
+        source = inspect.getsource(pe_module.PrometheusHandler.send_metrics)
+        assert 'f"regime_adjustments_{_sym}{_profile_suffix}.json"' in source or \
+            "regime_adjustments_{_sym}" in source, (
+                "send_metrics precisa preferir o arquivo scoped por symbol+profile "
+                "antes do fallback só-por-profile"
+            )
+
+    def test_send_metrics_reads_symbol_scoped_trade_window_first(self, pe_module):
+        import inspect
+        source = inspect.getsource(pe_module.PrometheusHandler.send_metrics)
+        assert "trade_window_{_sym}" in source, (
+            "send_metrics precisa preferir o trade_window scoped por symbol+profile "
+            "antes do fallback só-por-profile"
+        )


### PR DESCRIPTION
## Summary
Investigando a posição DOGE-USDT shadow #3817, notei que o exporter chegou a expor `target_sell=63015` — um preço de escala BTC, não DOGE. Rastreado até:

- `market_rag.py:1361` — `self.adjustments_file` escopado só por profile (`regime_adjustments_{profile}.json`), não por symbol.
- `trading_agent.py:1138` — `_get_trade_window_file()` mesmo padrão (`trade_window_{profile}.json`).

Isso significa que **BTC_USDT_shadow, ETH_USDT_shadow, SOL_USDT_shadow e DOGE_USDT_shadow todos leem e gravam o mesmo arquivo** — sempre que a frota é reiniciada, os processos correm pra gravar por último e todos os outros ficam lendo regime/target de outro símbolo. No host dá pra ver a evidência direta: arquivos corretamente scoped por símbolo (`trade_window_DOGE-USDT_shadow.json`) intocados desde 18/07, ao lado de arquivos só-por-profile (`trade_window_shadow.json`) regravados hoje às 15:44-15:45 — exatamente quando reiniciei a frota.

É a mesma classe de bug do `index.pkl` legado, corrigido em 2026-07-13 (`project_market_rag_shared_index_contamination_20260713`) — mas aquele fix só cobriu `index_file`; os arquivos irmãos `adjustments_file` (duas linhas abaixo, no mesmo `__init__`) e `trade_window` nunca receberam o mesmo tratamento.

## Fix
- `market_rag.py`: `adjustments_file` agora `regime_adjustments_{symbol}{profile_suffix}.json`.
- `trading_agent.py`: `_get_trade_window_file()` agora `trade_window_{symbol}{profile_suffix}.json`.
- `prometheus_exporter.py`: lê o arquivo scoped por symbol primeiro, com fallback pro legado só-por-profile (nunca mais escrito após esse fix, mas ainda presente no disco).

Esses nomes restauram exatamente o padrão que os arquivos legados de 18/07 já usavam — sugerindo que isso foi uma regressão introduzida depois daquela data, não um design original.

## Test plan
- [x] `tests/test_market_rag_symbol_isolation.py` (10 testes, incl. 1 novo confirmando `adjustments_file` scoped por symbol+profile)
- [x] `tests/test_ai_trade_window.py` (28 testes, incl. 1 novo confirmando `_get_trade_window_file()` scoped por symbol+profile)
- [x] `tests/test_prometheus_exporter.py` (14 testes, incl. 2 novos confirmando o exporter prefere o arquivo scoped por symbol)
- [x] `tests/test_ollama_trade_controls.py` — asserção antiga validava o nome de arquivo *sem* symbol (exatamente o comportamento incorreto); atualizada para o nome correto
- [x] Suite ampla rodada individualmente sem regressão: rebuy_lock_enforcement, buy_target_tolerance, track_record_agent_integration, ai_plan_fallback, ollama_startup_jitter, trade_metadata_targets, profile_trade_guards, buy_profitability_guard, multi_entry_sell_behavior, runtime_safety_guards, main_transfer_and_dynamic_positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)