### PR TITLE
fix(ci): resolve DATABASE_URL via Secrets Agent, destravando o deploy em main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,33 @@ jobs:
             git reset --hard origin/main
 
             echo "🔎 Resolvendo DATABASE_URL do runtime..."
-            TRADING_DATABASE_URL="$(sudo systemctl show crypto-agent@BTC_USDT_aggressive.service -p Environment --value 2>/dev/null | tr ' ' '\n' | sed -n 's/^DATABASE_URL=//p' | tail -n1)"
+            # O DSN saiu dos units em 2026-07-03 e passou a ser resolvido pelo
+            # Secrets Agent/Authentik (shared/database_url). Usamos o mesmo
+            # secrets_helper.get_database_url() que training_db.py usa, para o
+            # deploy e o runtime nunca divergirem de DSN.
+            # secrets-api.env carrega as credenciais do Secrets Agent; é 0640
+            # root:btc-trading e o usuário do deploy lê pelo grupo (sem sudo).
+            set -a
+            . /etc/crypto-agent/secrets-api.env
+            set +a
+            # "< /dev/null" é obrigatório: sem ele o python herda o stdin deste
+            # heredoc e consome o resto do script de deploy, matando-o em silêncio.
+            TRADING_DATABASE_URL="$(python3 -c "import sys; sys.path.insert(0,'btc_trading_agent'); from secrets_helper import get_database_url; print(get_database_url())" 2>/dev/null < /dev/null | tail -n1)"
+
+            # Fallbacks legados: units com Environment=DATABASE_URL e .env local.
+            # Ambos vazios hoje, mantidos para ambientes que ainda os usem.
+            if [ -z "${TRADING_DATABASE_URL}" ]; then
+              TRADING_DATABASE_URL="$(sudo systemctl show crypto-agent@BTC_USDT_aggressive.service -p Environment --value 2>/dev/null | tr ' ' '\n' | sed -n 's/^DATABASE_URL=//p' | tail -n1)"
+            fi
             if [ -z "${TRADING_DATABASE_URL}" ]; then
               TRADING_DATABASE_URL="$(grep '^DATABASE_URL=' btc_trading_agent/.env 2>/dev/null | cut -d= -f2-)"
             fi
             if [ -z "${TRADING_DATABASE_URL}" ]; then
-              echo "❌ DATABASE_URL do trading não encontrado"
+              echo "❌ DATABASE_URL do trading não encontrado (Secrets Agent + fallbacks legados)"
               exit 1
             fi
+            # Nunca ecoar o DSN: só esquema e tamanho.
+            echo "✅ DSN resolvido (${TRADING_DATABASE_URL%%://*}, ${#TRADING_DATABASE_URL} chars)"
 
             echo "🗄️ Aplicando migration do trading schema..."
             python3 scripts/migrate_trading_profile_schema.py \

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T22:28:51.582744+00:00",
+  "generated_at": "2026-08-01T22:59:48.349806+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T22:28:51.582744+00:00`
+- Generated at: `2026-08-01T22:59:48.349806+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`


### PR DESCRIPTION
## Problema

O job `Deploy no Servidor` do `ci.yml` falha em **todo push para main desde 2026-06-23**.

| Métrica | Valor |
|---|---|
| Último sucesso do `ci.yml` em main | **2026-06-22** |
| Runs analisados (2026-04-05 → 2026-08-01) | 300 |
| Sucessos desde 2026-06-23 | **0** |
| Mensagem | `❌ DATABASE_URL do trading não encontrado` |

Amostragem em 2026-06-23, 07-15 e 07-25 confirma causa idêntica.

## Causa-raiz

O DSN saiu dos units em 2026-07-03 e passou a ser resolvido pelo Secrets Agent/Authentik. Está documentado no próprio servidor, em `/etc/systemd/system/crypto-agent@.service.d/common.conf`:

```ini
# DATABASE_URL removido (2026-07-03): resolvido via Secrets Agent/Authentik
# (shared/database_url, field=url) pelo secrets_helper.get_database_url()
```

O bloco de resolução do `ci.yml` é de **2026-03-14** (`bd34f3b9`, #102), quando o DSN de fato vivia na unit, e não recebe commit desde 2026-07-01. Os dois caminhos que ele tenta estão mortos — verificado em `192.168.15.2`:

| Caminho | Resultado |
|---|---|
| `systemctl show ... -p Environment` | 20 vars, **`DATABASE_URL` = 0 ocorrências** |
| `btc_trading_agent/.env` | `No such file or directory` |
| os 3 `EnvironmentFile=` da unit | `DATABASE_URL` = 0 em **todos** |

O primeiro é estruturalmente incapaz de funcionar: `systemctl show -p Environment` só expõe diretivas `Environment=`, nunca o conteúdo de `EnvironmentFile=`.

## Impacto

O `git reset --hard origin/main` roda **antes** do ponto de falha. Há ~6 semanas o código em `/home/homelab/myClaude` é atualizado a cada push, mas o job aborta antes de:

- aplicar `scripts/migrate_trading_profile_schema.py`
- gravar o drop-in `crypto-exporter@.service.d/env.conf`
- reiniciar `shared-telegram-bot`, `shared-whatsapp-bot`, `specialized-agents`

Código no disco e serviços em execução vêm divergindo em silêncio.

## Correção

Resolver pelo mesmo `secrets_helper.get_database_url()` que `training_db.py` usa — assim deploy e runtime não podem divergir de DSN. As duas buscas antigas viram fallback.

`/etc/crypto-agent/secrets-api.env` (0640 `root:btc-trading`) traz as credenciais do Secrets Agent e o usuário do deploy o lê pelo grupo, **sem sudo**.

### Detalhe não-óbvio: `< /dev/null`

O script de deploy chega pelo **stdin do ssh** (`ssh ... << 'DEPLOY_SCRIPT'`). Sem `< /dev/null`, o `python3` herda esse stdin e **consome o resto do script**, matando o deploy em silêncio — reproduzido durante o desenvolvimento deste fix.

### Segurança

O DSN nunca é ecoado; o log mostra só esquema e tamanho (`✅ DSN resolvido (postgresql, 69 chars)`).

## Validação

Bloco executado no servidor pela **mesma mecânica do workflow** (script via stdin do ssh), pulando as etapas destrutivas:

```
🔎 Resolvendo DATABASE_URL do runtime...
✅ DSN resolvido (postgresql, 69 chars)
🔵 LINHA APOS O PYTHON EXECUTOU — script sobreviveu ao stdin
🔵 FIM
--- exit=0 ---
```

Também: `yaml.safe_load` OK e `bash -n` no script extraído do heredoc OK.

## Atenção ao mergear

Este PR **destrava um deploy represado de ~6 semanas**. No primeiro push para main após o merge, o job vai rodar até o fim pela primeira vez desde 2026-06-22: aplicar migration de schema e **reiniciar 3 serviços**. Vale conferir antes o que divergiu entre o código no disco e os serviços em execução.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
