### PR TITLE
feat(secrets): get_telegram_bot_token() + migra consumidores env-only

### DIFF
--- a/.opencode/plugins/rpa4all-hooks.ts
+++ b/.opencode/plugins/rpa4all-hooks.ts
@@ -1,0 +1,520 @@
+/**
+ * rpa4all-hooks — opencode plugin que importa os hooks do eddie-auto-dev.
+ *
+ * Ponte opencode ↔ tools/copilot_hooks + tools/hooks (fonte de verdade),
+ * no mesmo espírito do bridge do Pi (`.pi/extensions/rpa4all-hooks`).
+ *
+ * Dependências: nenhuma além de Node builtins (spawn/fs/path/url).
+ *
+ * Contrato opencode (v1 SDK):
+ *   - Plugin = named export de função que recebe PluginInput e devolve Hooks.
+ *   - `tool.execute.before` → input.tool + output.args (+ sessionID em input)
+ *   - `tool.execute.after`  → input.tool + input.args
+ *   - `chat.message`        → input.sessionID, output.message/output.parts
+ *   - `event`               → { event } (session.idle/status/error…)
+ *
+ * Mapeamento (espelha hooks.json):
+ *   - UserPromptSubmit → tools/copilot_hooks/internet_preference_context.py
+ *                        + tools/copilot_hooks/inject_memory_context.py
+ *   - PreToolUse       → pre_tool_guardrails + registries + record_stopped
+ *   - PostToolUse      → post_edit_validate + ai_response_analyzer
+ *   - Stop             → block_incomplete_stop + restore_stopped
+ *   - Web tools        → web_agent_live_log (pre/delta) + open_agent_log_terminal
+ *
+ * Fail-open: qualquer erro interno nunca quebra a sessão. Decisões válidas
+ * (`deny`/`ask`) viram exceção no plugin (bloqueia a tool); `block` em Stop
+ * vira contexto na próxima mensagem do agente.
+ */
+
+/**
+ * Plugin opencode que ponteia os hooks do eddie-auto-dev.
+ * Exportado como named (padrão opencode: `export const NomePlugin`), sem default.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+
+export type HookDecision = {
+  ok: boolean;
+  raw: string;
+  parsed: Record<string, unknown> | null;
+  permissionDecision?: "deny" | "ask" | "allow";
+  permissionReason?: string;
+  additionalContext?: string;
+  stopDecision?: "block" | "continue";
+  stopReason?: string;
+  systemMessage?: string;
+  error?: string;
+};
+
+const TOOL_NAME_MAP: Record<string, string> = {
+  bash: "Bash",
+  read: "Read",
+  write: "Write",
+  edit: "Edit",
+  grep: "Grep",
+  glob: "Glob",
+  list: "LS",
+  find: "Find",
+  ls: "LS",
+  cat: "Read",
+};
+
+const PRE_TOOL_HOOKS: Array<{ script: string; timeoutMs: number }> = [
+  { script: "tools/hooks/record_stopped.py", timeoutMs: 5_000 },
+];
+
+const GUARDRAIL_HOOKS: Array<{ script: string; timeoutMs: number }> = [
+  { script: "tools/copilot_hooks/pre_tool_guardrails.py", timeoutMs: 10_000 },
+  { script: "tools/hooks/api_registry_validate.py", timeoutMs: 10_000 },
+  { script: "tools/hooks/variable_registry_validate.py", timeoutMs: 10_000 },
+  { script: "tools/hooks/table_registry_validate.py", timeoutMs: 10_000 },
+  { script: "tools/hooks/cmdb_validate.py", timeoutMs: 10_000 },
+];
+
+const POST_TOOL_HOOKS: Array<{ script: string; timeoutMs: number }> = [
+  { script: "tools/copilot_hooks/post_edit_validate.py", timeoutMs: 10_000 },
+  { script: "tools/copilot_hooks/ai_response_analyzer.py", timeoutMs: 10_000 },
+];
+
+const STOP_HOOKS: Array<{ script: string; timeoutMs: number }> = [
+  { script: "tools/hooks/block_incomplete_stop.py", timeoutMs: 30_000 },
+  { script: "tools/hooks/restore_stopped.py", timeoutMs: 60_000 },
+];
+
+const MEMORY_HOOK = { script: "tools/copilot_hooks/inject_memory_context.py", timeoutMs: 5_000 };
+const INTERNET_HOOK = { script: "tools/copilot_hooks/internet_preference_context.py", timeoutMs: 5_000 };
+const WEB_PRE = { script: "tools/hooks/web_agent_live_log.py", mode: "--mode=pre", timeoutMs: 5_000 };
+const WEB_TERMINAL = { script: "tools/hooks/open_agent_log_terminal.py", timeoutMs: 8_000 };
+
+function findRepoRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  for (let i = 0; i < 14; i++) {
+    if (
+      existsSync(join(dir, "tools", "copilot_hooks")) &&
+      existsSync(join(dir, "tools", "hooks"))
+    ) {
+      return dir;
+    }
+    const parent = resolve(dir, "..");
+    if (parent === dir) break;
+    dir = parent;
+  }
+  const fallback = "/workspace/eddie-auto-dev";
+  if (existsSync(join(fallback, "tools", "copilot_hooks"))) return fallback;
+  return startDir;
+}
+
+function mapToolName(name: string): string {
+  const base = name.toLowerCase().split("__").pop() ?? name;
+  return TOOL_NAME_MAP[base] ?? TOOL_NAME_MAP[name] ?? name;
+}
+
+function safeStr(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function mapToolInput(name: string, input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...input };
+  const path = safeStr(input.path) || safeStr(input.file_path) || safeStr(input.filePath);
+  const base = name.toLowerCase().split("__").pop() ?? name;
+  if (path) {
+    out.path = path;
+    out.file_path = path;
+    out.filePath = path;
+  }
+  if (base === "bash") {
+    const command = safeStr(input.command) || safeStr(input.cmd) || "";
+    out.command = command;
+  }
+  if (base === "write" || base === "edit") {
+    if (typeof input.content === "string") {
+      out.content = input.content;
+      out.new_string = input.content;
+      out.newString = input.content;
+    }
+    if (typeof input.newString === "string") {
+      out.content = input.newString;
+      out.new_string = input.newString;
+    }
+    if (typeof input.oldString === "string") {
+      out.old_string = input.oldString;
+    }
+  }
+  return out;
+}
+
+function envelope(
+  eventName: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  cwd: string,
+  sessionId: string,
+): Record<string, unknown> {
+  return {
+    hook_event_name: eventName,
+    hookEventName: eventName,
+    tool_name: toolName,
+    toolName,
+    tool_input: toolInput,
+    toolInput,
+    cwd,
+    working_directory: cwd,
+    workingDirectory: cwd,
+    session_id: sessionId,
+    sessionId,
+  };
+}
+
+function parseHookOutput(stdout: string, stderr: string): HookDecision {
+  const raw = stdout.trim();
+  if (!raw) {
+    return { ok: false, raw: "", parsed: null, permissionDecision: "allow" };
+  }
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
+    parsed = JSON.parse(lines[lines.length - 1] ?? raw) as Record<string, unknown>;
+  } catch {
+    return {
+      ok: false,
+      raw,
+      parsed: null,
+      error: `invalid JSON from hook: ${raw.slice(0, 200)} stderr=${stderr.slice(0, 120)}`,
+    };
+  }
+  const nested =
+    parsed.hookSpecificOutput && typeof parsed.hookSpecificOutput === "object"
+      ? (parsed.hookSpecificOutput as Record<string, unknown>)
+      : parsed;
+  const permissionDecision = String(
+    nested.permissionDecision ?? nested.permission_decision ?? "",
+  ).toLowerCase();
+  const permissionReason = String(
+    nested.permissionDecisionReason ??
+      nested.permission_decision_reason ??
+      nested.reason ??
+      nested.additionalContext ??
+      "",
+  );
+  const additionalContext =
+    typeof nested.additionalContext === "string"
+      ? nested.additionalContext
+      : typeof parsed.additionalContext === "string"
+        ? parsed.additionalContext
+        : undefined;
+  const systemMessage = typeof parsed.systemMessage === "string" ? parsed.systemMessage : undefined;
+  const stopDecisionRaw = String(nested.decision ?? parsed.decision ?? "").toLowerCase();
+  const stopDecision = stopDecisionRaw === "block" ? "block"
+    : stopDecisionRaw === "approve" || stopDecisionRaw === "continue" ? "continue" : undefined;
+  const stopReason = typeof nested.reason === "string" ? nested.reason
+    : typeof parsed.reason === "string" ? parsed.reason : undefined;
+
+  return {
+    ok: true,
+    raw,
+    parsed,
+    permissionDecision:
+      permissionDecision === "deny" ||
+      permissionDecision === "ask" ||
+      permissionDecision === "allow"
+        ? (permissionDecision as "deny" | "ask" | "allow")
+        : "allow",
+    permissionReason: permissionReason || undefined,
+    additionalContext,
+    stopDecision,
+    stopReason,
+    systemMessage,
+  };
+}
+
+function runPythonHook(
+  scriptRel: string,
+  args: string[],
+  payload: Record<string, unknown>,
+  options: { repoRoot: string; timeoutMs: number },
+): Promise<Readonly<HookDecision>> {
+  const scriptPath = existsSync(join(options.repoRoot, scriptRel))
+    ? join(options.repoRoot, scriptRel)
+    : join(MODULE_DIR, "..", scriptRel);
+  const stdinPayload = JSON.stringify(payload);
+  const env = {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: options.repoRoot,
+    RPA4ALL_OPENCODE: "true",
+  };
+
+  return new Promise((resolveDecision) => {
+    const child = spawn("python3", [scriptPath, ...args], {
+      cwd: options.repoRoot,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      resolveDecision({
+        ok: false,
+        raw: stdout,
+        parsed: null,
+        error: `timeout after ${options.timeoutMs}ms (${scriptRel}): ${stderr.slice(0, 200)}`,
+      });
+    }, options.timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveDecision({ ok: false, raw: stdout, parsed: null, error: `spawn error: ${err.message}` });
+    });
+    child.on("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveDecision(parseHookOutput(stdout, stderr));
+    });
+    child.stdin.write(stdinPayload);
+    child.stdin.end();
+  });
+}
+
+function isWebTool(name: string): boolean {
+  const n = (name || "").toLowerCase();
+  return (
+    n.startsWith("web-agent__") ||
+    n.startsWith("web_agent__") ||
+    n.includes("web-agent") ||
+    n.includes("web_run_task") ||
+    n.includes("web_fill_form") ||
+    n.includes("web_scrape") ||
+    n.includes("web_apply") ||
+    n.includes("web_analyze")
+  );
+}
+
+function isEditLike(name: string): boolean {
+  const n = name.toLowerCase();
+  const b = n.split("__").pop() ?? n;
+  const tokens = ["edit", "create", "write", "replace", "patch", "file", "string"];
+  return tokens.some((t) => b.includes(t) || n.includes(t));
+}
+
+function isCommandLike(name: string): boolean {
+  const n = name.toLowerCase();
+  const b = n.split("__").pop() ?? n;
+  const tokens = ["terminal", "execute", "command", "run", "shell", "bash", "cmd"];
+  return tokens.some((t) => b.includes(t) || n.includes(t));
+}
+
+function extractPrompt(message: unknown): string {
+  if (!message) return "";
+  if (typeof message === "string") return message;
+  if (Array.isArray(message)) {
+    return message.map((p) => {
+      if (typeof p === "string") return p;
+      if (p?.type === "text") return safeStr(p.text);
+      if (p?.text) return safeStr(p.text);
+      return "";
+    }).join("\n");
+  }
+  if (typeof message === "object") {
+    const m = message as Record<string, unknown>;
+    const texts: string[] = [];
+    if (typeof m.text === "string" && m.text.trim()) texts.push(m.text);
+    for (const key of ["content", "parts"]) {
+      const v = m[key];
+      if (Array.isArray(v)) texts.push(extractPrompt(v));
+    }
+    return texts.join("\n");
+  }
+  return "";
+}
+
+export const rpa4allHooksPlugin = async ({ directory, project }: { directory: string; project: { directory?: string } }) => {
+  const cwd = directory || project?.directory || process.cwd();
+  let repoRoot = findRepoRoot(cwd);
+  if (!existsSync(join(repoRoot, "tools", "hooks"))) repoRoot = findRepoRoot(MODULE_DIR);
+
+  const pendingContext = new Map<string, string[]>();
+  const pendingPromptContext = new Map<string, string>();
+
+  function queueContext(sessionID: string, text: string | undefined): void {
+    if (!text) return;
+    const arr = pendingContext.get(sessionID) ?? [];
+    arr.push(text);
+    pendingContext.set(sessionID, arr);
+  }
+
+  async function runSingle(
+    scriptRel: string,
+    args: string[],
+    payload: Record<string, unknown>,
+  ): Promise<Readonly<HookDecision>> {
+    return runPythonHook(scriptRel, args, payload, {
+      repoRoot,
+      timeoutMs: 10_000,
+    });
+  }
+
+  async function runGuardrailChain(payload: Record<string, unknown>) {
+    let deny: Readonly<HookDecision> | undefined;
+    let ask: Readonly<HookDecision> | undefined;
+    const contexts: string[] = [];
+    for (const hook of [...PRE_TOOL_HOOKS, ...GUARDRAIL_HOOKS]) {
+      const decision = await runSingle(hook.script, [], payload);
+      if (decision.error && decision.parsed === null) continue;
+      if (decision.permissionDecision === "deny" && !deny) deny = decision;
+      else if (decision.permissionDecision === "ask" && !ask) ask = decision;
+      if (decision.additionalContext) contexts.push(decision.additionalContext);
+    }
+    return {
+      permissionDecision: deny ? "deny" : ask ? "ask" : "allow",
+      permissionReason: deny?.permissionReason ?? ask?.permissionReason,
+      additionalContext: contexts.join("\n\n") || undefined,
+    };
+  }
+
+  return {
+    "chat.message": async (input: any, output: any) => {
+      const sessionID = input?.sessionID ?? input?.sessionId ?? "default";
+      const text =
+        extractPrompt(output?.message?.parts ?? output?.parts) ||
+        extractPrompt(output?.message?.message) ||
+        extractPrompt(output?.content) ||
+        extractPrompt(output);
+      if (!text) return;
+      const base = { cwd: repoRoot, session_id: sessionID, sessionId: sessionID };
+      const inter = await runSingle(INTERNET_HOOK.script, [], {
+        hook_event_name: "UserPromptSubmit",
+        prompt: text,
+        user_prompt: text,
+        text,
+        ...base,
+      });
+      if (inter.additionalContext) {
+        pendingPromptContext.set(sessionID, inter.additionalContext);
+      }
+      const mem = await runSingle(MEMORY_HOOK.script, [], {
+        hook_event_name: "UserPromptSubmit",
+        prompt: text,
+        user_prompt: text,
+        text,
+        ...base,
+      });
+      if (mem.additionalContext) {
+        pendingPromptContext.set(
+          sessionID,
+          [pendingPromptContext.get(sessionID), mem.additionalContext].filter(Boolean).join("\n\n"),
+        );
+      }
+    },
+
+    "experimental.chat.system.transform": async (input: { sessionID?: string }, output: { system: string[] }) => {
+      const sessionID = input?.sessionID ?? "default";
+      const extra = pendingPromptContext.get(sessionID);
+      const flushed = pendingContext.get(sessionID);
+      if (extra) {
+        output.system.push(`\n\n${extra}`);
+        pendingPromptContext.delete(sessionID);
+      }
+      if (flushed && flushed.length > 0) {
+        output.system.push(`\n\n${flushed.join("\n\n")}`);
+        pendingContext.delete(sessionID);
+      }
+    },
+
+    "tool.execute.before": async (input: { tool?: string; sessionID?: string }, output: { args?: Record<string, unknown> }) => {
+      const sessionID = input?.sessionID ?? "default";
+      const rawTool = input.tool ?? "";
+      const toolName = mapToolName(rawTool);
+      const args = (output?.args ?? {}) as Record<string, unknown>;
+      const toolInput = mapToolInput(rawTool, args);
+      const payload = envelope("PreToolUse", toolName, toolInput, repoRoot, sessionID);
+
+      const isWeb = isWebTool(rawTool);
+      if (isWeb) {
+        await runSingle(WEB_PRE.script, [WEB_PRE.mode], payload).then(() => {});
+        const t = await runSingle(WEB_TERMINAL.script, [], payload);
+        if (t.additionalContext) queueContext(sessionID, t.additionalContext);
+      }
+
+      const decision = await runGuardrailChain(payload);
+
+      if (decision.permissionDecision === "deny" || decision.permissionDecision === "ask") {
+        const reason = decision.permissionReason || "Política do workspace";
+        const suffix =
+          decision.permissionDecision === "ask"
+            ? "\n\nObtive confirmação explícita do usuário antes de prosseguir."
+            : "";
+        throw new Error(
+          `[rpa4all-hooks] ${decision.permissionDecision.toUpperCase()}: ${reason}${suffix}`,
+        );
+      }
+      queueContext(sessionID, decision.additionalContext);
+    },
+
+    "tool.execute.after": async (input: any, _output: any) => {
+      const sessionID = input?.sessionID ?? "default";
+      const rawTool = input.tool ?? "";
+      const toolName = mapToolName(rawTool);
+      const args = (input.args ?? {}) as Record<string, unknown>;
+      if (!isEditLike(toolName) && !isCommandLike(toolName)) return;
+      const toolInput = mapToolInput(rawTool, args);
+      const payload = {
+        ...envelope("PostToolUse", toolName, toolInput, repoRoot, sessionID),
+        tool_input: { ...toolInput, ...(args as object) },
+      };
+      for (const hook of POST_TOOL_HOOKS) {
+        const d = await runSingle(hook.script, [], payload);
+        if (d.additionalContext) queueContext(sessionID, d.additionalContext);
+        if (d.systemMessage) queueContext(sessionID, d.systemMessage);
+      }
+    },
+
+    event: async ({ event }: any) => {
+      if (!event) return;
+      const sessionID =
+        event.properties?.sessionID ??
+        event.properties?.info?.sessionID ??
+        event.properties?.info?.id ??
+        "default";
+      const type = event.type;
+
+      if (type?.startsWith("session.")) {
+        const status = typeof event.properties?.status === "string"
+          ? event.properties.status
+          : event.properties?.status?.type;
+        if (status && !(status === "idle" || status === "error" || type === "session.end")) return;
+
+        const stopPayload = envelope("Stop", "Stop", {}, repoRoot, String(sessionID));
+        for (const hook of STOP_HOOKS) {
+          const d = await runSingle(hook.script, [], stopPayload);
+          if (!d.error && d.parsed) {
+            if (d.stopDecision === "block" && d.stopReason) {
+              queueContext(String(sessionID), `⚠️ Encerramento com tarefa incompleta: ${d.stopReason}`);
+            }
+            if (d.systemMessage) queueContext(String(sessionID), d.systemMessage);
+          }
+        }
+      }
+    },
+  };
+};

--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,193 +1,9 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-31T21:11:53.969995",
+  "generatedAt": "2026-08-02T21:14:06.905556",
   "environment": "production",
   "categories": {
     "services": {
-      "WIKI_API": {
-        "name": "WIKI_API",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "test_variable_registry_validate"
-        ]
-      },
-      "WIKI_PUBLIC": {
-        "name": "WIKI_PUBLIC",
-        "type": "url",
-        "source": ".env",
-        "value": "https://wiki.rpa4all.com",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 4
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".env",
-            "line": 4
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_API": {
-        "name": "WIKI_OLLAMA_API",
-        "type": "url",
-        "source": ".env",
-        "value": "http://192.168.15.2:11437/api",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 6
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".env",
-            "line": 6
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_MODEL": {
-        "name": "WIKI_OLLAMA_MODEL",
-        "type": "string",
-        "source": ".env",
-        "value": "qwen3:8b",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 7
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".env",
-            "line": 7
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_LOCALE": {
-        "name": "WIKI_LOCALE",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "wiki_agent",
-          "server_error_alert"
-        ]
-      },
-      "WIKI_TIMEOUT": {
-        "name": "WIKI_TIMEOUT",
-        "type": "integer",
-        "source": ".env",
-        "value": "90",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 9
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".env",
-            "line": 9
-          }
-        ],
-        "contexts": []
-      },
-      "PAGES_FILE": {
-        "name": "PAGES_FILE",
-        "type": "string",
-        "source": ".env",
-        "value": "wiki_pages.json",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 10
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".env",
-            "line": 10
-          }
-        ],
-        "contexts": []
-      },
       "OPENAI_COMPATIBLE_ENABLED": {
         "name": "OPENAI_COMPATIBLE_ENABLED",
         "type": "string",
@@ -221,51 +37,51 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_bridge",
-          "ollama_client",
-          "tape_quality_ollama_narrator",
-          "github_agent_streamlit",
-          "home_assistant_integration",
-          "bn_acervo_agent",
-          "debug_ollama",
-          "github_agent",
-          "user_management",
-          "llm_compatibility",
-          "test_github_agent",
           "agenda_media_router",
-          "streamlit_app",
-          "rss_sentiment_exporter",
-          "run_sentiment_finetune",
+          "ollama_warmup",
+          "user_management",
           "rss_llm_trainer",
           "whatsapp_persona_panel_server",
-          "ollama_finetune_batch",
-          "gmail_expurgo_inteligente",
-          "llm_tool_client",
-          "nextcloud_agent",
-          "coordinator",
-          "finetune_whatsapp_model",
-          "telegram_bot",
-          "openwebui_integration",
-          "test_ollama_quick",
-          "process_all_messages_from_tmp",
-          "config",
+          "github_agent_streamlit",
           "test_improvements",
-          "ollama_warmup",
-          "email_trainer",
-          "proxy_tool_interceptor",
-          "agent_documentation_manager",
-          "trading_selfheal_exporter",
-          "test_models",
-          "job_application_agent",
-          "llm_system_demo",
-          "apply_real_job",
-          "llm_log_panel_server",
-          "compatibility_allinone",
-          "train_llm_on_conversations",
-          "ollama_offloader",
+          "rss_sentiment_exporter",
           "github_agent_server",
+          "trading_selfheal_exporter",
+          "test_ollama_quick",
+          "ollama_finetune_batch",
+          "test_models",
+          "ollama_offloader",
+          "openwebui_integration",
+          "bn_acervo_agent",
+          "llm_compatibility",
+          "nextcloud_agent",
+          "agent_documentation_manager",
+          "whatsapp_bot",
+          "ollama_client",
+          "email_trainer",
           "create_dev_agent",
-          "whatsapp_bot"
+          "coordinator",
+          "gmail_expurgo_inteligente",
+          "compatibility_allinone",
+          "llm_tool_client",
+          "streamlit_app",
+          "ollama_mcp_bridge",
+          "home_assistant_integration",
+          "github_agent",
+          "finetune_whatsapp_model",
+          "config",
+          "debug_ollama",
+          "job_application_agent",
+          "telegram_bot",
+          "tape_quality_ollama_narrator",
+          "llm_system_demo",
+          "proxy_tool_interceptor",
+          "run_sentiment_finetune",
+          "test_github_agent",
+          "llm_log_panel_server",
+          "process_all_messages_from_tmp",
+          "train_llm_on_conversations",
+          "apply_real_job"
         ]
       },
       "OLLAMA_MODEL": {
@@ -274,27 +90,27 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_client",
-          "tape_quality_ollama_narrator",
-          "github_agent_streamlit",
-          "github_agent",
           "user_management",
-          "test_github_agent",
-          "streamlit_app",
-          "llm_tool_client",
+          "github_agent_streamlit",
           "nas_ai_assessor",
-          "nextcloud_agent",
-          "telegram_bot",
-          "extract_whatsapp_train",
-          "config",
-          "test_sell_target_backtest",
-          "trading_selfheal_exporter",
-          "agent_documentation_manager",
-          "job_application_agent",
-          "ollama_offloader",
           "github_agent_server",
+          "trading_selfheal_exporter",
+          "ollama_offloader",
+          "nextcloud_agent",
+          "agent_documentation_manager",
+          "whatsapp_bot",
+          "ollama_client",
+          "test_sell_target_backtest",
           "create_dev_agent",
-          "whatsapp_bot"
+          "llm_tool_client",
+          "streamlit_app",
+          "github_agent",
+          "config",
+          "job_application_agent",
+          "telegram_bot",
+          "tape_quality_ollama_narrator",
+          "extract_whatsapp_train",
+          "test_github_agent"
         ]
       },
       "OLLAMA_HOST_GPU1": {
@@ -303,18 +119,18 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_client",
-          "rss_sentiment_exporter",
-          "run_sentiment_finetune",
-          "rss_llm_trainer",
           "tape_quality_ollama_narrator",
-          "config",
+          "ollama_warmup",
           "ollama_finetune_batch",
+          "rss_llm_trainer",
           "ollama_offloader",
           "real_workload",
-          "nextcloud_agent",
+          "run_sentiment_finetune",
           "bn_acervo_agent",
-          "ollama_warmup"
+          "nextcloud_agent",
+          "config",
+          "ollama_client",
+          "rss_sentiment_exporter"
         ]
       },
       "OLLAMA_MODEL_GPU1": {
@@ -333,101 +149,11 @@
         "value": "5",
         "locations": [
           {
-            "file": ".env",
-            "line": 22
-          },
-          {
             "file": ".env.openai-compatible.example",
             "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".env",
-            "line": 22
           }
         ],
         "contexts": []
-      },
-      "NEXTCLOUD_URL": {
-        "name": "NEXTCLOUD_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config",
-          "nextcloud_agent",
-          "configure_authentik_nextcloud_oidc",
-          "user_management",
-          "storage_portal_api"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_USER": {
-        "name": "NEXTCLOUD_ADMIN_USER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_CONTAINER": {
-        "name": "NEXTCLOUD_CONTAINER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_AGENT_ENABLED": {
-        "name": "NEXTCLOUD_AGENT_ENABLED",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_GPU": {
-        "name": "NEXTCLOUD_OLLAMA_GPU",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_TIMEOUT": {
-        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_DEFAULT_DRY_RUN": {
-        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
       },
       "GEMINI_ENABLED": {
         "name": "GEMINI_ENABLED",
@@ -447,18 +173,6 @@
           {
             "file": ".env.consolidated",
             "line": 21
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 21
           }
         ],
         "contexts": []
@@ -469,11 +183,11 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-backend"
+          "mailu-dovecot",
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-postfix"
         ]
       },
       "ADMIN_EMAIL": {
@@ -484,18 +198,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 28
           }
         ],
@@ -510,18 +212,6 @@
           {
             "file": ".env.consolidated",
             "line": 29
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 29
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 29
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 29
           }
         ],
         "contexts": []
@@ -534,18 +224,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 33
           }
         ],
@@ -560,18 +238,6 @@
           {
             "file": ".env.consolidated",
             "line": 34
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 34
           }
         ],
         "contexts": []
@@ -584,18 +250,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 35
           }
         ],
@@ -610,18 +264,6 @@
           {
             "file": ".env.consolidated",
             "line": 36
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 36
           }
         ],
         "contexts": []
@@ -634,18 +276,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 37
           }
         ],
@@ -660,18 +290,6 @@
           {
             "file": ".env.consolidated",
             "line": 38
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 38
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 38
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 38
           }
         ],
         "contexts": []
@@ -684,18 +302,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 39
           }
         ],
@@ -710,18 +316,6 @@
           {
             "file": ".env.consolidated",
             "line": 40
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 40
           }
         ],
         "contexts": []
@@ -734,18 +328,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 41
           }
         ],
@@ -760,18 +342,6 @@
           {
             "file": ".env.consolidated",
             "line": 42
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 42
           }
         ],
         "contexts": []
@@ -784,18 +354,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 43
           }
         ],
@@ -810,18 +368,6 @@
           {
             "file": ".env.consolidated",
             "line": 44
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 44
           }
         ],
         "contexts": []
@@ -834,18 +380,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 52
           }
         ],
@@ -860,18 +394,6 @@
           {
             "file": ".env.consolidated",
             "line": 53
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 53
           }
         ],
         "contexts": []
@@ -884,18 +406,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 60
           }
         ],
@@ -910,18 +420,6 @@
           {
             "file": ".env.consolidated",
             "line": 61
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 61
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 61
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 61
           }
         ],
         "contexts": []
@@ -934,18 +432,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 91
           }
         ],
@@ -960,18 +446,6 @@
           {
             "file": ".env.consolidated",
             "line": 121
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 121
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 121
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 121
           }
         ],
         "contexts": []
@@ -984,18 +458,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 122
           }
         ],
@@ -1028,18 +490,90 @@
           {
             "file": ".env.consolidated",
             "line": 125
-          },
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_API": {
+        "name": "WIKI_API",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "test_variable_registry_validate"
+        ]
+      },
+      "WIKI_PUBLIC": {
+        "name": "WIKI_PUBLIC",
+        "type": "url",
+        "source": ".env",
+        "value": "https://wiki.rpa4all.com",
+        "locations": [
           {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 125
-          },
+            "file": ".env.example.wiki",
+            "line": 3
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_API": {
+        "name": "WIKI_OLLAMA_API",
+        "type": "url",
+        "source": ".env",
+        "value": "http://<homelab-ip>:11437/api",
+        "locations": [
           {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 125
-          },
+            "file": ".env.example.wiki",
+            "line": 5
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_MODEL": {
+        "name": "WIKI_OLLAMA_MODEL",
+        "type": "string",
+        "source": ".env",
+        "value": "mistral:7b",
+        "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 125
+            "file": ".env.example.wiki",
+            "line": 6
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_LOCALE": {
+        "name": "WIKI_LOCALE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "server_error_alert",
+          "wiki_agent"
+        ]
+      },
+      "WIKI_TIMEOUT": {
+        "name": "WIKI_TIMEOUT",
+        "type": "integer",
+        "source": ".env",
+        "value": "90",
+        "locations": [
+          {
+            "file": ".env.example.wiki",
+            "line": 8
+          }
+        ],
+        "contexts": []
+      },
+      "PAGES_FILE": {
+        "name": "PAGES_FILE",
+        "type": "string",
+        "source": ".env",
+        "value": "wiki_pages.json",
+        "locations": [
+          {
+            "file": ".env.example.wiki",
+            "line": 9
           }
         ],
         "contexts": []
@@ -1050,18 +584,6 @@
         "source": ".env",
         "value": "127.0.0.1",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 6
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 6
@@ -1076,18 +598,6 @@
         "value": "18091",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 7
           }
@@ -1101,18 +611,6 @@
         "value": "127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 8
           }
@@ -1125,18 +623,6 @@
         "source": ".env",
         "value": "18092",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 9
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 9
@@ -1169,18 +655,6 @@
         "value": "auth.rpa4all.com netbox.cmdb.local localhost 127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 14
           }
@@ -1193,18 +667,6 @@
         "source": ".env",
         "value": "https://auth.rpa4all.com",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 15
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 15
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 15
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 15
@@ -1228,18 +690,6 @@
         "value": "true",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 17
           }
@@ -1252,18 +702,6 @@
         "source": ".env",
         "value": "https://auth.rpa4all.com/outpost.goauthentik.io/sign_out",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 18
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 18
@@ -1287,18 +725,6 @@
         "value": "v4.6-5.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 31
           }
@@ -1311,18 +737,6 @@
         "source": ".env",
         "value": "latest",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 34
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 34
@@ -1337,18 +751,6 @@
         "value": "1.29-alpine",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 36
           }
@@ -1361,18 +763,6 @@
         "source": ".env",
         "value": "cmdb-admin",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 45
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 45
@@ -1387,18 +777,6 @@
         "value": "cmdb-admin@local",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 46
           }
@@ -1411,18 +789,6 @@
         "source": ".env",
         "value": "cmdb@local",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 48
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 48
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 48
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 48
@@ -1437,18 +803,6 @@
         "value": "localhost",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 49
           }
@@ -1461,18 +815,6 @@
         "source": ".env",
         "value": "25",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 50
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 50
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 50
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 50
@@ -1487,18 +829,6 @@
         "value": "false",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 51
           }
@@ -1512,18 +842,6 @@
         "value": "false",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 52
           }
@@ -1536,18 +854,6 @@
         "source": ".env",
         "value": "false",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 53
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 53
@@ -1598,9 +904,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ltfs_recovery",
           "tape_manager",
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "tape_orchestrator"
         ]
       },
       "LTFS_WORKDIR": {
@@ -1611,18 +917,6 @@
         "locations": [
           {
             "file": "systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
             "line": 3
           }
         ],
@@ -1637,18 +931,6 @@
           {
             "file": "systemd/ltfs-lto6-sg1.env",
             "line": 4
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-            "line": 4
           }
         ],
         "contexts": []
@@ -1662,18 +944,6 @@
           {
             "file": "systemd/ltfs-lto6-sg1.env",
             "line": 5
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-            "line": 5
           }
         ],
         "contexts": []
@@ -1684,10 +954,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
-          "tape_orchestrator",
           "ltfs_recovery",
-          "ltfs_checkpoint_writer"
+          "ltfs_checkpoint_writer",
+          "tape_manager",
+          "tape_orchestrator"
         ]
       },
       "LTFS_TAPE_DEVICE": {
@@ -1696,9 +966,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ltfs_recovery",
           "tape_manager",
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "tape_orchestrator"
         ]
       },
       "LTO6_SG_DEV": {
@@ -1734,11 +1004,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_safe_eject",
           "ltfs_recovery",
-          "tape_component_quality_agent",
-          "tape_orchestrator"
+          "tape_manager",
+          "tape_orchestrator",
+          "tape_component_quality_agent"
         ]
       },
       "LTFS_SELF_HEAL_STATE_FILE": {
@@ -1765,9 +1035,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "autonomous_remediator",
           "run_pipeline_all_envs",
-          "operations_agent"
+          "operations_agent",
+          "autonomous_remediator"
         ]
       },
       "TUNNEL_APP_NAME": {
@@ -1778,18 +1048,6 @@
         "locations": [
           {
             "file": "deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
             "line": 13
           }
         ],
@@ -1831,18 +1089,6 @@
           {
             "file": "tools/authentik_management/configs/grafana.env",
             "line": 24
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/grafana.env",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/grafana.env",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/grafana.env",
-            "line": 24
           }
         ],
         "contexts": []
@@ -1854,16 +1100,8 @@
         "value": "trading-analyst",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/crypto-agent/models.env",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/crypto-agent/models.env",
-            "line": 8
-          },
-          {
             "file": "deploy/crypto-agent/models.env",
-            "line": 8
+            "line": 18
           }
         ],
         "contexts": []
@@ -1874,9 +1112,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nextcloud_agent",
           "ollama_client",
-          "ollama_offloader"
+          "ollama_offloader",
+          "nextcloud_agent"
         ]
       },
       "OLLAMA_PLAN_MODEL": {
@@ -2069,8 +1307,8 @@
         "value": null,
         "contexts": [
           "user_management",
-          "storage_portal_api",
-          "2_user_management"
+          "2_user_management",
+          "storage_portal_api"
         ]
       },
       "POSTFIX_CMD_PATH": {
@@ -2196,10 +1434,10 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
-          "grafana",
           "glpi",
           "glpi-db",
-          "netbox-postgres"
+          "netbox-postgres",
+          "grafana"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -2558,36 +1796,37 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "diretor",
-          "daily-agenda-panel",
-          "crypto-agent@",
-          "agent-network-exporter",
-          "marketing-x-posts",
-          "meeting-translator",
-          "trading-analyst-weekly-retrain",
-          "candle-collector",
-          "whatsapp-toolcall-chunked-train",
-          "marketing-api",
+          "nas-ram-exporter",
           "marketing-daily-report",
-          "marketing-email-drip",
-          "notebook-power-agent",
-          "eddie-expurgo",
-          "coordinator",
+          "marketing-x-posts",
           "kucoin-usdt-rebalance",
-          "tape-component-quality-exporter",
-          "trading-daily-report",
-          "daily-agenda-broadcast",
           "kucoin-postgres-sync",
-          "decisions-track-record-rollup",
-          "clear-trading-agent",
+          "marketing-api",
+          "daily-agenda-panel",
+          "agent-network-exporter",
           "eddie-telegram-bot",
+          "eddie-calendar",
+          "whatsapp-toolcall-chunked-train",
           "bn-acervo-agent",
           "rss-sentiment-exporter",
-          "nas-ollama-load",
+          "diretor",
+          "trading-analyst-weekly-retrain",
+          "crypto-agent@",
+          "coordinator",
+          "trading-daily-report",
+          "banking-metrics-exporter",
+          "meeting-translator",
+          "daily-agenda-broadcast",
           "approval-gateway",
+          "candle-collector",
+          "eddie-expurgo",
+          "decisions-track-record-rollup",
           "ollama-gpu-coordinator",
-          "eddie-calendar",
-          "banking-metrics-exporter"
+          "tape-component-quality-exporter",
+          "marketing-email-drip",
+          "notebook-power-agent",
+          "nas-ollama-load",
+          "clear-trading-agent"
         ]
       },
       "TG_LONG_POLL": {
@@ -2605,8 +1844,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "mcp_tool_bridge",
-          "approval_gateway"
+          "approval_gateway",
+          "mcp_tool_bridge"
         ]
       },
       "BANKING_EXPORTER_PORT": {
@@ -2642,12 +1881,12 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "whatsapp-persona-panel",
           "decisions-track-record-rollup",
+          "rss-sentiment-exporter",
+          "whatsapp-persona-panel",
           "ollama-finetune",
-          "candle-collector",
           "llm-log-panel",
-          "rss-sentiment-exporter"
+          "candle-collector"
         ]
       },
       "HOME": {
@@ -2657,11 +1896,11 @@
         "value": "/apps/crypto-trader",
         "contexts": [
           "decisions-track-record-rollup",
-          "crypto-agent@",
+          "rss-sentiment-exporter",
           "ollama-finetune",
-          "candle-collector",
           "llm-log-panel",
-          "rss-sentiment-exporter"
+          "candle-collector",
+          "crypto-agent@"
         ]
       },
       "PYTHONPATH": {
@@ -2671,16 +1910,16 @@
         "value": "/apps/crypto-trader/trading",
         "contexts": [
           "decisions-track-record-rollup",
-          "marketing-email-drip",
-          "marketing-x-posts",
-          "ollama-finetune",
-          "clear-trading-agent",
-          "candle-collector",
           "tape-component-quality-exporter",
-          "llm-log-panel",
+          "marketing-daily-report",
+          "marketing-x-posts",
+          "marketing-email-drip",
           "rss-sentiment-exporter",
+          "ollama-finetune",
           "marketing-api",
-          "marketing-daily-report"
+          "llm-log-panel",
+          "clear-trading-agent",
+          "candle-collector"
         ]
       },
       "CLEAR_CONFIG_FILE": {
@@ -2708,16 +1947,16 @@
         "source": "systemd",
         "value": "/usr/local/bin:/usr/bin:/bin",
         "contexts": [
-          "crypto-agent@",
-          "eddie-whatsapp-bot",
-          "specialized_agents-dashboard",
+          "job-monitor",
+          "tape-component-quality-exporter",
           "github-agent",
           "kucoin-usdt-rebalance",
-          "tape-component-quality-exporter",
-          "job-monitor",
-          "homelab-dashboard",
+          "specialized_agents-dashboard",
+          "eddie-whatsapp-bot",
+          "kucoin-postgres-sync",
           "rpa4all-validation",
-          "kucoin-postgres-sync"
+          "crypto-agent@",
+          "homelab-dashboard"
         ]
       },
       "ADMIN_CHAT_ID": {
@@ -2726,16 +1965,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "send_pending_report",
-          "kucoin_api",
-          "github_agent_streamlit",
+          "telegram_bot",
+          "coordinator",
+          "trading_selfheal_exporter",
           "gmail_expurgo_inteligente",
           "calendar_reminder_service",
+          "send_pending_report",
           "mt5_api",
-          "coordinator",
+          "kucoin_api",
           "storj_payout_monitor",
-          "trading_selfheal_exporter",
-          "telegram_bot"
+          "github_agent_streamlit"
         ]
       },
       "OLLAMA_PLAN_HOST": {
@@ -2744,8 +1983,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "position_manager_mixin",
           "compare_ollama_replay",
+          "position_manager_mixin",
           "trading_agent"
         ]
       },
@@ -3054,8 +2293,8 @@
         "source": "systemd",
         "value": "5",
         "contexts": [
-          "dhcp-selfheal",
-          "grafana-selfheal"
+          "grafana-selfheal",
+          "dhcp-selfheal"
         ]
       },
       "WHATSAPP_NUMBER": {
@@ -3064,11 +2303,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "extract_whatsapp_train",
-          "config",
           "calendar_reminder_service",
+          "extract_whatsapp_train",
+          "whatsapp_bot",
           "google_calendar_integration",
-          "whatsapp_bot"
+          "config"
         ]
       },
       "WAHA_API": {
@@ -3105,16 +2344,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "setup_waha",
-          "process_all_messages_from_tmp",
-          "test_whatsapp",
-          "github_agent_streamlit",
           "gmail_expurgo_inteligente",
           "search_waha_nil",
           "wait_and_run_whatsapp_test",
+          "setup_waha",
+          "test_whatsapp",
           "whatsapp_manager",
-          "apply_real_job",
-          "whatsapp_bot"
+          "github_agent_streamlit",
+          "process_all_messages_from_tmp",
+          "whatsapp_bot",
+          "apply_real_job"
         ]
       },
       "GMAIL_DATA_DIR": {
@@ -3142,8 +2381,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_bot",
-          "config"
+          "config",
+          "whatsapp_bot"
         ]
       },
       "PERSONA_MODEL_SAFE": {
@@ -3261,15 +2500,15 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "homelab_mcp_server",
-          "openwebui_validator_agent",
-          "install_webui_function_api",
-          "capture_login_playwright",
-          "ask_director_coordinator",
           "report_test_to_diretor",
+          "install_webui_function_api",
+          "openwebui_validator_agent",
+          "codex_mcp_server",
+          "homelab_mcp_server",
           "create_director_model",
           "list_webui",
-          "codex_mcp_server"
+          "capture_login_playwright",
+          "ask_director_coordinator"
         ]
       },
       "API_BASE_URL": {
@@ -3341,10 +2580,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_github_agent",
-          "github_agent_server",
           "github_agent_streamlit",
-          "github_agent"
+          "test_github_agent",
+          "github_agent",
+          "github_agent_server"
         ]
       },
       "FAIL_THRESHOLD": {
@@ -3371,8 +2610,9 @@
         "source": "systemd",
         "value": "nextcloud",
         "contexts": [
+          "homelab-tape-log-drain-nextcloud",
           "homelab-tape-log-drain-sg1",
-          "homelab-tape-log-drain-nextcloud"
+          "tape-log-spool-drain-nextcloud"
         ]
       },
       "ROUTE_TARGET_ROOT": {
@@ -3381,8 +2621,9 @@
         "source": "systemd",
         "value": "/mnt/pretape/lto6-cache/logs",
         "contexts": [
+          "homelab-tape-log-drain-nextcloud",
           "homelab-tape-log-drain-sg1",
-          "homelab-tape-log-drain-nextcloud"
+          "tape-log-spool-drain-nextcloud"
         ]
       },
       "BYPASS_CONF": {
@@ -3418,8 +2659,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "job_monitor_continuous",
           "scan_whatsapp_llm",
+          "job_monitor_continuous",
           "apply_real_job",
           "llm_system_demo"
         ]
@@ -3470,15 +2711,24 @@
           "openwebui_agent_coordinator_function"
         ]
       },
+      "JRNL_REPLICA_NAS": {
+        "name": "JRNL_REPLICA_NAS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
+        ]
+      },
       "TAPE_ACCESS_LOCKFILE": {
         "name": "TAPE_ACCESS_LOCKFILE",
         "type": "path",
         "source": "systemd",
         "value": "/run/lock/tape-access-sg0.lock",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
+          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
-          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf"
         ]
       },
       "TAPE_ACCESS_QUEUE_DIR": {
@@ -3487,9 +2737,9 @@
         "source": "systemd",
         "value": "/run/tape-queue-sg0",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
+          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
-          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf"
         ]
       },
       "TAPE_ACCESS_HOLDER_FILE": {
@@ -3498,9 +2748,9 @@
         "source": "systemd",
         "value": "/run/tape-queue-sg0/current",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
+          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
-          "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf"
         ]
       },
       "X_AGENT_URL": {
@@ -3536,10 +2786,19 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_gpu_coordinator",
-          "trading_analyst_finetune_batch",
           "nas_ollama_load",
-          "trading_analyst_shadow_eval"
+          "ollama_gpu_coordinator",
+          "trading_analyst_shadow_eval",
+          "trading_analyst_finetune_batch"
+        ]
+      },
+      "NAS_RAM_EXPORTER_PORT": {
+        "name": "NAS_RAM_EXPORTER_PORT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "nas_ram_exporter"
         ]
       },
       "GPU_CLOCK_MAX": {
@@ -3568,8 +2827,8 @@
         "contexts": [
           "ollama-gpu1",
           "ollama.service/zz-gpu0-visible-device.conf",
-          "ollama-finetune",
-          "ollama-gpu1.service/zz-gpu1-visible-device.conf"
+          "ollama-gpu1.service/zz-gpu1-visible-device.conf",
+          "ollama-finetune"
         ]
       },
       "PYTORCH_CUDA_ALLOC_CONF": {
@@ -3599,6 +2858,15 @@
           "ollama_gpu_coordinator"
         ]
       },
+      "OLLAMA_NAS_RAM_EXPORTER_HOST": {
+        "name": "OLLAMA_NAS_RAM_EXPORTER_HOST",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
       "GPU_COORD_PORT": {
         "name": "GPU_COORD_PORT",
         "type": "string",
@@ -3614,13 +2882,67 @@
         "source": "systemd",
         "value": "10",
         "contexts": [
-          "ollama-gpu-coordinator",
           "ollama-gpu-coordinator.service/zz-dual-gpu-routing.conf",
+          "ollama-gpu-coordinator",
           "ollama-gpu-coordinator.service/busy-wait.conf"
         ]
       },
       "GPU_COORD_REQUEST_TIMEOUT_SEC": {
         "name": "GPU_COORD_REQUEST_TIMEOUT_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_SOFT_PIN": {
+        "name": "GPU_COORD_SOFT_PIN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_SOFT_PIN_BUSY": {
+        "name": "GPU_COORD_SOFT_PIN_BUSY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_AUX_MAX_VRAM_MB": {
+        "name": "GPU_COORD_AUX_MAX_VRAM_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_RAM_MARGIN_MB": {
+        "name": "GPU_COORD_NAS_RAM_MARGIN_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_RAM_MODEL_OVERHEAD_MB": {
+        "name": "GPU_COORD_NAS_RAM_MODEL_OVERHEAD_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_MIN_FREE_RAM_MB": {
+        "name": "GPU_COORD_NAS_MIN_FREE_RAM_MB",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -3738,10 +3060,10 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "ollama.service/zz-concurrency-limit.conf",
           "ollama-gpu1",
-          "ollama.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/ollama-optimized.conf",
+          "ollama.service/zz-concurrency-limit.conf",
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OLLAMA_MAX_LOADED_MODELS": {
@@ -3750,14 +3072,14 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "ollama-gpu1",
-          "ollama-gpu1.service/zzzz-idle-power.conf",
-          "ollama.service/ollama-optimized.conf",
-          "ollama.service/zzzz-idle-power.conf",
-          "ollama.service/zzzzz-idle-power-final.conf",
-          "ollama.service/zzzz-warmup-curl.conf",
           "ollama.service/zzz-dual-model.conf",
+          "ollama.service/zzzzz-idle-power-final.conf",
+          "ollama-gpu1",
+          "ollama.service/zzzz-idle-power.conf",
+          "ollama-gpu1.service/zzzz-idle-power.conf",
+          "ollama.service/zzzz-warmup-curl.conf",
           "ollama-gpu1.service/zzzzz-idle-power-final.conf",
+          "ollama.service/ollama-optimized.conf",
           "ollama-nas.service/zzzz-idle-power.conf"
         ]
       },
@@ -3796,10 +3118,10 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
           "ollama-gpu1",
+          "ollama.service/ollama-optimized.conf",
           "ollama-gpu1.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OLLAMA_NUM_THREADS": {
@@ -3808,10 +3130,10 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
           "ollama-gpu1",
+          "ollama.service/ollama-optimized.conf",
           "ollama-gpu1.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OMP_NUM_THREADS": {
@@ -3820,10 +3142,10 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
           "ollama-gpu1",
+          "ollama.service/ollama-optimized.conf",
           "ollama-gpu1.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OMP_THREAD_LIMIT": {
@@ -3832,9 +3154,9 @@
         "source": "systemd",
         "value": "2",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
+          "ollama.service/ollama-optimized.conf",
           "ollama-gpu1.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OLLAMA_WARM_MODEL_GPU0": {
@@ -3861,8 +3183,8 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/ollama-optimized.conf",
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OPENBLAS_NUM_THREADS": {
@@ -3871,8 +3193,8 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/ollama-optimized.conf",
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OMP_PROC_BIND": {
@@ -3908,8 +3230,8 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-perf-containment.conf",
-          "ollama.service/ollama-optimized.conf"
+          "ollama.service/ollama-optimized.conf",
+          "ollama.service/zz-perf-containment.conf"
         ]
       },
       "OLLAMA_SCHED_SPREAD": {
@@ -3927,8 +3249,8 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-concurrency-limit.conf",
-          "ollama.service/zz-perf-containment.conf"
+          "ollama.service/zz-perf-containment.conf",
+          "ollama.service/zz-concurrency-limit.conf"
         ]
       },
       "WAIT_SECONDS": {
@@ -4072,8 +3394,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tuya_token_selfheal",
           "tuya_local_key_selfheal",
+          "tuya_token_selfheal",
           "storj_payout_monitor",
           "iot_presence_watchdog"
         ]
@@ -4085,6 +3407,33 @@
         "value": null,
         "contexts": [
           "storj_payout_monitor"
+        ]
+      },
+      "DESTINATION": {
+        "name": "DESTINATION",
+        "type": "string",
+        "source": "systemd",
+        "value": "journald",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
+        ]
+      },
+      "RETENTION_DAYS": {
+        "name": "RETENTION_DAYS",
+        "type": "integer",
+        "source": "systemd",
+        "value": "7",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
+        ]
+      },
+      "MAX_FILE_SIZE_MB": {
+        "name": "MAX_FILE_SIZE_MB",
+        "type": "integer",
+        "source": "systemd",
+        "value": "100",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
         ]
       },
       "NARRATOR_STATE_FILE": {
@@ -4252,8 +3601,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "FT_EPOCHS": {
@@ -4262,10 +3611,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "SMTP_HOST": {
@@ -4274,8 +3623,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "email_nurturing",
           "user_management",
+          "email_nurturing",
           "storage_portal_api"
         ]
       },
@@ -4285,8 +3634,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "email_nurturing",
           "user_management",
+          "email_nurturing",
           "storage_portal_api"
         ]
       },
@@ -4326,8 +3675,21 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "email_nurturing",
           "user_management",
+          "email_nurturing",
+          "storage_portal_api"
+        ]
+      },
+      "NEXTCLOUD_URL": {
+        "name": "NEXTCLOUD_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "user_management",
+          "configure_authentik_nextcloud_oidc",
+          "nextcloud_agent",
+          "config",
           "storage_portal_api"
         ]
       },
@@ -4392,8 +3754,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "send1_loop",
-          "open_agent_log_terminal"
+          "open_agent_log_terminal",
+          "send1_loop"
         ]
       },
       "AGENTS_API": {
@@ -4402,11 +3764,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "telegram_bot",
           "coordinator",
           "list_agents",
-          "telegram_bot",
-          "whatsapp_bot",
-          "homelab_test"
+          "homelab_test",
+          "whatsapp_bot"
         ]
       },
       "OPENWEBUI_HOST": {
@@ -4415,8 +3777,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "openwebui_integration",
           "telegram_bot",
+          "openwebui_integration",
           "whatsapp_bot"
         ]
       },
@@ -4426,48 +3788,48 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_ssh_mcp",
-          "test_ai_interactive",
-          "install_function_webui",
-          "fix_director_model",
-          "test_embed",
-          "train_coordinator",
-          "index_new_knowledge",
-          "test_final",
-          "gmail_weekly_cleaner",
-          "update_rag_simple",
-          "test_assistant",
-          "generate_learning_evolution_graph",
-          "generate_learning_dashboard",
-          "fix_model",
-          "populate_grafana_dashboard",
-          "deploy_grafana_server_selector",
-          "test_github_agent",
-          "force_activate_persistent",
-          "ask_director_coordinator",
-          "test_endpoints_final",
-          "configure_diretor_model",
-          "telegram_bot",
-          "openwebui_agent_coordinator_function",
-          "recreate_printer_complete",
-          "test_ollama_quick",
-          "check_diretor_status",
-          "config",
-          "test_rpa_selenium",
-          "rag_dashboard",
-          "check_model",
-          "create_neural_dashboard",
-          "test_printer_function",
           "ui_smoke_tests",
-          "fix_diretor_model",
-          "test_llm_quick",
-          "web_search",
-          "install_printer_function",
-          "server_knowledge_generator",
+          "fix_model",
+          "test_final",
+          "recreate_printer_complete",
+          "update_rag_simple",
           "extract_and_train",
           "diagnose_phomemo_connection",
+          "test_embed",
+          "install_printer_function",
+          "test_ollama_quick",
+          "server_knowledge_generator",
+          "test_printer_function",
+          "test_ai_interactive",
+          "check_model",
+          "web_search",
+          "test_endpoints_final",
+          "openwebui_agent_coordinator_function",
+          "index_new_knowledge",
+          "deploy_grafana_server_selector",
+          "ask_director_coordinator",
+          "generate_learning_evolution_graph",
+          "test_llm_quick",
+          "create_neural_dashboard",
+          "rag_dashboard",
+          "install_function_webui",
+          "config",
+          "force_activate_persistent",
           "test_ollama_create",
-          "control_panel"
+          "test_ssh_mcp",
+          "control_panel",
+          "telegram_bot",
+          "populate_grafana_dashboard",
+          "configure_diretor_model",
+          "fix_director_model",
+          "train_coordinator",
+          "gmail_weekly_cleaner",
+          "check_diretor_status",
+          "test_github_agent",
+          "test_assistant",
+          "test_rpa_selenium",
+          "generate_learning_dashboard",
+          "fix_diretor_model"
         ]
       },
       "RAG_API": {
@@ -4476,11 +3838,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "web_search",
+          "telegram_bot",
           "train_coordinator",
-          "index_new_knowledge",
           "rag_dashboard",
-          "telegram_bot"
+          "web_search",
+          "index_new_knowledge"
         ]
       },
       "DEPLOY_HOST": {
@@ -4570,8 +3932,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_btc_secrets_helper",
           "secret_store",
+          "test_btc_secrets_helper",
           "secrets_helper"
         ]
       },
@@ -4618,17 +3980,6 @@
         "value": null,
         "contexts": [
           "wiki_refactor"
-        ]
-      },
-      "TG_BOT_T": {
-        "name": "TG_BOT_T",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "approval_gateway",
-          "alert_digest_agent",
-          "pre_tool_guardrails"
         ]
       },
       "TG_BOT_CHAT": {
@@ -4687,12 +4038,42 @@
           "nextcloud_agent"
         ]
       },
+      "NEXTCLOUD_ADMIN_USER": {
+        "name": "NEXTCLOUD_ADMIN_USER",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_CONTAINER": {
+        "name": "NEXTCLOUD_CONTAINER",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
+          "nextcloud_agent"
+        ]
+      },
       "NEXTCLOUD_CONTAINER_CANDIDATES": {
         "name": "NEXTCLOUD_CONTAINER_CANDIDATES",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_TIMEOUT": {
+        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
           "nextcloud_agent"
         ]
       },
@@ -4734,6 +4115,15 @@
       },
       "WG_PEER_RANGE_END": {
         "name": "WG_PEER_RANGE_END",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_BRUTE_FORCE_ALLOWLIST": {
+        "name": "NEXTCLOUD_BRUTE_FORCE_ALLOWLIST",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -5012,6 +4402,33 @@
           "config"
         ]
       },
+      "NEXTCLOUD_AGENT_ENABLED": {
+        "name": "NEXTCLOUD_AGENT_ENABLED",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_GPU": {
+        "name": "NEXTCLOUD_OLLAMA_GPU",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_DEFAULT_DRY_RUN": {
+        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
       "REMOTE_ORCHESTRATOR_ENABLED": {
         "name": "REMOTE_ORCHESTRATOR_ENABLED",
         "type": "string",
@@ -5027,9 +4444,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "populate_grafana_dashboard",
+          "config",
           "deploy_grafana_server_selector",
-          "config"
+          "populate_grafana_dashboard"
         ]
       },
       "HOMELAB_BASE_DIR": {
@@ -5221,8 +4638,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "LLM_GPU0_HOST": {
@@ -5231,8 +4648,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "LLM_GPU1_HOST": {
@@ -5241,8 +4658,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "LLM_NAS_HOST": {
@@ -5251,8 +4668,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "OLLAMA_STRUCTURED_CROSS_MODEL_FALLBACK": {
@@ -5315,8 +4732,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "secrets_helper",
-          "kucoin_api"
+          "kucoin_api",
+          "secrets_helper"
         ]
       },
       "OLLAMA_SELL_NOTIFY_MODEL": {
@@ -5334,10 +4751,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "streamlit_app",
-          "run_diretor_service",
+          "run_coordinator_service",
           "eddie_whatsapp_exporter",
-          "run_coordinator_service"
+          "streamlit_app",
+          "run_diretor_service"
         ]
       },
       "COORDINATOR_SPLIT_TIMEOUT_SECONDS": {
@@ -5546,8 +4963,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "patch_ai_plans_profile",
-          "ha_grafana_sync"
+          "ha_grafana_sync",
+          "patch_ai_plans_profile"
         ]
       },
       "PGPORT": {
@@ -5556,8 +4973,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "patch_ai_plans_profile",
-          "ha_grafana_sync"
+          "ha_grafana_sync",
+          "patch_ai_plans_profile"
         ]
       },
       "PGUSER": {
@@ -5566,8 +4983,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "patch_ai_plans_profile",
-          "ha_grafana_sync"
+          "ha_grafana_sync",
+          "patch_ai_plans_profile"
         ]
       },
       "ZTE_USER": {
@@ -5576,8 +4993,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "zte_wg_portforward",
-          "zte_akash_portforward"
+          "zte_akash_portforward",
+          "zte_wg_portforward"
         ]
       },
       "ZTE_PASS": {
@@ -5586,8 +5003,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "zte_wg_portforward",
-          "zte_akash_portforward"
+          "zte_akash_portforward",
+          "zte_wg_portforward"
         ]
       },
       "DEV_SITE_PORT": {
@@ -5605,11 +5022,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "capture_streamlit_screenshot",
+          "run_headless_ui_test",
           "playwright_click_and_check",
           "test_rpa_selenium",
-          "github_agent_server",
-          "run_headless_ui_test",
-          "capture_streamlit_screenshot"
+          "github_agent_server"
         ]
       },
       "INTERCEPTOR_API": {
@@ -5628,8 +5045,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "run_headless_ui_test",
-          "playwright_click_and_check"
+          "playwright_click_and_check",
+          "run_headless_ui_test"
         ]
       },
       "ROUTER_URL": {
@@ -5638,8 +5055,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "router_network_config",
-          "router_udp_port_forward"
+          "router_udp_port_forward",
+          "router_network_config"
         ]
       },
       "ROUTER_USER": {
@@ -5693,10 +5110,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_DATASET_DIR": {
@@ -5705,10 +5122,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_OUTPUT_DIR": {
@@ -5717,10 +5134,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_MAX_SEQ": {
@@ -5729,10 +5146,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_BATCH": {
@@ -5741,10 +5158,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_GRAD_ACCUM": {
@@ -5753,10 +5170,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_LORA_RANK": {
@@ -5765,10 +5182,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_LORA_ALPHA": {
@@ -5777,10 +5194,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_LR": {
@@ -5789,10 +5206,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_WARMUP": {
@@ -5801,10 +5218,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_MIN_SAMPLES": {
@@ -5813,10 +5230,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "trading_analyst_finetune_batch",
+          "eddie_persona_finetune_peft",
           "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "whatsapp_toolcall_finetune_peft",
+          "trading_analyst_finetune_batch"
         ]
       },
       "FT_SAVE_STEPS": {
@@ -5825,8 +5242,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "FT_SAVE_TOTAL_LIMIT": {
@@ -5835,8 +5252,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "NEXTCLOUD_BASE_URL": {
@@ -5873,8 +5290,8 @@
         "value": null,
         "contexts": [
           "trading_analyst_rollout_report",
-          "trading_analyst_finetune_batch",
-          "trading_analyst_shadow_eval"
+          "trading_analyst_shadow_eval",
+          "trading_analyst_finetune_batch"
         ]
       },
       "SHARED_AGENTS_API": {
@@ -5883,8 +5300,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "list_agents",
-          "homelab_test"
+          "homelab_test",
+          "list_agents"
         ]
       },
       "DAILY_AGENDA_ARTIFACTS_DIR": {
@@ -5902,8 +5319,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_LOG_JSON_TAIL": {
@@ -5912,8 +5329,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_LOG_FLUSH_SECONDS": {
@@ -5922,8 +5339,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_STALE_SECONDS": {
@@ -5977,9 +5394,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "llm_compatibility",
           "llm_system_demo",
-          "process_all_messages_from_tmp",
-          "llm_compatibility"
+          "process_all_messages_from_tmp"
         ]
       },
       "WAHA_MESSAGES_PER_CHAT": {
@@ -6107,8 +5524,8 @@
         "value": null,
         "contexts": [
           "capture_streamlit_screenshot",
-          "github_agent_server",
-          "set_interceptor_url"
+          "set_interceptor_url",
+          "github_agent_server"
         ]
       },
       "STREAMLIT_SCREENSHOT_OUT": {
@@ -6155,9 +5572,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ltfs_recovery",
           "tape_manager",
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "tape_orchestrator"
         ]
       },
       "LTFS_MEDIUM_WAIT_TIMEOUT": {
@@ -6184,9 +5601,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ltfs_recovery",
           "tape_manager",
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "tape_orchestrator"
         ]
       },
       "PORTAL_URL": {
@@ -6268,8 +5685,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "telegram_mcp_server",
-          "secrets_loader"
+          "secrets_loader",
+          "telegram_mcp_server"
         ]
       },
       "DAILY_AGENDA_PANEL_URL": {
@@ -6334,6 +5751,43 @@
         "value": null,
         "contexts": [
           "ollama_gpu_selfheal"
+        ]
+      },
+      "LTFS_JOURNAL_DIR": {
+        "name": "LTFS_JOURNAL_DIR",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_checkpoint_writer",
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_REPLICA_EXTRA": {
+        "name": "JRNL_REPLICA_EXTRA",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_RSYNC_OPTS": {
+        "name": "JRNL_RSYNC_OPTS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_DRY_RUN": {
+        "name": "JRNL_DRY_RUN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
         ]
       },
       "COORD_POLL_INTERVAL": {
@@ -6516,33 +5970,6 @@
           "ollama_gpu_coordinator"
         ]
       },
-      "GPU_COORD_AUX_MAX_VRAM_MB": {
-        "name": "GPU_COORD_AUX_MAX_VRAM_MB",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_SOFT_PIN": {
-        "name": "GPU_COORD_SOFT_PIN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_SOFT_PIN_BUSY": {
-        "name": "GPU_COORD_SOFT_PIN_BUSY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
       "GPU_COORD_PG_DSN": {
         "name": "GPU_COORD_PG_DSN",
         "type": "string",
@@ -6558,9 +5985,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ha_grafana_sync",
           "tuya_local_key_selfheal",
-          "tuya_token_selfheal",
-          "ha_grafana_sync"
+          "tuya_token_selfheal"
         ]
       },
       "EDDIE_API_URL": {
@@ -6597,9 +6024,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "evoke_handler",
           "diretor_latency_exporter",
-          "app",
-          "evoke_handler"
+          "app"
         ]
       },
       "POLL": {
@@ -6890,8 +6317,8 @@
           "ltfs_checkpoint_writer"
         ]
       },
-      "LTFS_JOURNAL_DIR": {
-        "name": "LTFS_JOURNAL_DIR",
+      "GLOBAL_TAPE_LOCK_TIMEOUT": {
+        "name": "GLOBAL_TAPE_LOCK_TIMEOUT",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -6951,8 +6378,8 @@
         "value": null,
         "contexts": [
           "report_test_to_diretor",
-          "auto_validate_redirect",
-          "capture_login_playwright"
+          "capture_login_playwright",
+          "auto_validate_redirect"
         ]
       },
       "SAFE_MIGRATE_LOG": {
@@ -6970,8 +6397,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_orchestrator",
-          "tape_safe_eject"
+          "tape_safe_eject",
+          "tape_orchestrator"
         ]
       },
       "LTFS_DEBUG": {
@@ -7125,8 +6552,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "ltfs_recovery",
+          "tape_orchestrator"
         ]
       },
       "MKLTFS_BIN": {
@@ -7144,8 +6571,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "ltfs_recovery",
+          "tape_orchestrator"
         ]
       },
       "LTFS_BACKGROUND_UNITS": {
@@ -7298,18 +6725,18 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "fix_diretor_model",
           "install_printer_function",
-          "check_diretor_status",
-          "fix_director_model",
-          "install_copilot_function",
-          "test_final",
-          "github_agent_server",
-          "install_terminal_function",
           "fix_model",
-          "configure_diretor_model",
           "install_whatsapp_function",
-          "screenshot_openwebui"
+          "test_final",
+          "fix_director_model",
+          "screenshot_openwebui",
+          "install_copilot_function",
+          "install_terminal_function",
+          "check_diretor_status",
+          "configure_diretor_model",
+          "github_agent_server",
+          "fix_diretor_model"
         ]
       },
       "VALIDATOR_CHECK_PHRASE": {
@@ -7408,13 +6835,13 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "install_ocr_function",
           "recreate_printer_complete",
+          "install_webui_function_api",
+          "test_printer_function",
+          "install_ocr_function",
           "install_function_webui",
           "webui_function_manager",
-          "force_activate_persistent",
-          "install_webui_function_api",
-          "test_printer_function"
+          "force_activate_persistent"
         ]
       },
       "WEBUI_EMAIL": {
@@ -7423,8 +6850,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_webui_install",
           "install_ocr_function",
+          "test_webui_install",
           "install_webui_function_api"
         ]
       },
@@ -7601,6 +7028,15 @@
           "pre_tool_guardrails"
         ]
       },
+      "TG_BOT_T": {
+        "name": "TG_BOT_T",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "pre_tool_guardrails"
+        ]
+      },
       "TUYA_ZERO_ACTIVE_RETRIES": {
         "name": "TUYA_ZERO_ACTIVE_RETRIES",
         "type": "string",
@@ -7625,22 +7061,22 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_llm_quick",
-          "extract_whatsapp_train",
-          "test_ai_interactive",
-          "test_embed",
-          "extract_and_train",
-          "test_final",
-          "nas_ai_assessor",
-          "gmail_weekly_cleaner",
-          "check_model",
-          "update_rag_simple",
-          "test_sell_target_backtest",
-          "test_assistant",
-          "generate_learning_evolution_graph",
-          "generate_learning_dashboard",
           "test_ollama_create",
-          "openwebui_agent_coordinator_function"
+          "generate_learning_evolution_graph",
+          "test_final",
+          "test_llm_quick",
+          "test_ai_interactive",
+          "check_model",
+          "gmail_weekly_cleaner",
+          "extract_whatsapp_train",
+          "openwebui_agent_coordinator_function",
+          "update_rag_simple",
+          "test_assistant",
+          "extract_and_train",
+          "test_sell_target_backtest",
+          "test_embed",
+          "nas_ai_assessor",
+          "generate_learning_dashboard"
         ]
       },
       "REQUEST_TIMEOUT_SECONDS": {
@@ -7652,14 +7088,131 @@
           "nas_ai_assessor"
         ]
       },
+      "PVPN_IFACE": {
+        "name": "PVPN_IFACE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_CONF": {
+        "name": "PVPN_CONF",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_CANDIDATES": {
+        "name": "PVPN_CANDIDATES",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_STATE": {
+        "name": "PVPN_STATE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_METRICS": {
+        "name": "PVPN_METRICS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_MIN_GAIN_PCT": {
+        "name": "PVPN_MIN_GAIN_PCT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_MIN_DWELL_SEC": {
+        "name": "PVPN_MIN_DWELL_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_PING_COUNT": {
+        "name": "PVPN_PING_COUNT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_PING_FWMARK": {
+        "name": "PVPN_PING_FWMARK",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_HANDSHAKE_TIMEOUT_SEC": {
+        "name": "PVPN_HANDSHAKE_TIMEOUT_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_LOSS_PENALTY_MS": {
+        "name": "PVPN_LOSS_PENALTY_MS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PARTIAL_DEGRADED_MIN_MISSING": {
+        "name": "PARTIAL_DEGRADED_MIN_MISSING",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "tuya_token_selfheal"
+        ]
+      },
+      "PARTIAL_DEGRADED_STREAK_THRESHOLD": {
+        "name": "PARTIAL_DEGRADED_STREAK_THRESHOLD",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "tuya_token_selfheal"
+        ]
+      },
       "GROK_SESSION_ID": {
         "name": "GROK_SESSION_ID",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
-          "web_agent_live_log",
-          "open_agent_log_terminal"
+          "open_agent_log_terminal",
+          "web_agent_live_log"
         ]
       },
       "ALLOW_INCOMPLETE": {
@@ -7992,8 +7545,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "rss_llm_trainer",
-          "extract_and_train"
+          "extract_and_train",
+          "rss_llm_trainer"
         ]
       },
       "AGENT_CHAT_URL": {
@@ -8056,13 +7609,13 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "recreate_printer_complete",
-          "generate_learning_dashboard",
-          "force_activate_persistent",
-          "server_knowledge_generator",
-          "diagnose_phomemo_connection",
           "generate_learning_evolution_graph",
-          "test_endpoints_final"
+          "server_knowledge_generator",
+          "recreate_printer_complete",
+          "test_endpoints_final",
+          "diagnose_phomemo_connection",
+          "force_activate_persistent",
+          "generate_learning_dashboard"
         ]
       },
       "WAHA_SESSION": {
@@ -8072,8 +7625,8 @@
         "value": null,
         "contexts": [
           "wait_and_run_whatsapp_test",
-          "extract_whatsapp_train",
-          "test_whatsapp"
+          "test_whatsapp",
+          "extract_whatsapp_train"
         ]
       },
       "MYCLAUDE_ROOT": {
@@ -8083,6 +7636,16 @@
         "value": null,
         "contexts": [
           "test_calculadora"
+        ]
+      },
+      "LINKEDIN_EMAIL": {
+        "name": "LINKEDIN_EMAIL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "linkedin_content_purger",
+          "linkedin_job_scanner"
         ]
       },
       "LLM_TIMEOUT": {
@@ -8318,15 +7881,6 @@
         "value": null,
         "contexts": [
           "compatibility_semantic"
-        ]
-      },
-      "LINKEDIN_EMAIL": {
-        "name": "LINKEDIN_EMAIL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "linkedin_job_scanner"
         ]
       },
       "MISSING_METRICS_PORT": {
@@ -8695,14 +8249,15 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_INTERVAL": {
@@ -8711,14 +8266,15 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_EXPR": {
@@ -8727,13 +8283,14 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_FOR": {
@@ -8742,14 +8299,15 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SEVERITY": {
@@ -8758,14 +8316,15 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_COMPONENT": {
@@ -8775,8 +8334,9 @@
         "value": "rpa4all-snapshot",
         "contexts": [
           "ollama_coord_error_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "gpu_coord_failover_rules",
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_SUMMARY": {
@@ -8785,14 +8345,15 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -8801,14 +8362,15 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -8835,13 +8397,14 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_FOR": {
@@ -8850,14 +8413,15 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_SEVERITY": {
@@ -8866,14 +8430,15 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_COMPONENT": {
@@ -8883,8 +8448,9 @@
         "value": "rpa4all-snapshot",
         "contexts": [
           "ollama_coord_error_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "gpu_coord_failover_rules",
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_SUMMARY": {
@@ -8893,14 +8459,15 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -8909,14 +8476,15 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
           "rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_ACTION": {
@@ -8943,10 +8511,11 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -8955,10 +8524,11 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -8968,10 +8538,11 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -8981,6 +8552,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -8990,10 +8562,11 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9003,10 +8576,11 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9025,10 +8599,11 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -9037,8 +8612,9 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -9049,8 +8625,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -9061,6 +8638,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9070,8 +8648,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -9082,8 +8661,9 @@
         "source": "yaml",
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -9103,8 +8683,9 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
-          "ltfs-selfheal-rules",
           "selfhealing_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9114,8 +8695,9 @@
         "source": "yaml",
         "value": "10m",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9125,8 +8707,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9136,6 +8719,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9145,8 +8729,9 @@
         "source": "yaml",
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9156,8 +8741,9 @@
         "source": "yaml",
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9176,6 +8762,7 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -9186,8 +8773,9 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9197,8 +8785,9 @@
         "source": "yaml",
         "value": "info",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9208,6 +8797,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9217,8 +8807,9 @@
         "source": "yaml",
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9228,8 +8819,9 @@
         "source": "yaml",
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
-          "ltfs-selfheal-rules",
           "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9248,8 +8840,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "GLOBAL_EVALUATION_INTERVAL": {
@@ -9258,8 +8850,8 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_0_JOB_NAME": {
@@ -9268,8 +8860,8 @@
         "source": "yaml",
         "value": "prometheus",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_JOB_NAME": {
@@ -9278,8 +8870,8 @@
         "source": "yaml",
         "value": "node-exporter",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_1_STATIC_CONFIGS_0_LABELS_INSTANCE": {
@@ -9297,8 +8889,8 @@
         "source": "yaml",
         "value": "cadvisor",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_2_SCRAPE_INTERVAL": {
@@ -9325,8 +8917,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_INTERVAL": {
@@ -9335,8 +8927,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_SCRAPE_TIMEOUT": {
@@ -9354,8 +8946,8 @@
         "source": "yaml",
         "value": "btc_usdt_conservative",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_3_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -9382,8 +8974,8 @@
         "source": "yaml",
         "value": "crypto-exporter-btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_INTERVAL": {
@@ -9392,8 +8984,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_SCRAPE_TIMEOUT": {
@@ -9411,8 +9003,8 @@
         "source": "yaml",
         "value": "btc_usdt_aggressive",
         "contexts": [
-          "prometheus-config",
-          "prometheus"
+          "prometheus",
+          "prometheus-config"
         ]
       },
       "SCRAPE_CONFIGS_4_STATIC_CONFIGS_0_LABELS_PROFILE": {
@@ -10384,9 +9976,9 @@
         "source": "yaml",
         "value": "trading_agent_alerts",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_INTERVAL": {
@@ -10395,9 +9987,9 @@
         "source": "yaml",
         "value": "15s",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_EXPR": {
@@ -10406,8 +9998,8 @@
         "source": "yaml",
         "value": "trading_agent_up == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_0_FOR": {
@@ -10416,9 +10008,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_SEVERITY": {
@@ -10427,9 +10019,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_LABELS_COMPONENT": {
@@ -10447,9 +10039,9 @@
         "source": "yaml",
         "value": "\ud83d\udd34 Trading Agent {{ $labels.symbol }} DOWN",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DESCRIPTION": {
@@ -10458,9 +10050,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} \u00e9 est\u00e1 inativo por mais de 3 minutos. Systemd unit pode estar crashed.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_0_ANNOTATIONS_DASHBOARD": {
@@ -10478,8 +10070,8 @@
         "source": "yaml",
         "value": "trading_agent_stalled == 1",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_FOR": {
@@ -10488,9 +10080,9 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_SEVERITY": {
@@ -10499,9 +10091,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_LABELS_COMPONENT": {
@@ -10519,9 +10111,9 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f Trading Agent {{ $labels.symbol }} STALLED",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DESCRIPTION": {
@@ -10530,9 +10122,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00f5es por mais de 5 minutos. Poss\u00edvel deadlock na DB ou timeout na API KuCoin.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_1_ANNOTATIONS_DASHBOARD": {
@@ -10550,8 +10142,8 @@
         "source": "yaml",
         "value": "trading_agent_last_decision_age_seconds > 900",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_FOR": {
@@ -10560,9 +10152,9 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_SEVERITY": {
@@ -10571,9 +10163,9 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_LABELS_COMPONENT": {
@@ -10591,9 +10183,9 @@
         "source": "yaml",
         "value": "\u23f3 Trading Agent {{ $labels.symbol }} \u2014 Decisions Gap 15+ min",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -10602,9 +10194,9 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} n\u00e3o gerou decis\u00e3o h\u00e1 {{ $value | humanizeDuration }}. Self-heal pode executar restart.",
         "contexts": [
-          "rules",
+          "selfhealing_rules",
           "alert_rules",
-          "selfhealing_rules"
+          "rules"
         ]
       },
       "GROUPS_1_RULES_3_EXPR": {
@@ -10613,8 +10205,8 @@
         "source": "yaml",
         "value": "trading_agent_consecutive_failures > 6",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_FOR": {
@@ -10623,8 +10215,8 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_SEVERITY": {
@@ -10633,8 +10225,8 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_LABELS_COMPONENT": {
@@ -10652,8 +10244,8 @@
         "source": "yaml",
         "value": "\ud83d\udea8 Trading Agent {{ $labels.symbol }} \u2014 Self-Heal FAILED",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -10662,8 +10254,8 @@
         "source": "yaml",
         "value": "Agent {{ $labels.symbol }} failed health checks {{ $value | humanize }} times. Auto-restart n\u00e3o conseguiu recuperar. Interven\u00e7\u00e3o manual necess\u00e1ria.",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -10690,8 +10282,8 @@
         "source": "yaml",
         "value": "up{job=\"crypto-exporters\"} == 0",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_FOR": {
@@ -10754,8 +10346,8 @@
         "source": "yaml",
         "value": "increase(trading_selfheal_actions_total{action=\"ollama_error\"}[1h]) > 5",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_5_FOR": {
@@ -10818,8 +10410,8 @@
         "source": "yaml",
         "value": "rate(trading_agent_restart_total[1h]) > 3",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_6_FOR": {
@@ -11026,8 +10618,8 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_RECEIVER": {
@@ -11036,8 +10628,8 @@
         "source": "yaml",
         "value": "default",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_GROUP_WAIT": {
@@ -11046,8 +10638,8 @@
         "source": "yaml",
         "value": "10s",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_GROUP_INTERVAL": {
@@ -11056,8 +10648,8 @@
         "source": "yaml",
         "value": "10s",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_REPEAT_INTERVAL": {
@@ -11066,8 +10658,8 @@
         "source": "yaml",
         "value": "12h",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_0_MATCH_CATEGORY": {
@@ -11085,8 +10677,8 @@
         "source": "yaml",
         "value": "telegram",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_0_CONTINUE": {
@@ -11095,8 +10687,8 @@
         "source": "yaml",
         "value": "True",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_1_RECEIVER": {
@@ -11105,8 +10697,8 @@
         "source": "yaml",
         "value": "telegram-webhook",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_1_GROUP_WAIT": {
@@ -11115,8 +10707,8 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_1_GROUP_INTERVAL": {
@@ -11125,8 +10717,8 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_1_REPEAT_INTERVAL": {
@@ -11135,8 +10727,8 @@
         "source": "yaml",
         "value": "1h",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_2_MATCH_CATEGORY": {
@@ -11154,8 +10746,8 @@
         "source": "yaml",
         "value": "telegram-webhook",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "ROUTE_ROUTES_2_CONTINUE": {
@@ -11308,8 +10900,8 @@
         "source": "yaml",
         "value": "default",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "RECEIVERS_1_NAME": {
@@ -11318,8 +10910,8 @@
         "source": "yaml",
         "value": "estou-aqui",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "RECEIVERS_2_NAME": {
@@ -11328,8 +10920,8 @@
         "source": "yaml",
         "value": "telegram",
         "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
+          "alertmanager.production",
+          "alertmanager_telegram"
         ]
       },
       "RECEIVERS_3_NAME": {
@@ -11556,9 +11148,9 @@
         "source": "yaml",
         "value": "ollama",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules",
           "ollama_coord_error_rules",
+          "rules",
+          "ltfs-selfheal-rules",
           "gpu_coord_failover_rules"
         ]
       },
@@ -11568,9 +11160,9 @@
         "source": "yaml",
         "value": "ollama",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules",
           "ollama_coord_error_rules",
+          "rules",
+          "ltfs-selfheal-rules",
           "gpu_coord_failover_rules"
         ]
       },
@@ -11580,8 +11172,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -11590,8 +11182,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -11600,8 +11192,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -11610,8 +11202,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -11620,6 +11212,7 @@
         "source": "yaml",
         "value": "up{job=\"nas-node-exporter\",instance=\"rpa4all-nas-001\"} == 0",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -11629,8 +11222,9 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -11639,8 +11233,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -11649,8 +11244,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -11659,8 +11254,9 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -11669,8 +11265,9 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SERVICE": {
@@ -11697,11 +11294,11 @@
         "source": "yaml",
         "value": "1",
         "contexts": [
-          "authentik-http",
-          "datasources",
-          "rules",
-          "contactpoints",
           "policies",
+          "datasources",
+          "contactpoints",
+          "rules",
+          "authentik-http",
           "dashboards"
         ]
       },
@@ -14868,7 +14465,7 @@
         "name": "GROUPS_2_RULES_0_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-agent-down",
+        "value": "alert-btc-loop-error",
         "contexts": [
           "rules"
         ]
@@ -14877,7 +14474,7 @@
         "name": "GROUPS_2_RULES_0_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC Trading Agent Down",
+        "value": "BTC Trading Agent Loop Error",
         "contexts": [
           "rules"
         ]
@@ -14904,7 +14501,7 @@
         "name": "GROUPS_2_RULES_0_DATA_0_RELATIVETIMERANGE_FROM",
         "type": "integer",
         "source": "yaml",
-        "value": "300",
+        "value": "600",
         "contexts": [
           "rules"
         ]
@@ -14931,7 +14528,7 @@
         "name": "GROUPS_2_RULES_0_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "btc_trading_agent_running",
+        "value": "btc_trading_loop_errors_5m",
         "contexts": [
           "rules"
         ]
@@ -14967,7 +14564,7 @@
         "name": "GROUPS_2_RULES_0_DATA_1_RELATIVETIMERANGE_FROM",
         "type": "integer",
         "source": "yaml",
-        "value": "300",
+        "value": "600",
         "contexts": [
           "rules"
         ]
@@ -15039,7 +14636,7 @@
         "name": "GROUPS_2_RULES_0_DATA_2_RELATIVETIMERANGE_FROM",
         "type": "integer",
         "source": "yaml",
-        "value": "300",
+        "value": "600",
         "contexts": [
           "rules"
         ]
@@ -15084,7 +14681,7 @@
         "name": "GROUPS_2_RULES_0_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "lt",
+        "value": "gt",
         "contexts": [
           "rules"
         ]
@@ -15107,8 +14704,8 @@
           "rules"
         ]
       },
-      "GROUPS_2_RULES_0_DATA_2_MODEL_EXPRESSION": {
-        "name": "GROUPS_2_RULES_0_DATA_2_MODEL_EXPRESSION",
+      "GROUPS_2_RULES_0_DATA_2_MODEL_CONDITIONS_0_EXPRESSION": {
+        "name": "GROUPS_2_RULES_0_DATA_2_MODEL_CONDITIONS_0_EXPRESSION",
         "type": "string",
         "source": "yaml",
         "value": "B",
@@ -15120,7 +14717,7 @@
         "name": "GROUPS_2_RULES_0_FOR",
         "type": "string",
         "source": "yaml",
-        "value": "3m",
+        "value": "1m",
         "contexts": [
           "rules"
         ]
@@ -15147,7 +14744,7 @@
         "name": "GROUPS_2_RULES_0_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "Trading agent BTC est\u00e1 OFFLINE h\u00e1 mais de 3 minutos",
+        "value": "Trading agent BTC em crash loop ({{ $labels.profile }})",
         "contexts": [
           "rules"
         ]
@@ -15156,7 +14753,7 @@
         "name": "GROUPS_2_RULES_0_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "O agente de trading BTC parou de reportar m\u00e9tricas. Verificar systemd: sudo systemctl status btc-trading-agent",
+        "value": "Detectados erros de loop nos \u00faltimos 5 min. Verificar: journalctl -u crypto-agent@BTC_USDT_{{ $labels.profile }} -n 50",
         "contexts": [
           "rules"
         ]
@@ -15183,7 +14780,7 @@
         "name": "GROUPS_2_RULES_1_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-pnl-loss",
+        "value": "alert-btc-agent-down",
         "contexts": [
           "rules"
         ]
@@ -15192,7 +14789,7 @@
         "name": "GROUPS_2_RULES_1_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC PnL 24h Negativo (> -5%)",
+        "value": "BTC Trading Agent Down",
         "contexts": [
           "rules"
         ]
@@ -15246,7 +14843,7 @@
         "name": "GROUPS_2_RULES_1_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "btc_trading_cumulative_pnl_24h",
+        "value": "btc_trading_agent_running",
         "contexts": [
           "rules"
         ]
@@ -15435,7 +15032,7 @@
         "name": "GROUPS_2_RULES_1_FOR",
         "type": "string",
         "source": "yaml",
-        "value": "5m",
+        "value": "3m",
         "contexts": [
           "rules"
         ]
@@ -15462,7 +15059,7 @@
         "name": "GROUPS_2_RULES_1_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "PnL 24h do BTC est\u00e1 abaixo de -5%",
+        "value": "Trading agent BTC est\u00e1 OFFLINE h\u00e1 mais de 3 minutos",
         "contexts": [
           "rules"
         ]
@@ -15471,7 +15068,7 @@
         "name": "GROUPS_2_RULES_1_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "O PnL acumulado nas \u00faltimas 24h est\u00e1 {{ $values.A }}%. Considerar pausar o agente.",
+        "value": "O agente de trading BTC parou de reportar m\u00e9tricas. Verificar systemd: sudo systemctl status btc-trading-agent",
         "contexts": [
           "rules"
         ]
@@ -15498,7 +15095,7 @@
         "name": "GROUPS_2_RULES_2_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-rsi-high",
+        "value": "alert-btc-pnl-loss",
         "contexts": [
           "rules"
         ]
@@ -15507,7 +15104,7 @@
         "name": "GROUPS_2_RULES_2_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC RSI Sobrecomprado (> 75)",
+        "value": "BTC PnL 24h Negativo (> -5%)",
         "contexts": [
           "rules"
         ]
@@ -15561,7 +15158,7 @@
         "name": "GROUPS_2_RULES_2_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "btc_trading_rsi",
+        "value": "btc_trading_cumulative_pnl_24h",
         "contexts": [
           "rules"
         ]
@@ -15714,7 +15311,7 @@
         "name": "GROUPS_2_RULES_2_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "gt",
+        "value": "lt",
         "contexts": [
           "rules"
         ]
@@ -15759,7 +15356,7 @@
         "name": "GROUPS_2_RULES_2_LABELS_SEVERITY",
         "type": "string",
         "source": "yaml",
-        "value": "warning",
+        "value": "critical",
         "contexts": [
           "rules"
         ]
@@ -15777,7 +15374,7 @@
         "name": "GROUPS_2_RULES_2_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "RSI do BTC est\u00e1 em zona de sobrecompra (> 75)",
+        "value": "PnL 24h do BTC est\u00e1 abaixo de -5%",
         "contexts": [
           "rules"
         ]
@@ -15786,7 +15383,7 @@
         "name": "GROUPS_2_RULES_2_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "RSI atual: {{ $values.A }}. Mercado pode estar sobrecomprado.",
+        "value": "O PnL acumulado nas \u00faltimas 24h est\u00e1 {{ $values.A }}%. Considerar pausar o agente.",
         "contexts": [
           "rules"
         ]
@@ -15813,7 +15410,7 @@
         "name": "GROUPS_2_RULES_3_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-rsi-low",
+        "value": "alert-btc-rsi-high",
         "contexts": [
           "rules"
         ]
@@ -15822,7 +15419,7 @@
         "name": "GROUPS_2_RULES_3_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC RSI Sobrevendido (< 25)",
+        "value": "BTC RSI Sobrecomprado (> 75)",
         "contexts": [
           "rules"
         ]
@@ -16029,7 +15626,7 @@
         "name": "GROUPS_2_RULES_3_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "lt",
+        "value": "gt",
         "contexts": [
           "rules"
         ]
@@ -16092,7 +15689,7 @@
         "name": "GROUPS_2_RULES_3_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "RSI do BTC est\u00e1 em zona de sobrevenda (< 25)",
+        "value": "RSI do BTC est\u00e1 em zona de sobrecompra (> 75)",
         "contexts": [
           "rules"
         ]
@@ -16101,7 +15698,7 @@
         "name": "GROUPS_2_RULES_3_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "RSI atual: {{ $values.A }}. Pode ser oportunidade de compra.",
+        "value": "RSI atual: {{ $values.A }}. Mercado pode estar sobrecomprado.",
         "contexts": [
           "rules"
         ]
@@ -16128,7 +15725,7 @@
         "name": "GROUPS_2_RULES_4_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-high-volatility",
+        "value": "alert-btc-rsi-low",
         "contexts": [
           "rules"
         ]
@@ -16137,7 +15734,7 @@
         "name": "GROUPS_2_RULES_4_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC Volatilidade Alta (> 5%)",
+        "value": "BTC RSI Sobrevendido (< 25)",
         "contexts": [
           "rules"
         ]
@@ -16191,7 +15788,7 @@
         "name": "GROUPS_2_RULES_4_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "btc_trading_volatility",
+        "value": "btc_trading_rsi",
         "contexts": [
           "rules"
         ]
@@ -16344,7 +15941,7 @@
         "name": "GROUPS_2_RULES_4_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "gt",
+        "value": "lt",
         "contexts": [
           "rules"
         ]
@@ -16380,7 +15977,7 @@
         "name": "GROUPS_2_RULES_4_FOR",
         "type": "string",
         "source": "yaml",
-        "value": "3m",
+        "value": "5m",
         "contexts": [
           "rules"
         ]
@@ -16407,7 +16004,7 @@
         "name": "GROUPS_2_RULES_4_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "Volatilidade do BTC acima de 5%",
+        "value": "RSI do BTC est\u00e1 em zona de sobrevenda (< 25)",
         "contexts": [
           "rules"
         ]
@@ -16416,7 +16013,7 @@
         "name": "GROUPS_2_RULES_4_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "Volatilidade atual: {{ $values.A }}%. Mercado inst\u00e1vel.",
+        "value": "RSI atual: {{ $values.A }}. Pode ser oportunidade de compra.",
         "contexts": [
           "rules"
         ]
@@ -16443,7 +16040,7 @@
         "name": "GROUPS_2_RULES_5_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-low-winrate",
+        "value": "alert-btc-high-volatility",
         "contexts": [
           "rules"
         ]
@@ -16452,7 +16049,7 @@
         "name": "GROUPS_2_RULES_5_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC Win Rate Baixo (abaixo de 40%)",
+        "value": "BTC Volatilidade Alta (> 5%)",
         "contexts": [
           "rules"
         ]
@@ -16506,7 +16103,7 @@
         "name": "GROUPS_2_RULES_5_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "btc_trading_win_rate{profile=~\"aggressive|conservative\"} * 100",
+        "value": "btc_trading_volatility",
         "contexts": [
           "rules"
         ]
@@ -16659,7 +16256,7 @@
         "name": "GROUPS_2_RULES_5_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "lt",
+        "value": "gt",
         "contexts": [
           "rules"
         ]
@@ -16695,7 +16292,7 @@
         "name": "GROUPS_2_RULES_5_FOR",
         "type": "string",
         "source": "yaml",
-        "value": "10m",
+        "value": "3m",
         "contexts": [
           "rules"
         ]
@@ -16722,7 +16319,7 @@
         "name": "GROUPS_2_RULES_5_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "Win rate do BTC no profile {{ $labels.profile }} est\u00e1 abaixo de 40%",
+        "value": "Volatilidade do BTC acima de 5%",
         "contexts": [
           "rules"
         ]
@@ -16731,7 +16328,7 @@
         "name": "GROUPS_2_RULES_5_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "Win rate atual: {{ $values.A }}%. Estrat\u00e9gia pode precisar de ajuste.",
+        "value": "Volatilidade atual: {{ $values.A }}%. Mercado inst\u00e1vel.",
         "contexts": [
           "rules"
         ]
@@ -16758,7 +16355,7 @@
         "name": "GROUPS_2_RULES_6_UID",
         "type": "string",
         "source": "yaml",
-        "value": "alert-btc-stop-loss",
+        "value": "alert-btc-low-winrate",
         "contexts": [
           "rules"
         ]
@@ -16767,7 +16364,7 @@
         "name": "GROUPS_2_RULES_6_TITLE",
         "type": "string",
         "source": "yaml",
-        "value": "BTC Stop Loss Ativado",
+        "value": "BTC Win Rate Baixo (abaixo de 40%)",
         "contexts": [
           "rules"
         ]
@@ -16821,7 +16418,7 @@
         "name": "GROUPS_2_RULES_6_DATA_0_MODEL_EXPR",
         "type": "string",
         "source": "yaml",
-        "value": "increase(btc_trading_exit_stop_loss[5m])",
+        "value": "btc_trading_win_rate{profile=~\"aggressive|conservative\"} * 100",
         "contexts": [
           "rules"
         ]
@@ -16974,7 +16571,7 @@
         "name": "GROUPS_2_RULES_6_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
         "type": "string",
         "source": "yaml",
-        "value": "gt",
+        "value": "lt",
         "contexts": [
           "rules"
         ]
@@ -17010,7 +16607,7 @@
         "name": "GROUPS_2_RULES_6_FOR",
         "type": "string",
         "source": "yaml",
-        "value": "0s",
+        "value": "10m",
         "contexts": [
           "rules"
         ]
@@ -17037,7 +16634,7 @@
         "name": "GROUPS_2_RULES_6_ANNOTATIONS_SUMMARY",
         "type": "string",
         "source": "yaml",
-        "value": "Stop Loss ativado no BTC!",
+        "value": "Win rate do BTC no profile {{ $labels.profile }} est\u00e1 abaixo de 40%",
         "contexts": [
           "rules"
         ]
@@ -17046,7 +16643,7 @@
         "name": "GROUPS_2_RULES_6_ANNOTATIONS_DESCRIPTION",
         "type": "string",
         "source": "yaml",
-        "value": "Um stop loss foi disparado nos \u00faltimos 5 minutos.",
+        "value": "Win rate atual: {{ $values.A }}%. Estrat\u00e9gia pode precisar de ajuste.",
         "contexts": [
           "rules"
         ]
@@ -17062,6 +16659,321 @@
       },
       "GROUPS_2_RULES_6_EXECERRSTATE": {
         "name": "GROUPS_2_RULES_6_EXECERRSTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_UID": {
+        "name": "GROUPS_2_RULES_7_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "alert-btc-stop-loss",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_TITLE": {
+        "name": "GROUPS_2_RULES_7_TITLE",
+        "type": "string",
+        "source": "yaml",
+        "value": "BTC Stop Loss Ativado",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_CONDITION": {
+        "name": "GROUPS_2_RULES_7_CONDITION",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_0_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_2_RULES_7_DATA_0_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_2_RULES_7_DATA_0_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_DATASOURCEUID": {
+        "name": "GROUPS_2_RULES_7_DATA_0_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "dfc0w4yioe4u8e",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_MODEL_EXPR": {
+        "name": "GROUPS_2_RULES_7_DATA_0_MODEL_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(btc_trading_exit_stop_loss[5m])",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_MODEL_INSTANT": {
+        "name": "GROUPS_2_RULES_7_DATA_0_MODEL_INSTANT",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_0_MODEL_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_0_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_1_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_2_RULES_7_DATA_1_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_2_RULES_7_DATA_1_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_DATASOURCEUID": {
+        "name": "GROUPS_2_RULES_7_DATA_1_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_MODEL_EXPRESSION": {
+        "name": "GROUPS_2_RULES_7_DATA_1_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_MODEL_REDUCER": {
+        "name": "GROUPS_2_RULES_7_DATA_1_MODEL_REDUCER",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_MODEL_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_1_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_1_MODEL_TYPE": {
+        "name": "GROUPS_2_RULES_7_DATA_1_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "reduce",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_2_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_2_RULES_7_DATA_2_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_2_RULES_7_DATA_2_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_DATASOURCEUID": {
+        "name": "GROUPS_2_RULES_7_DATA_2_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_TYPE": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "threshold",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_REFID": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "gt",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "and",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_DATA_2_MODEL_EXPRESSION": {
+        "name": "GROUPS_2_RULES_7_DATA_2_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_FOR": {
+        "name": "GROUPS_2_RULES_7_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0s",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_LABELS_SEVERITY": {
+        "name": "GROUPS_2_RULES_7_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_LABELS_CATEGORY": {
+        "name": "GROUPS_2_RULES_7_LABELS_CATEGORY",
+        "type": "string",
+        "source": "yaml",
+        "value": "trading",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_2_RULES_7_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Stop Loss ativado no BTC!",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_2_RULES_7_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Um stop loss foi disparado nos \u00faltimos 5 minutos.",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_NODATASTATE": {
+        "name": "GROUPS_2_RULES_7_NODATASTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_2_RULES_7_EXECERRSTATE": {
+        "name": "GROUPS_2_RULES_7_EXECERRSTATE",
         "type": "string",
         "source": "yaml",
         "value": "OK",
@@ -20642,6 +20554,1023 @@
           "rules"
         ]
       },
+      "GROUPS_6_ORGID": {
+        "name": "GROUPS_6_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_NAME": {
+        "name": "GROUPS_6_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "Infrastructure - Ollama GPU",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_FOLDER": {
+        "name": "GROUPS_6_FOLDER",
+        "type": "string",
+        "source": "yaml",
+        "value": "Eddie Alerts",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_INTERVAL": {
+        "name": "GROUPS_6_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "1m",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_UID": {
+        "name": "GROUPS_6_RULES_0_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "alert-ollama-selfheal-ratelimit",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_TITLE": {
+        "name": "GROUPS_6_RULES_0_TITLE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Ollama Selfheal Rate-Limited",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_ISPAUSED": {
+        "name": "GROUPS_6_RULES_0_ISPAUSED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "False",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_CONDITION": {
+        "name": "GROUPS_6_RULES_0_CONDITION",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_REFID": {
+        "name": "GROUPS_6_RULES_0_DATA_0_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_6_RULES_0_DATA_0_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "3600",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_6_RULES_0_DATA_0_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_DATASOURCEUID": {
+        "name": "GROUPS_6_RULES_0_DATA_0_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "dfc0w4yioe4u8e",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_MODEL_EXPR": {
+        "name": "GROUPS_6_RULES_0_DATA_0_MODEL_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "max(increase(ollama_gpu_selfheal_restarts_total[1h])) >= 3",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_MODEL_INSTANT": {
+        "name": "GROUPS_6_RULES_0_DATA_0_MODEL_INSTANT",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_0_MODEL_REFID": {
+        "name": "GROUPS_6_RULES_0_DATA_0_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_REFID": {
+        "name": "GROUPS_6_RULES_0_DATA_1_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_6_RULES_0_DATA_1_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_6_RULES_0_DATA_1_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_DATASOURCEUID": {
+        "name": "GROUPS_6_RULES_0_DATA_1_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_MODEL_EXPRESSION": {
+        "name": "GROUPS_6_RULES_0_DATA_1_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_MODEL_REDUCER": {
+        "name": "GROUPS_6_RULES_0_DATA_1_MODEL_REDUCER",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_MODEL_REFID": {
+        "name": "GROUPS_6_RULES_0_DATA_1_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_1_MODEL_TYPE": {
+        "name": "GROUPS_6_RULES_0_DATA_1_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "reduce",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_REFID": {
+        "name": "GROUPS_6_RULES_0_DATA_2_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_6_RULES_0_DATA_2_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_6_RULES_0_DATA_2_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_DATASOURCEUID": {
+        "name": "GROUPS_6_RULES_0_DATA_2_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_MODEL_TYPE": {
+        "name": "GROUPS_6_RULES_0_DATA_2_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "threshold",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_MODEL_EXPRESSION": {
+        "name": "GROUPS_6_RULES_0_DATA_2_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE": {
+        "name": "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "gt",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE": {
+        "name": "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "and",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE": {
+        "name": "GROUPS_6_RULES_0_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_FOR": {
+        "name": "GROUPS_6_RULES_0_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0s",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_LABELS_SEVERITY": {
+        "name": "GROUPS_6_RULES_0_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_LABELS_CATEGORY": {
+        "name": "GROUPS_6_RULES_0_LABELS_CATEGORY",
+        "type": "string",
+        "source": "yaml",
+        "value": "ollama",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_6_RULES_0_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Selfheal atingiu limite de restarts (3/hora)",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_6_RULES_0_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Uma ou ambas GPUs precisaram de 3+ restarts na \u00faltima hora. Interven\u00e7\u00e3o manual necess\u00e1ria \u2014 poss\u00edvel problema de hardware ou VRAM.",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_NODATASTATE": {
+        "name": "GROUPS_6_RULES_0_NODATASTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_6_RULES_0_EXECERRSTATE": {
+        "name": "GROUPS_6_RULES_0_EXECERRSTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Alerting",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_ORGID": {
+        "name": "GROUPS_7_ORGID",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "1",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_NAME": {
+        "name": "GROUPS_7_NAME",
+        "type": "string",
+        "source": "yaml",
+        "value": "Infrastructure - Storj",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_FOLDER": {
+        "name": "GROUPS_7_FOLDER",
+        "type": "string",
+        "source": "yaml",
+        "value": "Eddie Alerts",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_INTERVAL": {
+        "name": "GROUPS_7_INTERVAL",
+        "type": "string",
+        "source": "yaml",
+        "value": "1m",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_UID": {
+        "name": "GROUPS_7_RULES_0_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "alert-storj-api-stale",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_TITLE": {
+        "name": "GROUPS_7_RULES_0_TITLE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Storj API Dados Desatualizados",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_CONDITION": {
+        "name": "GROUPS_7_RULES_0_CONDITION",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_0_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_0_DATA_0_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "120",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_0_DATA_0_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_0_DATA_0_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "dfc0w4yioe4u8e",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_MODEL_EXPR": {
+        "name": "GROUPS_7_RULES_0_DATA_0_MODEL_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj_api_stale_seconds",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_MODEL_INSTANT": {
+        "name": "GROUPS_7_RULES_0_DATA_0_MODEL_INSTANT",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_0_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_0_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_1_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_0_DATA_1_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "120",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_0_DATA_1_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_0_DATA_1_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_MODEL_EXPRESSION": {
+        "name": "GROUPS_7_RULES_0_DATA_1_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_MODEL_REDUCER": {
+        "name": "GROUPS_7_RULES_0_DATA_1_MODEL_REDUCER",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_1_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_1_MODEL_TYPE": {
+        "name": "GROUPS_7_RULES_0_DATA_1_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "reduce",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_2_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_0_DATA_2_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "120",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_0_DATA_2_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_0_DATA_2_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_TYPE": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "threshold",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "gt",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "and",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_DATA_2_MODEL_EXPRESSION": {
+        "name": "GROUPS_7_RULES_0_DATA_2_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_FOR": {
+        "name": "GROUPS_7_RULES_0_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "1m",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_LABELS_SEVERITY": {
+        "name": "GROUPS_7_RULES_0_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_LABELS_CATEGORY": {
+        "name": "GROUPS_7_RULES_0_LABELS_CATEGORY",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_7_RULES_0_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Storj API servindo cache h\u00e1 mais de 60s",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_7_RULES_0_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj_api_stale_seconds = {{ $values.A }}s. A API local do node (14002) parou de responder; o exporter est\u00e1 servindo o \u00faltimo payload bom. Checar storj-host-shim, storj-api-proxy e ip neigh show 192.168.15.250.",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_NODATASTATE": {
+        "name": "GROUPS_7_RULES_0_NODATASTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_0_EXECERRSTATE": {
+        "name": "GROUPS_7_RULES_0_EXECERRSTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_UID": {
+        "name": "GROUPS_7_RULES_1_UID",
+        "type": "string",
+        "source": "yaml",
+        "value": "alert-storj-api-down",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_TITLE": {
+        "name": "GROUPS_7_RULES_1_TITLE",
+        "type": "string",
+        "source": "yaml",
+        "value": "Storj API Fora do Ar",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_CONDITION": {
+        "name": "GROUPS_7_RULES_1_CONDITION",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_0_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_1_DATA_0_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_1_DATA_0_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_1_DATA_0_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "dfc0w4yioe4u8e",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_MODEL_EXPR": {
+        "name": "GROUPS_7_RULES_1_DATA_0_MODEL_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj_api_up",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_MODEL_INSTANT": {
+        "name": "GROUPS_7_RULES_1_DATA_0_MODEL_INSTANT",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_0_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_0_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_1_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_1_DATA_1_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_1_DATA_1_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_1_DATA_1_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_MODEL_EXPRESSION": {
+        "name": "GROUPS_7_RULES_1_DATA_1_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "A",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_MODEL_REDUCER": {
+        "name": "GROUPS_7_RULES_1_DATA_1_MODEL_REDUCER",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_1_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_1_MODEL_TYPE": {
+        "name": "GROUPS_7_RULES_1_DATA_1_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "reduce",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_2_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_RELATIVETIMERANGE_FROM": {
+        "name": "GROUPS_7_RULES_1_DATA_2_RELATIVETIMERANGE_FROM",
+        "type": "integer",
+        "source": "yaml",
+        "value": "300",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_RELATIVETIMERANGE_TO": {
+        "name": "GROUPS_7_RULES_1_DATA_2_RELATIVETIMERANGE_TO",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "0",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_DATASOURCEUID": {
+        "name": "GROUPS_7_RULES_1_DATA_2_DATASOURCEUID",
+        "type": "string",
+        "source": "yaml",
+        "value": "__expr__",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_TYPE": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "threshold",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_REFID": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_REFID",
+        "type": "string",
+        "source": "yaml",
+        "value": "C",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_EVALUATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "lt",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_OPERATOR_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "and",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_CONDITIONS_0_REDUCER_TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "last",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_DATA_2_MODEL_EXPRESSION": {
+        "name": "GROUPS_7_RULES_1_DATA_2_MODEL_EXPRESSION",
+        "type": "string",
+        "source": "yaml",
+        "value": "B",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_FOR": {
+        "name": "GROUPS_7_RULES_1_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_LABELS_SEVERITY": {
+        "name": "GROUPS_7_RULES_1_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_LABELS_CATEGORY": {
+        "name": "GROUPS_7_RULES_1_LABELS_CATEGORY",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_7_RULES_1_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Storj API fora do ar h\u00e1 mais de 5 minutos",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_7_RULES_1_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "storj_api_up = {{ $values.A }}. Scrape do exporter chegando, mas a API local do node n\u00e3o responde nem via cache. Interven\u00e7\u00e3o manual prov\u00e1vel.",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_NODATASTATE": {
+        "name": "GROUPS_7_RULES_1_NODATASTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
+      "GROUPS_7_RULES_1_EXECERRSTATE": {
+        "name": "GROUPS_7_RULES_1_EXECERRSTATE",
+        "type": "string",
+        "source": "yaml",
+        "value": "OK",
+        "contexts": [
+          "rules"
+        ]
+      },
       "CONTACTPOINTS_0_ORGID": {
         "name": "CONTACTPOINTS_0_ORGID",
         "type": "boolean",
@@ -21144,6 +22073,231 @@
           "datasources"
         ]
       },
+      "GROUPS_0_RULES_6_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_6_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-tape",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_EXPR": {
+        "name": "GROUPS_0_RULES_7_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(ltfs_cache_flush_runs_total{status=\"error\"}[1h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_FOR": {
+        "name": "GROUPS_0_RULES_7_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_7_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_7_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-flush",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_7_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS cache flush job failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_7_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Cache flush job failed on {{ $labels.instance }} in the last hour.\nCheck journal for ltfs-cache-flush.service.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_EXPR": {
+        "name": "GROUPS_0_RULES_8_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "time() - ltfs_cache_flush_last_run_timestamp > 7200\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_FOR": {
+        "name": "GROUPS_0_RULES_8_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_8_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_8_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-flush",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_8_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS cache flush job stale (>2h)",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_8_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "No successful cache flush run in the last 2 hours on {{ $labels.instance }}.\nTimer may be stuck or jobs failing silently.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_EXPR": {
+        "name": "GROUPS_0_RULES_9_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(ltfs_catalog_verify_total{status=\"failed\"}[24h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_FOR": {
+        "name": "GROUPS_0_RULES_9_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_9_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_9_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-catalog",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_9_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS catalog verification failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_9_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Catalog verification found inconsistencies on {{ $labels.instance }}.\nCheck ltfs-catalog-verify.service journal.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_EXPR": {
+        "name": "GROUPS_0_RULES_10_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(tape_log_spool_drain_runs_total{status=\"error\"}[1h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_FOR": {
+        "name": "GROUPS_0_RULES_10_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_10_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_10_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "tape-logs",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_10_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Tape log spool drain failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_10_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Log drain for route {{ $labels.route }} failed on {{ $labels.instance }}.\nLogs may accumulate in staging.",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
       "TUNNEL": {
         "name": "TUNNEL",
         "type": "string",
@@ -21385,60 +22539,6 @@
         "value": "30s",
         "contexts": [
           "cloudflared-rpa4all-ide"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU",
-        "type": "string",
-        "source": "yaml",
-        "value": "rtx2060super",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM",
-        "type": "string",
-        "source": "yaml",
-        "value": "8gb",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST",
-        "type": "string",
-        "source": "yaml",
-        "value": "nas",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT",
-        "type": "string",
-        "source": "yaml",
-        "value": "nas",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE",
-        "type": "string",
-        "source": "yaml",
-        "value": "gpu-coordinator",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST",
-        "type": "string",
-        "source": "yaml",
-        "value": "homelab",
-        "contexts": [
-          "prometheus"
         ]
       },
       "OPENAPI": {
@@ -21933,8 +23033,8 @@
         "source": "yaml",
         "value": "Homelab MCP Server",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "VERSION": {
@@ -21943,8 +23043,8 @@
         "source": "yaml",
         "value": "0.0.1",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "SCHEMA": {
@@ -21953,8 +23053,8 @@
         "source": "yaml",
         "value": "v1",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_NAME": {
@@ -21963,8 +23063,8 @@
         "source": "yaml",
         "value": "homelab",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_COMMAND": {
@@ -21973,8 +23073,8 @@
         "source": "yaml",
         "value": "/home/edenilson/shared-auto-dev/.venv/bin/python",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_ENV_HOMELAB_URL": {
@@ -21983,8 +23083,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:8503",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "MCPSERVERS_0_ENV_API_BASE_URL": {
@@ -21993,8 +23093,8 @@
         "source": "yaml",
         "value": "http://192.168.15.2:3000",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       },
       "DATASOURCES_0_JSONDATA_TLSSKIPVERIFY": {
@@ -22035,18 +23135,6 @@
       }
     },
     "authentication": {
-      "WIKI_TOKEN": {
-        "name": "WIKI_TOKEN",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "wiki_sync",
-          "create_wiki_page",
-          "wiki_agent",
-          "wiki_bulk_publish"
-        ]
-      },
       "OPENAI_COMPATIBLE_API_KEY": {
         "name": "OPENAI_COMPATIBLE_API_KEY",
         "type": "string",
@@ -22063,50 +23151,11 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".env",
-            "line": 17
-          },
-          {
             "file": ".env.example",
             "line": 1
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".env",
-            "line": 17
           }
         ],
         "contexts": []
-      },
-      "DB_PASSWORD": {
-        "name": "DB_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "investigate_btc"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_PASSWORD": {
-        "name": "NEXTCLOUD_ADMIN_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
       },
       "GOOGLE_AI_API_KEY": {
         "name": "GOOGLE_AI_API_KEY",
@@ -22126,18 +23175,6 @@
           {
             "file": ".env.consolidated",
             "line": 16
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 16
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 16
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 16
           }
         ],
         "contexts": []
@@ -22150,18 +23187,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 20
           }
         ],
@@ -22176,18 +23201,6 @@
           {
             "file": ".env.consolidated",
             "line": 22
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 22
           }
         ],
         "contexts": []
@@ -22198,11 +23211,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-backend"
+          "mailu-dovecot",
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-postfix"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -22213,18 +23226,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 31
           }
         ],
@@ -22239,18 +23240,6 @@
           {
             "file": ".env.consolidated",
             "line": 32
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 32
           }
         ],
         "contexts": []
@@ -22263,18 +23252,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 45
           }
         ],
@@ -22289,18 +23266,6 @@
           {
             "file": ".env.consolidated",
             "line": 54
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 54
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 54
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 54
           }
         ],
         "contexts": []
@@ -22314,21 +23279,19 @@
           {
             "file": ".env.consolidated",
             "line": 59
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 59
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 59
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 59
           }
         ],
         "contexts": []
+      },
+      "DB_PASSWORD": {
+        "name": "DB_PASSWORD",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox",
+          "netbox-worker"
+        ]
       },
       "SHARED_IPC_SECRET": {
         "name": "SHARED_IPC_SECRET",
@@ -22338,18 +23301,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 92
           }
         ],
@@ -22361,34 +23312,47 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_playwright",
+          "smart_ir_selfheal",
+          "job_monitor_continuous",
+          "secrets_helper",
           "secrets_loader",
           "github_agent_streamlit",
-          "send_pending_report",
-          "kucoin_api",
-          "setup_telegram",
-          "coordinator",
-          "test_telegram",
-          "job_monitor_continuous",
-          "storj_payout_monitor",
-          "telegram_bot",
-          "ltfs_button_watch",
-          "telegram_mcp_server",
-          "config",
-          "mt5_api",
-          "linkedin_job_scanner",
           "trading_analyst_rollout_report",
-          "trading_selfheal_exporter",
           "alertmanager_telegram_webhook",
-          "ci_watcher",
           "iot_presence_watchdog",
-          "trading_daily_report",
-          "setup_trading_telegram_channel",
-          "server_error_alert",
+          "telegram_mcp_server",
+          "trading_selfheal_exporter",
           "ollama_gpu_selfheal",
-          "akash_sweep_to_kucoin",
+          "ltfs_button_watch",
+          "setup_telegram",
+          "trading_daily_report",
+          "test_telegram",
+          "coordinator",
+          "mt5_api",
+          "ci_watcher",
           "ltfs_recovery",
-          "smart_ir_selfheal"
+          "storj_payout_monitor",
+          "config",
+          "akash_sweep_to_kucoin",
+          "setup_trading_telegram_channel",
+          "telegram_bot",
+          "server_error_alert",
+          "send_pending_report",
+          "linkedin_job_scanner",
+          "kucoin_api",
+          "test_playwright"
+        ]
+      },
+      "WIKI_TOKEN": {
+        "name": "WIKI_TOKEN",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "wiki_sync",
+          "wiki_bulk_publish",
+          "create_wiki_page",
+          "wiki_agent"
         ]
       },
       "NETBOX_REMOTE_AUTH_ENABLED": {
@@ -22397,18 +23361,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 19
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 19
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 19
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 19
@@ -22423,18 +23375,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 20
           }
@@ -22447,18 +23387,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 21
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 21
@@ -22473,18 +23401,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 22
           }
@@ -22497,18 +23413,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 23
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 23
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 23
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 23
@@ -22523,18 +23427,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 24
           }
@@ -22547,18 +23439,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 25
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 25
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 25
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 25
@@ -22573,18 +23453,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 26
           }
@@ -22597,18 +23465,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 27
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 27
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 27
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 27
@@ -22623,18 +23479,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 41
           }
@@ -22647,18 +23491,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 42
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 42
@@ -22673,18 +23505,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 43
           }
@@ -22698,18 +23518,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 44
           }
@@ -22722,18 +23530,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 47
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 47
@@ -22759,18 +23555,6 @@
           {
             "file": "deploy/production_autonomous.env",
             "line": 17
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
-            "line": 17
           }
         ],
         "contexts": []
@@ -22781,12 +23565,12 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_github_agent",
-          "config",
-          "setup_deploy_key",
-          "test_github_push",
-          "github_agent",
           "telegram_bot",
+          "test_github_push",
+          "test_github_agent",
+          "github_agent",
+          "setup_deploy_key",
+          "config",
           "control_panel"
         ]
       },
@@ -22958,11 +23742,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
+          "netbox-postgres",
+          "mailu-db",
+          "wikijs-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_PASSWORD": {
@@ -23256,26 +24040,26 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "tuya_token_renewer",
-          "homelab_mcp_server",
+          "smart_ir_selfheal",
+          "secrets_agent_client",
           "generate_ollama_api_key",
-          "home_assistant_integration",
-          "secrets_agent",
-          "test_secrets_agent",
-          "kucoin_api",
+          "secrets_helper",
+          "tuya_token_renewer",
           "ollama_finetune_batch",
           "audit_and_migrate_secrets",
-          "generate_gemini_api_key",
-          "storj_payout_monitor",
+          "test_secrets_agent",
+          "secrets_agent",
           "cmdb_validate",
-          "secrets_agent_client",
-          "setup_trading_telegram_channel",
-          "tuya_move_license",
-          "secrets_helper",
           "x_agent",
+          "tuya_move_license",
+          "home_assistant_integration",
+          "storj_payout_monitor",
           "akash_sweep_to_kucoin",
-          "smart_ir_selfheal"
+          "homelab_mcp_server",
+          "setup_trading_telegram_channel",
+          "kucoin_api",
+          "generate_gemini_api_key",
+          "configure_authentik_nas_ldap"
         ]
       },
       "SECRETS_AGENT_URL": {
@@ -23284,25 +24068,25 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "tuya_token_renewer",
-          "homelab_mcp_server",
+          "smart_ir_selfheal",
+          "secrets_agent_client",
           "generate_ollama_api_key",
-          "home_assistant_integration",
-          "kucoin_api",
+          "secrets_helper",
+          "tuya_token_renewer",
           "ollama_finetune_batch",
           "audit_and_migrate_secrets",
-          "generate_gemini_api_key",
-          "storj_payout_monitor",
-          "wikijs_authentik_oidc",
-          "secrets_agent_client",
           "agent_documentation_manager",
-          "setup_trading_telegram_channel",
-          "tuya_move_license",
-          "secrets_helper",
           "x_agent",
+          "tuya_move_license",
+          "home_assistant_integration",
+          "storj_payout_monitor",
           "akash_sweep_to_kucoin",
-          "smart_ir_selfheal"
+          "homelab_mcp_server",
+          "setup_trading_telegram_channel",
+          "wikijs_authentik_oidc",
+          "kucoin_api",
+          "generate_gemini_api_key",
+          "configure_authentik_nas_ldap"
         ]
       },
       "SECRETS_AGENT_DATA": {
@@ -23312,9 +24096,9 @@
         "value": "***REDACTED***",
         "contexts": [
           "test_btc_secrets_helper",
-          "test_secrets_agent",
-          "secrets_helper",
           "secret_store",
+          "secrets_helper",
+          "test_secrets_agent",
           "secrets_agent"
         ]
       },
@@ -23324,18 +24108,18 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "search_waha_nil",
+          "wait_and_run_whatsapp_test",
+          "test_whatsapp",
           "reports_integration",
           "extract_whatsapp_train",
-          "process_all_messages_from_tmp",
-          "test_whatsapp",
-          "scan_whatsapp_llm",
-          "github_agent_streamlit",
-          "search_waha_nil",
           "job_match_pipeline",
-          "wait_and_run_whatsapp_test",
+          "scan_whatsapp_llm",
           "search_waha_production",
-          "apply_real_job",
-          "whatsapp_bot"
+          "process_all_messages_from_tmp",
+          "whatsapp_bot",
+          "github_agent_streamlit",
+          "apply_real_job"
         ]
       },
       "BRIDGE_RUNTIME_TOKENS": {
@@ -23363,21 +24147,21 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "authentik_user_manager",
-          "secrets_helper",
-          "register_nextcloud_access_panel",
-          "authentik_secret_fetcher",
-          "authentik_rotate_secrets_agent_token",
-          "2_user_management",
-          "secrets_agent",
-          "install_authentik_os_login",
-          "configure_authentik_nextcloud_oidc",
-          "register_whatsapp_persona_panel",
-          "register_governance_app",
           "user_management",
+          "register_governance_app",
+          "configure_authentik_nextcloud_oidc",
+          "install_authentik_os_login",
+          "secrets_helper",
+          "authentik_user_manager",
+          "storage_portal_api",
+          "secrets_agent",
+          "authentik_secret_fetcher",
+          "register_nextcloud_access_panel",
+          "register_whatsapp_persona_panel",
           "register_llm_prompt_audit_panel",
-          "storage_portal_api"
+          "2_user_management",
+          "authentik_rotate_secrets_agent_token",
+          "configure_authentik_nas_ldap"
         ]
       },
       "AUTHENTIK_TOKEN": {
@@ -23386,20 +24170,20 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "authentik_user_manager",
-          "secrets_helper",
-          "register_nextcloud_access_panel",
-          "authentik_secret_fetcher",
-          "secrets_agent",
-          "install_authentik_os_login",
-          "configure_authentik_nextcloud_oidc",
-          "register_whatsapp_persona_panel",
+          "user_management",
           "register_governance_app",
           "register_mailu_authentik",
-          "user_management",
+          "configure_authentik_nextcloud_oidc",
+          "install_authentik_os_login",
+          "secrets_helper",
+          "authentik_user_manager",
+          "secrets_agent",
+          "authentik_secret_fetcher",
+          "register_nextcloud_access_panel",
+          "register_whatsapp_persona_panel",
           "register_llm_prompt_audit_panel",
-          "storage_portal_api"
+          "storage_portal_api",
+          "configure_authentik_nas_ldap"
         ]
       },
       "AUTHENTIK_VERIFY_TLS": {
@@ -23437,9 +24221,19 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_btc_secrets_helper",
           "secret_store",
+          "test_btc_secrets_helper",
           "secrets_helper"
+        ]
+      },
+      "NEXTCLOUD_ADMIN_PASSWORD": {
+        "name": "NEXTCLOUD_ADMIN_PASSWORD",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "config",
+          "nextcloud_agent"
         ]
       },
       "WG_SERVER_PUBKEY": {
@@ -23504,11 +24298,11 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "config",
-          "generate_learning_evolution_graph",
-          "generate_learning_dashboard",
           "populate_grafana_dashboard",
-          "deploy_grafana_server_selector"
+          "generate_learning_evolution_graph",
+          "config",
+          "deploy_grafana_server_selector",
+          "generate_learning_dashboard"
         ]
       },
       "CONUBE_ACTION_TOKEN": {
@@ -23529,14 +24323,34 @@
           "conube_agent"
         ]
       },
+      "TG_BOT_TOKEN": {
+        "name": "TG_BOT_TOKEN",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "secrets_helper"
+        ]
+      },
+      "TG_TOKEN": {
+        "name": "TG_TOKEN",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "secrets_loader",
+          "secrets_helper",
+          "telegram_mcp_server"
+        ]
+      },
       "API_KEY": {
         "name": "API_KEY",
         "type": "string",
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "kucoin_api"
+          "kucoin_api",
+          "secrets_helper"
         ]
       },
       "API_SECRET": {
@@ -23545,8 +24359,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "kucoin_api"
+          "kucoin_api",
+          "secrets_helper"
         ]
       },
       "API_KEY_VERSION": {
@@ -23591,8 +24405,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "patch_ai_plans_profile",
-          "ha_grafana_sync"
+          "ha_grafana_sync",
+          "patch_ai_plans_profile"
         ]
       },
       "SECRETS_API_URL": {
@@ -23601,10 +24415,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "router_network_config",
-          "router_udp_port_forward",
           "zte_akash_portforward",
-          "zte_modem_admin"
+          "zte_modem_admin",
+          "router_udp_port_forward",
+          "router_network_config"
         ]
       },
       "SECRETS_API_KEY": {
@@ -23613,10 +24427,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "router_network_config",
-          "router_udp_port_forward",
           "zte_akash_portforward",
-          "zte_modem_admin"
+          "zte_modem_admin",
+          "router_udp_port_forward",
+          "router_network_config"
         ]
       },
       "PANEL_API_KEY": {
@@ -23625,10 +24439,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "daily_agenda_panel_server",
-          "llm_log_panel_server",
           "whatsapp_persona_panel_server",
-          "daily_agenda_job_status"
+          "llm_log_panel_server",
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "AUTHENTIK_ADMIN_TOKEN": {
@@ -23665,16 +24479,6 @@
         "value": "***REDACTED***",
         "contexts": [
           "tape_manager"
-        ]
-      },
-      "TG_TOKEN": {
-        "name": "TG_TOKEN",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "telegram_mcp_server",
-          "secrets_loader"
         ]
       },
       "WIKI_API_KEY": {
@@ -23836,9 +24640,9 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "nas_ai_assessor",
           "create_neural_dashboard",
-          "create_neural_dashboard_remote"
+          "create_neural_dashboard_remote",
+          "nas_ai_assessor"
         ]
       },
       "HA_TOKEN_FILE": {
@@ -24157,6 +24961,16 @@
           "install_webui_function_api"
         ]
       },
+      "LINKEDIN_PASSWORD": {
+        "name": "LINKEDIN_PASSWORD",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "linkedin_content_purger",
+          "linkedin_job_scanner"
+        ]
+      },
       "GCAL_OAUTH_PORT": {
         "name": "GCAL_OAUTH_PORT",
         "type": "string",
@@ -24263,17 +25077,8 @@
         "value": "***REDACTED***",
         "contexts": [
           "update_grafana_panels_phase2",
-          "update_grafana_dashboard_phase2",
-          "grafana_learning_dashboard"
-        ]
-      },
-      "LINKEDIN_PASSWORD": {
-        "name": "LINKEDIN_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "linkedin_job_scanner"
+          "grafana_learning_dashboard",
+          "update_grafana_dashboard_phase2"
         ]
       },
       "ATS_PASSWORD": {
@@ -24479,82 +25284,403 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       }
     },
-    "database": {
-      "DATABASE_URL": {
-        "name": "DATABASE_URL",
+    "integrations": {
+      "GOOGLE_SDM_PROJECT": {
+        "name": "GOOGLE_SDM_PROJECT",
+        "type": "string",
+        "source": ".env",
+        "value": "projects/your_project_id",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 17
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_NUMBER": {
+        "name": "GOOGLE_SDM_PROJECT_NUMBER",
+        "type": "string",
+        "source": ".env",
+        "value": "your_project_number",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 18
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_ID": {
+        "name": "GOOGLE_SDM_PROJECT_ID",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
-          "kucoin_postgres_sync",
-          "prometheus_exporter",
-          "homelab_mcp_server",
-          "db_migrate",
-          "training_db",
-          "test_agent_memory",
-          "query_deposits",
-          "daily_report",
-          "operations_agent",
-          "search_whatsapp_postgres",
-          "2_user_management",
-          "eddie_central_missing_metrics",
-          "user_management",
-          "example_agent_memory",
-          "fetch_autocoinbot_trades",
-          "trading_conversation",
-          "setup_grafana_home",
-          "btc_signals_exporter",
-          "validate_trades_sync",
-          "agent_ipc",
-          "rss_sentiment_exporter",
-          "run_sentiment_finetune",
-          "rss_llm_trainer",
-          "decisions_track_record_rollup",
-          "news_sentiment_patch",
-          "ollama_finetune_batch",
-          "backfill_pnl",
-          "journal_ingestor",
-          "migrate_trading_profile_schema",
-          "diretor_latency_exporter",
-          "migrate_whatsapp_to_postgres",
-          "ollama_gpu_coordinator",
-          "candle_collector",
-          "trading_agent_desk_test",
-          "whatsapp_knowledge_finetune_dataset_builder",
-          "migrate_sqlite_to_postgres",
-          "export_trading_pnl_portfolio",
-          "watch_coordinator_db",
-          "restore_trading_history",
-          "run_migration",
-          "config",
-          "test_sell_target_backtest",
-          "test_integration_sentiment",
-          "autonomous_remediator",
-          "validate_sell_fix_final",
-          "telegram_trading",
-          "x_post_scheduler",
-          "email_nurturing",
-          "langgraph_base",
-          "agent_network_exporter",
-          "trading_analyst_rollout_report",
-          "trading_selfheal_exporter",
-          "trading_daily_report",
-          "calibrate_rss_sentiment",
-          "llm_log_panel_server",
-          "train_llm_on_conversations",
-          "secrets_helper",
-          "approval_gateway",
-          "grafana_query",
-          "lead_capture_api",
-          "eddie_central_extended_metrics",
-          "deploy_multiposition",
-          "whatsapp_bot"
+          "setup_google_home_oauth"
         ]
+      },
+      "TELEGRAM_CHAT_ID": {
+        "name": "TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "smart_ir_selfheal",
+          "job_monitor_continuous",
+          "secrets_loader",
+          "approval_gateway",
+          "trading_analyst_rollout_report",
+          "alertmanager_telegram_webhook",
+          "daily_report",
+          "iot_presence_watchdog",
+          "telegram_mcp_server",
+          "trading_selfheal_exporter",
+          "ollama_gpu_selfheal",
+          "ltfs_button_watch",
+          "setup_telegram",
+          "trading_daily_report",
+          "pre_tool_guardrails",
+          "test_telegram",
+          "alert_digest_agent",
+          "ci_watcher",
+          "ltfs_recovery",
+          "lead_capture_api",
+          "storj_payout_monitor",
+          "config",
+          "akash_sweep_to_kucoin",
+          "linkedin_job_scanner",
+          "kucoin_api",
+          "test_playwright",
+          "delivery_approval"
+        ]
+      },
+      "WEBHOOKS_ENABLED": {
+        "name": "WEBHOOKS_ENABLED",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox",
+          "netbox-worker"
+        ]
+      },
+      "MARKETING_TELEGRAM_NOTIFY": {
+        "name": "MARKETING_TELEGRAM_NOTIFY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "lead_capture_api"
+        ]
+      },
+      "GITHUB_AGENT_URL": {
+        "name": "GITHUB_AGENT_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "GOOGLE_CHROME_BIN": {
+        "name": "GOOGLE_CHROME_BIN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "conube_agent"
+        ]
+      },
+      "CONUBE_TELEGRAM_NOTIFY": {
+        "name": "CONUBE_TELEGRAM_NOTIFY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "conube_remediation"
+        ]
+      },
+      "TELEGRAM_PROXY_URL": {
+        "name": "TELEGRAM_PROXY_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "position_manager_mixin"
+        ]
+      },
+      "TELEGRAM_ERROR_CHAT_ID": {
+        "name": "TELEGRAM_ERROR_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "server_error_alert"
+        ]
+      },
+      "GITHUB_REPO": {
+        "name": "GITHUB_REPO",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "setup_deploy_key"
+        ]
+      },
+      "AGENDA_TELEGRAM_CHAT_ID": {
+        "name": "AGENDA_TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "secrets_loader",
+          "daily_agenda_config"
+        ]
+      },
+      "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT": {
+        "name": "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_recovery"
+        ]
+      },
+      "LTFS_TELEGRAM_POLL_INTERVAL": {
+        "name": "LTFS_TELEGRAM_POLL_INTERVAL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_recovery"
+        ]
+      },
+      "WEBHOOK_PORT": {
+        "name": "WEBHOOK_PORT",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram_webhook"
+        ]
+      },
+      "TELEGRAM_BOT_T": {
+        "name": "TELEGRAM_BOT_T",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "pre_tool_guardrails"
+        ]
+      },
+      "WEBHOOK_URL": {
+        "name": "WEBHOOK_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "whatsapp_manager"
+        ]
+      },
+      "GITHUB_CLIENT_ID": {
+        "name": "GITHUB_CLIENT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "github_agent_streamlit",
+          "github_agent_server"
+        ]
+      },
+      "GITHUB_REDIRECT_URI": {
+        "name": "GITHUB_REDIRECT_URI",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "github_agent_streamlit",
+          "github_agent_server"
+        ]
+      },
+      "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production",
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production",
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID",
+        "type": "integer",
+        "source": "yaml",
+        "value": "948686300",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE",
+        "type": "json",
+        "source": "yaml",
+        "value": "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} - {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "GLOBAL_TELEGRAM_API_URL": {
+        "name": "GLOBAL_TELEGRAM_API_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "https://api.telegram.org/bot",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      }
+    },
+    "database": {
+      "MAILU_DATABASE_URL": {
+        "name": "MAILU_DATABASE_URL",
+        "type": "url",
+        "source": ".env",
+        "value": "***REDACTED***",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 46
+          }
+        ],
+        "contexts": []
+      },
+      "MAILU_REDIS_URL": {
+        "name": "MAILU_REDIS_URL",
+        "type": "url",
+        "source": ".env",
+        "value": "redis://:${MAILU_REDIS_PASSWORD}@mailu-redis",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 47
+          }
+        ],
+        "contexts": []
       },
       "DB_HOST": {
         "name": "DB_HOST",
@@ -24598,55 +25724,77 @@
           "wikijs"
         ]
       },
-      "MAILU_DATABASE_URL": {
-        "name": "MAILU_DATABASE_URL",
-        "type": "url",
-        "source": ".env",
-        "value": "***REDACTED***",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 46
-          }
-        ],
-        "contexts": []
-      },
-      "MAILU_REDIS_URL": {
-        "name": "MAILU_REDIS_URL",
-        "type": "url",
-        "source": ".env",
-        "value": "redis://:${MAILU_REDIS_PASSWORD}@mailu-redis",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 47
-          }
-        ],
-        "contexts": []
+      "DATABASE_URL": {
+        "name": "DATABASE_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "user_management",
+          "rss_llm_trainer",
+          "test_integration_sentiment",
+          "ollama_gpu_coordinator",
+          "grafana_query",
+          "export_trading_pnl_portfolio",
+          "validate_sell_fix_final",
+          "secrets_helper",
+          "training_db",
+          "migrate_trading_profile_schema",
+          "backfill_pnl",
+          "watch_coordinator_db",
+          "approval_gateway",
+          "trading_analyst_rollout_report",
+          "setup_grafana_home",
+          "2_user_management",
+          "rss_sentiment_exporter",
+          "daily_report",
+          "langgraph_base",
+          "migrate_whatsapp_to_postgres",
+          "trading_selfheal_exporter",
+          "ollama_finetune_batch",
+          "query_deposits",
+          "agent_network_exporter",
+          "kucoin_postgres_sync",
+          "whatsapp_knowledge_finetune_dataset_builder",
+          "example_agent_memory",
+          "db_migrate",
+          "trading_daily_report",
+          "x_post_scheduler",
+          "prometheus_exporter",
+          "diretor_latency_exporter",
+          "journal_ingestor",
+          "candle_collector",
+          "whatsapp_bot",
+          "trading_agent_desk_test",
+          "restore_trading_history",
+          "btc_signals_exporter",
+          "fetch_autocoinbot_trades",
+          "test_sell_target_backtest",
+          "telegram_trading",
+          "validate_trades_sync",
+          "news_sentiment_patch",
+          "eddie_central_missing_metrics",
+          "trading_conversation",
+          "decisions_track_record_rollup",
+          "calibrate_rss_sentiment",
+          "autonomous_remediator",
+          "run_migration",
+          "search_whatsapp_postgres",
+          "lead_capture_api",
+          "email_nurturing",
+          "migrate_sqlite_to_postgres",
+          "homelab_mcp_server",
+          "config",
+          "etl_agent_executions_to_training",
+          "deploy_multiposition",
+          "run_sentiment_finetune",
+          "llm_log_panel_server",
+          "test_agent_memory",
+          "agent_ipc",
+          "operations_agent",
+          "eddie_central_extended_metrics",
+          "train_llm_on_conversations"
+        ]
       },
       "CMDB_TIMEZONE": {
         "name": "CMDB_TIMEZONE",
@@ -24654,18 +25802,6 @@
         "source": ".env",
         "value": "America/Sao_Paulo",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 1
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 1
@@ -24680,18 +25816,6 @@
         "value": "127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 4
           }
@@ -24704,18 +25828,6 @@
         "source": ".env",
         "value": "18090",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 5
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 5
@@ -24730,18 +25842,6 @@
         "value": "18-alpine",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 32
           }
@@ -24754,18 +25854,6 @@
         "source": ".env",
         "value": "9.0-alpine",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 33
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 33
@@ -24780,18 +25868,6 @@
         "value": "11",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 35
           }
@@ -24805,18 +25881,6 @@
         "value": "netbox",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 39
           }
@@ -24829,18 +25893,6 @@
         "source": ".env",
         "value": "netbox",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 40
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 40
@@ -24872,11 +25924,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
+          "netbox-postgres",
+          "mailu-db",
+          "wikijs-db"
         ]
       },
       "POSTGRES_USER": {
@@ -24885,11 +25937,11 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
-          "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
-          "netbox-postgres"
+          "netbox-postgres",
+          "mailu-db",
+          "wikijs-db"
         ]
       },
       "ROUNDCUBEMAIL_DB_TYPE": {
@@ -24952,8 +26004,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-roundcube",
-          "mailu-backend"
+          "mailu-backend",
+          "mailu-roundcube"
         ]
       },
       "GF_DATABASE_TYPE": {
@@ -25128,8 +26180,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "patch_ai_plans_profile",
-          "ha_grafana_sync"
+          "ha_grafana_sync",
+          "patch_ai_plans_profile"
         ]
       },
       "CHROMA_DB_PATH": {
@@ -25201,8 +26253,8 @@
         "source": "yaml",
         "value": "***REDACTED***",
         "contexts": [
-          "homelab",
-          "new-mcp-server"
+          "new-mcp-server",
+          "homelab"
         ]
       }
     },
@@ -25213,10 +26265,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
+          "restore_trading_history",
           "kucoin_api",
-          "restore_trading_history"
+          "test_kucoin_api",
+          "secrets_helper"
         ]
       },
       "KUCOIN_API_SECRET": {
@@ -25225,10 +26277,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
+          "restore_trading_history",
           "kucoin_api",
-          "restore_trading_history"
+          "test_kucoin_api",
+          "secrets_helper"
         ]
       },
       "KUCOIN_API_PASSPHRASE": {
@@ -25237,10 +26289,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
+          "restore_trading_history",
           "kucoin_api",
-          "restore_trading_history"
+          "test_kucoin_api",
+          "secrets_helper"
         ]
       },
       "KUCOIN_ALLOWED_IP": {
@@ -25251,18 +26303,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 69
           }
         ],
@@ -25310,10 +26350,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "trading_agent",
+          "kucoin_api",
           "prometheus_exporter",
           "fix_prometheus_exporter",
-          "kucoin_api",
-          "trading_agent",
           "validate_btc_config"
         ]
       },
@@ -25333,8 +26373,26 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "kucoin_postgres_sync",
-          "validate_trades_sync"
+          "validate_trades_sync",
+          "kucoin_postgres_sync"
+        ]
+      },
+      "GPU_COORD_TRADING_EXCLUSIVE_GPU0": {
+        "name": "GPU_COORD_TRADING_EXCLUSIVE_GPU0",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_TRADING_HEADROOM_MB": {
+        "name": "GPU_COORD_TRADING_HEADROOM_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
         ]
       },
       "COINGECKO_PRICE_URL": {
@@ -25352,10 +26410,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nas_ai_assessor",
-          "populate_grafana_dashboard",
           "tape_quality_ollama_narrator",
-          "alert_digest_agent"
+          "alert_digest_agent",
+          "populate_grafana_dashboard",
+          "nas_ai_assessor"
         ]
       },
       "OLLAMA_TRADING_MODEL": {
@@ -25364,9 +26422,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "trading_daily_report",
           "trading_conversation",
-          "ollama_mcp_bridge",
-          "trading_daily_report"
+          "ollama_mcp_bridge"
         ]
       },
       "TELEGRAM_TRADING_CHAT_ID": {
@@ -25384,10 +26442,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "mt5_api",
           "secrets_helper",
-          "test_mt5_bridge",
-          "bridge_api"
+          "bridge_api",
+          "mt5_api",
+          "test_mt5_bridge"
         ]
       },
       "COIN_SYMBOL": {
@@ -25424,8 +26482,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "homelab_mcp_server"
+          "homelab_mcp_server",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_HOST": {
@@ -25434,8 +26492,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_PORT": {
@@ -25444,8 +26502,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_USER": {
@@ -25454,8 +26512,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_PASSWORD": {
@@ -25464,8 +26522,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_NAME": {
@@ -25474,8 +26532,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "TRADING_STATUS_SYMBOL": {
@@ -25670,24 +26728,6 @@
       },
       "GPU_COORD_TRADING_GPU0_NAME": {
         "name": "GPU_COORD_TRADING_GPU0_NAME",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_TRADING_EXCLUSIVE_GPU0": {
-        "name": "GPU_COORD_TRADING_EXCLUSIVE_GPU0",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_TRADING_HEADROOM_MB": {
-        "name": "GPU_COORD_TRADING_HEADROOM_MB",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -26082,6 +27122,15 @@
           "rules"
         ]
       },
+      "GROUPS_2_RULES_7_LABELS_COIN": {
+        "name": "GROUPS_2_RULES_7_LABELS_COIN",
+        "type": "string",
+        "source": "yaml",
+        "value": "BTC",
+        "contexts": [
+          "rules"
+        ]
+      },
       "GROUPS_4_RULES_2_LABELS_COIN": {
         "name": "GROUPS_4_RULES_2_LABELS_COIN",
         "type": "string",
@@ -26128,398 +27177,6 @@
         ]
       }
     },
-    "integrations": {
-      "GOOGLE_SDM_PROJECT": {
-        "name": "GOOGLE_SDM_PROJECT",
-        "type": "string",
-        "source": ".env",
-        "value": "projects/your_project_id",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 17
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_NUMBER": {
-        "name": "GOOGLE_SDM_PROJECT_NUMBER",
-        "type": "string",
-        "source": ".env",
-        "value": "your_project_number",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 18
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_ID": {
-        "name": "GOOGLE_SDM_PROJECT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "setup_google_home_oauth"
-        ]
-      },
-      "TELEGRAM_CHAT_ID": {
-        "name": "TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "test_playwright",
-          "alert_digest_agent",
-          "pre_tool_guardrails",
-          "secrets_loader",
-          "daily_report",
-          "delivery_approval",
-          "kucoin_api",
-          "setup_telegram",
-          "test_telegram",
-          "job_monitor_continuous",
-          "storj_payout_monitor",
-          "ltfs_button_watch",
-          "telegram_mcp_server",
-          "config",
-          "linkedin_job_scanner",
-          "trading_analyst_rollout_report",
-          "trading_selfheal_exporter",
-          "alertmanager_telegram_webhook",
-          "ci_watcher",
-          "trading_daily_report",
-          "iot_presence_watchdog",
-          "ollama_gpu_selfheal",
-          "approval_gateway",
-          "akash_sweep_to_kucoin",
-          "ltfs_recovery",
-          "lead_capture_api",
-          "smart_ir_selfheal"
-        ]
-      },
-      "WEBHOOKS_ENABLED": {
-        "name": "WEBHOOKS_ENABLED",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "MARKETING_TELEGRAM_NOTIFY": {
-        "name": "MARKETING_TELEGRAM_NOTIFY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "lead_capture_api"
-        ]
-      },
-      "TELEGRAM_BOT_T": {
-        "name": "TELEGRAM_BOT_T",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "approval_gateway",
-          "alert_digest_agent",
-          "pre_tool_guardrails"
-        ]
-      },
-      "GITHUB_AGENT_URL": {
-        "name": "GITHUB_AGENT_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "GOOGLE_CHROME_BIN": {
-        "name": "GOOGLE_CHROME_BIN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "conube_agent"
-        ]
-      },
-      "CONUBE_TELEGRAM_NOTIFY": {
-        "name": "CONUBE_TELEGRAM_NOTIFY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "conube_remediation"
-        ]
-      },
-      "TELEGRAM_PROXY_URL": {
-        "name": "TELEGRAM_PROXY_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "position_manager_mixin"
-        ]
-      },
-      "TELEGRAM_ERROR_CHAT_ID": {
-        "name": "TELEGRAM_ERROR_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "server_error_alert"
-        ]
-      },
-      "GITHUB_REPO": {
-        "name": "GITHUB_REPO",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "setup_deploy_key"
-        ]
-      },
-      "AGENDA_TELEGRAM_CHAT_ID": {
-        "name": "AGENDA_TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "daily_agenda_config",
-          "secrets_loader"
-        ]
-      },
-      "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT": {
-        "name": "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ltfs_recovery"
-        ]
-      },
-      "LTFS_TELEGRAM_POLL_INTERVAL": {
-        "name": "LTFS_TELEGRAM_POLL_INTERVAL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ltfs_recovery"
-        ]
-      },
-      "WEBHOOK_PORT": {
-        "name": "WEBHOOK_PORT",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram_webhook"
-        ]
-      },
-      "WEBHOOK_URL": {
-        "name": "WEBHOOK_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "whatsapp_manager"
-        ]
-      },
-      "GITHUB_CLIENT_ID": {
-        "name": "GITHUB_CLIENT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "github_agent_server",
-          "github_agent_streamlit"
-        ]
-      },
-      "GITHUB_REDIRECT_URI": {
-        "name": "GITHUB_REDIRECT_URI",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "github_agent_server",
-          "github_agent_streamlit"
-        ]
-      },
-      "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID",
-        "type": "integer",
-        "source": "yaml",
-        "value": "948686300",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE",
-        "type": "json",
-        "source": "yaml",
-        "value": "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} - {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "True",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "GLOBAL_TELEGRAM_API_URL": {
-        "name": "GLOBAL_TELEGRAM_API_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "https://api.telegram.org/bot",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      }
-    },
     "infrastructure": {
       "LTFS_MOUNT_POINT": {
         "name": "LTFS_MOUNT_POINT",
@@ -26527,9 +27184,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ltfs_recovery",
           "tape_manager",
-          "tape_orchestrator",
-          "ltfs_recovery"
+          "tape_orchestrator"
         ]
       },
       "AGENT_NETWORK_EXPORTER_PORT": {
@@ -26610,8 +27267,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "create_dev_agent",
-          "config"
+          "config",
+          "create_dev_agent"
         ]
       },
       "LTFS_MAX_MOUNT_ATTEMPTS": {
@@ -26713,15 +27370,15 @@
         "value": null,
         "contexts": [
           "selenium_grafana_action",
+          "tape_quality_ollama_narrator",
+          "test_grafana_selenium",
+          "grafana_query",
+          "create_neural_dashboard",
+          "update_grafana_dashboard_phase2",
           "validate_eddie_central_api",
           "update_grafana_panels_phase2",
-          "tape_quality_ollama_narrator",
           "deploy_grafana",
-          "nas_ai_assessor",
-          "test_grafana_selenium",
-          "create_neural_dashboard",
-          "grafana_query",
-          "update_grafana_dashboard_phase2"
+          "nas_ai_assessor"
         ]
       },
       "GRAFANA_CONTAINER": {
@@ -26758,15 +27415,15 @@
         "value": null,
         "contexts": [
           "selenium_grafana_action",
-          "validate_eddie_central_api",
-          "update_grafana_panels_phase2",
           "tape_quality_ollama_narrator",
-          "deploy_grafana",
-          "nas_ai_assessor",
+          "populate_grafana_dashboard",
           "test_grafana_selenium",
           "grafana_query",
-          "populate_grafana_dashboard",
-          "deploy_grafana_server_selector"
+          "validate_eddie_central_api",
+          "update_grafana_panels_phase2",
+          "deploy_grafana",
+          "deploy_grafana_server_selector",
+          "nas_ai_assessor"
         ]
       },
       "GRAFANA_PASS": {
@@ -26776,13 +27433,13 @@
         "value": null,
         "contexts": [
           "selenium_grafana_action",
-          "validate_eddie_central_api",
-          "update_grafana_panels_phase2",
           "tape_quality_ollama_narrator",
-          "deploy_grafana",
+          "populate_grafana_dashboard",
           "test_grafana_selenium",
           "grafana_query",
-          "populate_grafana_dashboard",
+          "validate_eddie_central_api",
+          "update_grafana_panels_phase2",
+          "deploy_grafana",
           "deploy_grafana_server_selector"
         ]
       },
@@ -26792,8 +27449,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nas_ai_assessor",
-          "test_nas_dashboard_queries"
+          "test_nas_dashboard_queries",
+          "nas_ai_assessor"
         ]
       },
       "GRAFANA_FOLDER_UID": {
@@ -26802,8 +27459,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nas_ai_assessor",
-          "test_nas_dashboard_queries"
+          "test_nas_dashboard_queries",
+          "nas_ai_assessor"
         ]
       },
       "ALERTMANAGER_URL": {
@@ -26938,13 +27595,14 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ALERT": {
@@ -26953,13 +27611,14 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
+          "ollama_coord_error_rules",
+          "gpu_coord_failover_rules",
+          "selfhealing_rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_2_ALERT": {
@@ -26968,10 +27627,11 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
-          "ltfs-selfheal-rules",
+          "selfhealing_rules",
           "alert_rules",
-          "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -26980,8 +27640,9 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotFailureRate",
         "contexts": [
-          "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -26991,6 +27652,7 @@
         "source": "yaml",
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -27001,6 +27663,7 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules",
           "rpa4all-snapshot-alerts"
         ]
@@ -27011,8 +27674,8 @@
         "source": "yaml",
         "value": "TradingAgentDown",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_1_ALERT": {
@@ -27021,8 +27684,8 @@
         "source": "yaml",
         "value": "TradingAgentStalled",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_2_ALERT": {
@@ -27031,8 +27694,8 @@
         "source": "yaml",
         "value": "TradingDecisionsGap",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_3_ALERT": {
@@ -27041,8 +27704,8 @@
         "source": "yaml",
         "value": "TradingSelfHealExhausted",
         "contexts": [
-          "alert_rules",
-          "selfhealing_rules"
+          "selfhealing_rules",
+          "alert_rules"
         ]
       },
       "GROUPS_1_RULES_4_ALERT": {
@@ -27087,6 +27750,7 @@
         "source": "yaml",
         "value": "NASNodeExporterDown",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -27098,56 +27762,58 @@
         "contexts": [
           "contactpoints"
         ]
+      },
+      "GROUPS_0_RULES_7_ALERT": {
+        "name": "GROUPS_0_RULES_7_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CacheFlushJobFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ALERT": {
+        "name": "GROUPS_0_RULES_8_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CacheFlushJobStale",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ALERT": {
+        "name": "GROUPS_0_RULES_9_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CatalogVerificationFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ALERT": {
+        "name": "GROUPS_0_RULES_10_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "TapeLogSpoolDrainFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
       }
     }
   },
   "metadata": {
-    "totalVariables": 2711,
+    "totalVariables": 2911,
     "sourceFiles": [
-      ".env",
       ".env.openai-compatible.example",
       ".env.example",
       ".env.consolidated",
       ".env.example.wiki",
-      ".claude/worktrees/elegant-burnell-19147f/.env.openai-compatible.example",
-      ".claude/worktrees/elegant-burnell-19147f/.env.example",
-      ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-      ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.openai-compatible.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-      ".claude/worktrees/zen-bohr-5c1270/.env.openai-compatible.example",
-      ".claude/worktrees/zen-bohr-5c1270/.env.example",
-      ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-      ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
       "deploy/cmdb/.env.example",
-      ".env",
       "btc_trading_agent/BTC_USDT_shadow.env",
       "systemd/ltfs-lto6-sg1.env",
       "deploy/production_autonomous.env",
       "tools/authentik_management/configs/openwebui.env",
       "tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/zen-bohr-5c1270/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/crypto-agent/models.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/crypto-agent/models.env",
-      ".claude/worktrees/elegant-burnell-19147f/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/grafana.env",
       "deploy/crypto-agent/models.env",
       "docker/docker-compose.gdrive.yml",
       "docker/docker-compose.simple-mail.yml",
@@ -27161,45 +27827,6 @@
       "docker/docker-compose.ntopng.yml",
       "tools/vaultwarden/docker-compose.yml",
       "tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/printshare/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/printshare/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/printshare/docker-compose.yml",
       "deploy/cmdb/docker-compose.yml",
       "deploy/printshare/docker-compose.yml",
       "systemd/agent-network-exporter.service",
@@ -27251,6 +27878,7 @@
       "systemd/eddie-whatsapp-bot.service.d/env.conf",
       "systemd/eddie_central_extended_metrics.service",
       "systemd/ethwan-selfheal.service",
+      "systemd/fix-staging-perms.service",
       "systemd/github-agent.service",
       "systemd/grafana-dashboard-sync.service",
       "systemd/grafana-selfheal.service",
@@ -27282,7 +27910,12 @@
       "systemd/ltfs-button-watch.service",
       "systemd/ltfs-cache-flush.service.d/60-tape-gate.conf",
       "systemd/ltfs-cache-flush.service.d/70-rearm-timer-on-exit.conf",
+      "systemd/ltfs-cache-flush.timer",
+      "systemd/ltfs-catalog-verify.service",
+      "systemd/ltfs-catalog-verify.timer",
       "systemd/ltfs-deep-recovery.service",
+      "systemd/ltfs-journal-replicate.service",
+      "systemd/ltfs-journal-replicate.timer",
       "systemd/ltfs-log-rotation.service",
       "systemd/ltfs-log-rotation.timer",
       "systemd/ltfs-lto6-selfheal-escalator.service",
@@ -27313,6 +27946,7 @@
       "systemd/nas-ai-assessor.service.d/override.conf",
       "systemd/nas-ai-assessor.timer.d/10-power.conf",
       "systemd/nas-ollama-load.service",
+      "systemd/nas-ram-exporter.service",
       "systemd/nextcloud-tape-backup.service.d/30-no-overlap.conf",
       "systemd/nextcloud-tape-backup.service.d/35-sg0-tape-access-scope.conf",
       "systemd/nextcloud-tape-backup.timer.d/20-no-ltfs-require.conf",
@@ -27359,6 +27993,8 @@
       "systemd/pandaplus-telegram-bridge.service",
       "systemd/pihole-ipv6-dns-fix.service",
       "systemd/post-boot-check.service",
+      "systemd/protonvpn-best-server.service",
+      "systemd/protonvpn-best-server.timer",
       "systemd/protonvpn-boot-selfheal.service",
       "systemd/protonvpn-unit-selfheal.service",
       "systemd/protonvpn-unit-selfheal.timer",
@@ -27383,6 +28019,8 @@
       "systemd/storj-payout-monitor.service",
       "systemd/storj-payout-monitor.timer",
       "systemd/tape-component-quality-exporter.service",
+      "systemd/tape-log-spool-drain-nextcloud.service",
+      "systemd/tape-log-spool-drain-nextcloud.timer",
       "systemd/tape-quality-ollama-narrator.service",
       "systemd/tape-quality-ollama-narrator.timer",
       "systemd/tape-safe-eject.service",
@@ -27422,6 +28060,7 @@
       "tests/test_storj_withdraw.py",
       "tests/test_ollama_finetune_batch.py",
       "tests/test_hop_executor_dry_run.py",
+      "tests/test_protonvpn_best_server.py",
       "tests/test_server_error_alert.py",
       "tests/test_telegram_trading.py",
       "tests/test_catalog_variables.py",
@@ -27482,6 +28121,7 @@
       "tests/test_vpn_deb.py",
       "tests/test_storj_selfheal_exporter.py",
       "tests/test_final_boot_status_agent.py",
+      "tests/test_tuya_timer_anti_regression.py",
       "tests/test_ai_plan_fallback.py",
       "tests/test_taxonomy_meta.py",
       "tests/test_cmdb_agent.py",
@@ -27525,6 +28165,7 @@
       "tests/test_rss_llm_trainer.py",
       "tests/test_cloudflared_insert_ssh.py",
       "tests/test_configure_authentik_nextcloud_oidc.py",
+      "tests/test_whatsapp_toolcall_chunked_train_script.py",
       "tests/test_ntopng_auth_deploy.py",
       "tests/_variables_catalog_config.py",
       "tests/test_daily_agenda_approval.py",
@@ -27623,7 +28264,6 @@
       "tests/test_systemd_dropin_parity.py",
       "tests/test_storj_sync_public_address.py",
       "tests/test_llm_log_panel_server.py",
-      "philco10b_raspios/download_iso_libtorrent.py",
       "specialized_agents/telegram_notify.py",
       "specialized_agents/wiki_refactor.py",
       "specialized_agents/copilot_routes.py",
@@ -27717,6 +28357,7 @@
       "scripts/run_dev_tester_fix.py",
       "scripts/cloudflared_insert_ssh.py",
       "scripts/dump_zte_js.py",
+      "scripts/etl_agent_executions_to_training.py",
       "scripts/test_openai_compatible_model.py",
       "scripts/server_error_alert.py",
       "scripts/generate_swagger.py",
@@ -27808,7 +28449,6 @@
       "scripts/trading_analyst_shadow_eval.py",
       "scripts/wikijs_configure.py",
       "tasks/process_documentation_task.py",
-      ".tmp/parse_ha_cross.py",
       "content_automation/logging_setup.py",
       "content_automation/__init__.py",
       "content_automation/models.py",
@@ -27820,14 +28460,6 @@
       "content_automation/trends.py",
       "content_automation/main.py",
       "content_automation/storage.py",
-      "tmp/check_kcs_fee_status.py",
-      "tmp/publish_rss_wiki.py",
-      "tmp/buy_kcs_with_usdt.py",
-      "tmp/publish_kiosk_wiki.py",
-      "tmp/backtest_verify.py",
-      "tmp/regression_4h.py",
-      "tmp/investigate_btc.py",
-      "tmp/regression_20d.py",
       "tools/capture_streamlit_screenshot.py",
       "tools/tape_manager.py",
       "tools/rclone_progress_pessoal.py",
@@ -27845,6 +28477,7 @@
       "tools/daily_agenda_config.py",
       "tools/build_flavio_bolsonaro_agenda_source.py",
       "tools/daily_agenda_job_status.py",
+      "tools/ltfs_cache_flush.py",
       "tools/force_diretor_response.py",
       "tools/run_network_exporter.py",
       "tools/extract_and_store_secrets.py",
@@ -27859,6 +28492,7 @@
       "tools/gdrive_download_and_process.py",
       "tools/ui_smoke_tests.py",
       "tools/send_to_coordinator.py",
+      "tools/ltfs_journal_replicate.py",
       "tools/get_last_telegram_photo.py",
       "tools/tape_dual_recovery.py",
       "tools/watch_coordinator_db.py",
@@ -27872,6 +28506,8 @@
       "tools/parse_playwright_add_loop_results.py",
       "tools/collect_agent_responses.py",
       "tools/invoke_director.py",
+      "tools/ltfs_catalog_verify.py",
+      "tools/tape_log_spool_drain.py",
       "tools/test_record_trade.py",
       "tools/ollama_offloader.py",
       "tools/agent_documentation_manager.py",
@@ -27898,6 +28534,7 @@
       "tools/diretor_latency_exporter.py",
       "tools/agenda_media_router.py",
       "tools/test_cpu_tts_from_generated_text.py",
+      "tools/fix_staging_perms.py",
       "tools/daily_agenda_segments.py",
       "tools/remediate_trading_topology.py",
       "tools/mercadopago_oauth_setup.py",
@@ -27966,6 +28603,7 @@
       "tools/restore_trading_history.py",
       "tools/watch_agent_logs.py",
       "tools/ollama_warmup.py",
+      "tools/nas_ram_exporter.py",
       "tools/audit_undocumented_agents.py",
       "tools/telegram_listener.py",
       "tools/attach_and_dump_bus.py",
@@ -28012,6 +28650,7 @@
       "tools/homelab/tuya_token_renewer.py",
       "tools/homelab/nas_ai_assessor.py",
       "tools/homelab/ha_tuya_mq_watchdog.py",
+      "tools/homelab/protonvpn_best_server.py",
       "tools/homelab/patch_homeassistant_tuya_online_flags.py",
       "tools/homelab/iot_presence_watchdog.py",
       "tools/homelab/tuya_token_selfheal.py",
@@ -28269,8 +28908,10 @@
       "scripts/testing/test_complete_interception.py",
       "scripts/system/__init__.py",
       "scripts/system/legacy_wifi_probe.py",
+      "scripts/misc/debug_delete_probe5.py",
       "scripts/misc/lote2_processor.py",
       "scripts/misc/dry_run_scan.py",
+      "scripts/misc/linkedin_content_purger.py",
       "scripts/misc/fix_ltfs_xml.py",
       "scripts/misc/index_documentation.py",
       "scripts/misc/export_openwebui_roster.py",
@@ -28281,6 +28922,7 @@
       "scripts/misc/index_new_knowledge.py",
       "scripts/misc/install_director.py",
       "scripts/misc/install_webui_function.py",
+      "scripts/misc/debug_delete_probe3.py",
       "scripts/misc/activate_function_correct.py",
       "scripts/misc/llm_compatibility.py",
       "scripts/misc/send_via_curl.py",
@@ -28327,6 +28969,7 @@
       "scripts/misc/find_webui_users.py",
       "scripts/misc/force_interactions.py",
       "scripts/misc/google_calendar_integration.py",
+      "scripts/misc/debug_delete_probe4.py",
       "scripts/misc/ipv6-proxy-multi.py",
       "scripts/misc/lotes3to10_robust.py",
       "scripts/misc/dashboard_validations.py",
@@ -28348,6 +28991,7 @@
       "scripts/misc/home_assistant_integration.py",
       "scripts/misc/restore_grafana_authentik_login.py",
       "scripts/misc/send_pending_report.py",
+      "scripts/misc/debug_delete_probe2.py",
       "scripts/misc/impl_metrics_helper.py",
       "scripts/misc/report_validation_summary.py",
       "scripts/misc/start_waha.py",
@@ -28363,7 +29007,9 @@
       "scripts/misc/validation_scheduler.py",
       "scripts/misc/install_function_webui.py",
       "scripts/misc/web_search.py",
+      "scripts/misc/debug_delete_probe6.py",
       "scripts/misc/list_webui.py",
+      "scripts/misc/linkedin_content_purger_pw.py",
       "scripts/misc/openwebui_tool_executor.py",
       "scripts/misc/try_login.py",
       "scripts/misc/compatibility_semantic.py",
@@ -28409,6 +29055,7 @@
       "scripts/misc/force_activate_persistent.py",
       "scripts/misc/volume_server.py",
       "scripts/misc/delivery_approval.py",
+      "scripts/misc/debug_delete_probe.py",
       "scripts/misc/phomemo_print.py",
       "scripts/misc/phomemo_ble_print.py",
       "scripts/misc/cdp_screenshot.py",
@@ -28516,65 +29163,6 @@
       "config/inventory_homelab.yml",
       "tools/alerting/alertmanager.production.yml",
       "tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/elegant-burnell-19147f/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/zen-bohr-5c1270/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/alert_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/config/prometheus-config.yml",
-      ".claude/worktrees/zen-bohr-5c1270/config/inventory_homelab.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/alerting/alertmanager.production.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/ollama_coord_error_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/gpu_coord_failover_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/pandaplus_bridge_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/zen-bohr-5c1270/site/deploy/cloudflared-rpa4all-ide.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/alert_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/config/prometheus-config.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/config/inventory_homelab.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/alerting/alertmanager.production.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/ollama_coord_error_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/gpu_coord_failover_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/pandaplus_bridge_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/site/deploy/cloudflared-rpa4all-ide.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/alert_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/config/prometheus-config.yml",
-      ".claude/worktrees/elegant-burnell-19147f/config/inventory_homelab.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/elegant-burnell-19147f/site/deploy/cloudflared-rpa4all-ide.yml",
       "monitoring/prometheus/selfhealing_rules.yml",
       "monitoring/prometheus/ollama_coord_error_rules.yml",
       "monitoring/prometheus/gpu_coord_failover_rules.yml",
@@ -28586,45 +29174,17 @@
       "monitoring/grafana/provisioning/alerting/contactpoints.yml",
       "monitoring/grafana/provisioning/dashboards/dashboards.yml",
       "monitoring/grafana/provisioning/datasources/datasources.yml",
+      "monitoring/prometheus/rules/lto-staging-tape-alerts.yml",
       "site/deploy/cloudflared-rpa4all-ide.yml",
       "docs/openapi.yaml",
       "docs/openapi.generated.yaml",
       "content_automation/settings.yaml",
-      ".venv/lib/python3.13/site-packages/markdown_it/port.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/docs/openapi.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/docs/openapi.generated.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/settings.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/grafana/provisioning/datasources/authentik-http.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docs/openapi.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docs/openapi.generated.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/settings.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/grafana/provisioning/datasources/authentik-http.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/docs/openapi.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/docs/openapi.generated.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/settings.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/grafana/provisioning/datasources/authentik-http.yaml",
       "content_automation/data/prompts/curiosidades.yaml",
       "content_automation/data/prompts/cripto.yaml",
       "content_automation/data/prompts/viral_trends.yaml",
       ".continue/mcpServers/new-mcp-server.yaml",
       ".continue/mcpServers/homelab.yaml",
-      "grafana/provisioning/datasources/authentik-http.yaml",
-      "philco10b_raspios/.venv/lib/python3.13/site-packages/markdown_it/port.yaml"
+      "grafana/provisioning/datasources/authentik-http.yaml"
     ],
     "serviceCount": 0
   }

--- a/btc_trading_agent/secrets_helper.py
+++ b/btc_trading_agent/secrets_helper.py
@@ -92,6 +92,40 @@ def get_database_url() -> str:
     )
 
 
+def get_telegram_bot_token() -> str:
+    """Return the shared Telegram bot token.
+
+    Prefers env vars (TELEGRAM_BOT_TOKEN / TG_BOT_TOKEN / TG_TOKEN), then Secrets
+    Agent. The live secret answers on field=password (not field=value).
+    """
+    token = (
+        os.getenv("TELEGRAM_BOT_TOKEN")
+        or os.getenv("TG_BOT_TOKEN")
+        or os.getenv("TG_TOKEN")
+        or ""
+    ).strip()
+    if token:
+        return token
+
+    for secret_name, field in (
+        ("shared/telegram_bot_token", "password"),
+        ("shared/telegram_bot_token", "token"),
+        ("authentik/shared/telegram_bot_token", "password"),
+        ("authentik/shared/telegram_bot_token", "token"),
+        ("eddie/telegram_bot_token", "password"),
+        ("crypto/telegram_bot_token", "password"),
+    ):
+        token = get_secret(secret_name, field)
+        if token:
+            return token.strip()
+
+    raise RuntimeError(
+        "❌ TELEGRAM_BOT_TOKEN não configurado. "
+        "Configure via env var TELEGRAM_BOT_TOKEN ou Secrets Agent "
+        "(shared/telegram_bot_token, field=password)."
+    )
+
+
 def get_kucoin_credentials() -> tuple[str, str, str]:
     """Resolve KuCoin credentials from secrets or env vars."""
     api_key, api_secret, passphrase, _source = get_kucoin_credentials_with_source()

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T00:56:22.530559+00:00",
+  "generated_at": "2026-08-02T14:15:15.721863+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T00:44:53.715948+00:00",
+  "generated_at": "2026-08-02T00:53:07.639359+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T00:23:37.139088+00:00",
+  "generated_at": "2026-08-02T00:44:53.715948+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-03T00:24:40.179218+00:00",
+  "generated_at": "2026-08-03T00:27:35.316457+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T14:15:15.721863+00:00",
+  "generated_at": "2026-08-02T16:24:09.812940+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-01T22:28:51.582744+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-08-01T23:58:12.242584+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,20 +1,20 @@
 {
-  "generated_at": "2026-08-02T16:24:09.812940+00:00",
+  "generated_at": "2026-08-03T00:24:40.179218+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 201,
+    "repo_services": 211,
     "trading_instances": 12,
-    "critical_services": 77,
+    "critical_services": 85,
     "domains": {
       "identity": 4,
-      "monitoring": 18,
+      "monitoring": 19,
       "network": 23,
-      "operations": 113,
-      "storage": 32,
+      "operations": 115,
+      "storage": 39,
       "trading": 11
     }
   },
@@ -322,6 +322,14 @@
       "domain": "monitoring",
       "kind": "systemd",
       "source": "systemd/monitoring-containers-bootstrap.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nas-ram-exporter.service",
+      "domain": "monitoring",
+      "kind": "systemd",
+      "source": "systemd/nas-ram-exporter.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -966,10 +974,26 @@
       "candidate_system": "GLPI review"
     },
     {
+      "name": "faster-whisper-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/faster-whisper-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
       "name": "final-boot-status-agent.service",
       "domain": "operations",
       "kind": "systemd",
       "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "fix-staging-perms.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/fix-staging-perms.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -1574,10 +1598,50 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "ltfs-cache-flush.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-cache-flush.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "ltfs-deep-recovery.service",
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1690,6 +1754,22 @@
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -2159,6 +2239,13 @@
         "critical": true
       },
       {
+        "name": "nas-ram-exporter.service",
+        "domain": "monitoring",
+        "source": "systemd/nas-ram-exporter.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "rss-sentiment-exporter.service",
         "domain": "monitoring",
         "source": "systemd/rss-sentiment-exporter.service",
@@ -2460,9 +2547,44 @@
         "critical": true
       },
       {
+        "name": "ltfs-cache-flush.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-cache-flush.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "ltfs-deep-recovery.service",
         "domain": "storage",
         "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2561,6 +2683,20 @@
         "name": "storj-macvlan-watchdog.timer",
         "domain": "storage",
         "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.service",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.timer",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T00:53:07.639359+00:00",
+  "generated_at": "2026-08-02T00:56:22.530559+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T23:58:12.242584+00:00",
+  "generated_at": "2026-08-02T00:23:37.139088+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T22:28:51.582744+00:00`
+- Generated at: `2026-08-01T23:58:12.242584+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T00:24:40.179218+00:00`
+- Generated at: `2026-08-03T00:27:35.316457+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,20 +1,20 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T16:24:09.812940+00:00`
+- Generated at: `2026-08-03T00:24:40.179218+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `201`
-- Critical services flagged for MVP: `77`
+- Repo services discovered: `211`
+- Critical services flagged for MVP: `85`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
 - `identity`: 4
-- `monitoring`: 18
+- `monitoring`: 19
 - `network`: 23
-- `operations`: 113
-- `storage`: 32
+- `operations`: 115
+- `storage`: 39
 - `trading`: 11
 
 ## Trading profile instances (`12`)
@@ -54,6 +54,7 @@
 - `grafana-selfheal.service` (monitoring, systemd) from `systemd/grafana-selfheal.service`
 - `job-monitor.service` (monitoring, systemd) from `systemd/job-monitor.service`
 - `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
+- `nas-ram-exporter.service` (monitoring, systemd) from `systemd/nas-ram-exporter.service`
 - `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
 - `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
 - `storj-payout-monitor.service` (monitoring, systemd) from `systemd/storj-payout-monitor.service`
@@ -77,7 +78,6 @@
 - `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
 - `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
 - `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
-- `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
 
 ## Serviços anotados manualmente
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T23:58:12.242584+00:00`
+- Generated at: `2026-08-02T00:23:37.139088+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T14:15:15.721863+00:00`
+- Generated at: `2026-08-02T16:24:09.812940+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T00:23:37.139088+00:00`
+- Generated at: `2026-08-02T00:44:53.715948+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T00:56:22.530559+00:00`
+- Generated at: `2026-08-02T14:15:15.721863+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T00:44:53.715948+00:00`
+- Generated at: `2026-08-02T00:53:07.639359+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T00:53:07.639359+00:00`
+- Generated at: `2026-08-02T00:56:22.530559+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/docs/CENA_QUARTO_TUYA_LOCAL.md
+++ b/docs/CENA_QUARTO_TUYA_LOCAL.md
@@ -70,6 +70,18 @@ era falta de plano pago**:
    clique real. **Fix**: gatilhos com `for: 00:00:00.5` (só dispara
    quando o novo estado fica estável por meio segundo).
 
+7. **`mode: single` descartando cliques rápidos** — a automação foi
+   criada com `mode: single`, que **descarta** qualquer disparo que
+   aconteça enquanto uma execução ainda está rodando. Como cada rodada
+   da cena leva ~2-3 s (comandos duplicados + delays de 1 s), o segundo
+   clique físico feito nessa janela era simplesmente ignorado → a cena
+   "parava" ao acionar mais de 1 vez, e só voltava naturalmente quando
+   os cliques paravam (sem reset manual). **Fix (2026-08-02)**:
+   `mode: queued` com `max: 6` — cliques consecutivos agora são
+   enfileirados, cada execução reavalia o estado (fita+spot) do ciclo no
+   início, e o avanço de estado passa a ocorrer 1 passo por clique, por
+   mais rápido que o usuário clique.
+
 ## Dispositivos migrados para Tuya Local
 
 | Papel | Entidade HA | device_id Tuya (na doc, pode rotacionar) | IP local |
@@ -199,7 +211,8 @@ Arquivo: `automations.yaml` do Home Assistant (`homeassistant` container,
     - action: switch.turn_off
       target:
         entity_id: switch.spot_quarto
-  mode: single
+  mode: queued
+  max: 6
 ```
 
 Notas de design:
@@ -214,6 +227,11 @@ Notas de design:
   tiver funcionado.
 - O gatilho usa `for: 00:00:00.5` em vez de "qualquer mudança de estado"
   para filtrar o bounce do relé físico (ver causa #6 acima).
+- O `mode: queued` + `max: 6` permite cliques rápidos consecutivos: cada
+  disparo é enfileirado (até 6) e cada execução reavalia o estado no
+  início, então o ciclo avança 1 passo por clique mesmo se o usuário
+  acionar várias vezes devagar demais para o `single` original aceitar
+  (causa #7, fix 2026-08-02).
 
 ## Self-heal de `local_key` (tuya-local-key-selfheal)
 

--- a/docs/variables-taxonomy/TUYA_TOKEN_SELFHEAL.md
+++ b/docs/variables-taxonomy/TUYA_TOKEN_SELFHEAL.md
@@ -30,3 +30,5 @@ Complementa (não substitui) o **monitor** `tuya-token-renewer` — ver
 | `HEAL_SOFT_THRESHOLD_MIN` | `45` | Minutos restantes do access token do HA abaixo dos quais o selfheal renova proativamente e injeta. `0` = só com token já expirado. |
 | `TUYA_CLIENT_ID` | `HA_3y9q4ak7g4ephrvke` | Client ID público da integração Tuya do HA core (refresh Sharing API). |
 | `TUYA_SHARING_SITE` | `/home/homelab/myClaude/.venv/lib/python3.12/site-packages` | site-packages com `tuya_sharing` (venv do pandaplus-bridge). |
+| `PARTIAL_DEGRADED_MIN_MISSING` | `5` | Nº mínimo de entidades faltando (nem 0 ativas, nem token perto de expirar) para considerar degradação parcial — abaixo disso é tratado como blip normal de 1-2 dispositivos offline. |
+| `PARTIAL_DEGRADED_STREAK_THRESHOLD` | `3` | Checagens consecutivas (a cada 5 min) com degradação parcial sustentada antes de disparar reload da entry. Descoberto 2026-08-02: sem isso, um caso 72/82 ficou travado ~2h até o próximo refresh proativo coincidir e corrigir por acaso. |

--- a/grafana/dashboards/ollama-gpu-cluster.json
+++ b/grafana/dashboards/ollama-gpu-cluster.json
@@ -38,7 +38,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "sum(ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=~\"gpu0-rtx3060|gpu1-gtx1050|nas-rtx2060\"})",
+          "expr": "sum(ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=~\"gpu0-rtx3060|gpu1-gtx1050|nas-rtx2060\"})",
           "instant": true,
           "refId": "A"
         }
@@ -83,7 +83,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "sum(ollama_model_ram_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\"}) / 1024",
+          "expr": "sum(ollama_model_ram_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\"}) / 1024",
           "instant": true,
           "refId": "A",
           "legendFormat": "{{endpoint}} · {{model}}"
@@ -129,7 +129,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
           "instant": true,
           "refId": "A"
         }
@@ -174,7 +174,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
           "instant": true,
           "refId": "A"
         }
@@ -219,7 +219,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"nas-rtx2060\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"nas-rtx2060\"}",
           "instant": true,
           "refId": "A"
         }
@@ -264,7 +264,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "sum(gpu_coord_healthy{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\"})",
+          "expr": "sum(gpu_coord_healthy{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\"})",
           "instant": true,
           "refId": "A"
         }
@@ -303,7 +303,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "ollama_model_ram_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\"}",
+          "expr": "ollama_model_ram_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\"}",
           "instant": true,
           "legendFormat": "{{endpoint}} · {{model}}",
           "refId": "A"
@@ -345,7 +345,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
+          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
           "legendFormat": "GPU0 RTX 3060",
           "refId": "A"
         },
@@ -354,7 +354,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
+          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
           "legendFormat": "GPU1 GTX 1050",
           "refId": "B"
         },
@@ -363,7 +363,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"nas-rtx2060\"}",
+          "expr": "ollama_loaded_models{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"nas-rtx2060\"}",
           "legendFormat": "NAS RTX 2060",
           "refId": "C"
         }
@@ -404,7 +404,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
+          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
           "legendFormat": "GPU0 RTX 3060",
           "refId": "A"
         },
@@ -413,7 +413,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
+          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
           "legendFormat": "GPU1 GTX 1050",
           "refId": "B"
         },
@@ -422,7 +422,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"nas-rtx2060\"}",
+          "expr": "gpu_coord_active_requests{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"nas-rtx2060\"}",
           "legendFormat": "NAS RTX 2060",
           "refId": "C"
         }
@@ -463,7 +463,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu0-rtx3060\"}",
           "legendFormat": "GPU0 RTX3060 (12GB)",
           "refId": "A"
         },
@@ -472,7 +472,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"gpu1-gtx1050\"}",
           "legendFormat": "GPU1 GTX1050 (2GB)",
           "refId": "B"
         },
@@ -481,7 +481,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\",endpoint=\"nas-rtx2060\"}",
+          "expr": "gpu_coord_vram_free_mb{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\",endpoint=\"nas-rtx2060\"}",
           "legendFormat": "NAS RTX2060 (8GB)",
           "refId": "C"
         }
@@ -688,7 +688,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "sum(rate(gpu_coord_total_requests_served{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\"}[5m])) by (endpoint)",
+          "expr": "sum(rate(gpu_coord_total_requests_served{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\"}[5m])) by (endpoint)",
           "legendFormat": "{{endpoint}}",
           "refId": "A"
         }
@@ -729,7 +729,7 @@
             "type": "prometheus",
             "uid": "dfc0w4yioe4u8e"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(ollama_request_duration_seconds_bucket{job=\"ollama-gpu-coordinator\",instance=\"127.0.0.1:11437\"}[5m])) by (model, le))",
+          "expr": "histogram_quantile(0.95, sum(rate(ollama_request_duration_seconds_bucket{job=\"ollama-gpu-coordinator\",instance=~\"127.0.0.1:11437|172.17.0.1:11437\"}[5m])) by (model, le))",
           "legendFormat": "{{model}}",
           "refId": "A"
         }
@@ -845,6 +845,6 @@
   "timezone": "browser",
   "title": "Ollama GPU Cluster",
   "uid": "ollama-metrics-cluster",
-  "version": 6,
-  "description": "Cluster Ollama via ollama-gpu-coordinator (:11437). Queries usam max() + job=ollama-gpu-coordinator para evitar séries duplicadas (scrape multi-instance). VRAM por modelo: ollama_model_ram_mb do coordinator apenas."
+  "version": 7,
+  "description": "Cluster Ollama via ollama-gpu-coordinator (:11437). Queries filtram job=ollama-gpu-coordinator + instance=~\"127.0.0.1:11437|172.17.0.1:11437\" (aceita scrape via localhost OU bridge docker, robusto a flips). VRAM por modelo: ollama_model_ram_mb do coordinator apenas."
 }

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -570,6 +570,60 @@ groups:
   folder: Eddie Alerts
   interval: 1m
   rules:
+  - uid: alert-btc-loop-error
+    title: BTC Trading Agent Loop Error
+    condition: C
+    data:
+    - refId: A
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: dfc0w4yioe4u8e
+      model:
+        expr: btc_trading_loop_errors_5m
+        instant: true
+        refId: A
+    - refId: B
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: __expr__
+      model:
+        expression: A
+        reducer: last
+        refId: B
+        type: reduce
+    - refId: C
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: __expr__
+      model:
+        type: threshold
+        refId: C
+        conditions:
+        - evaluator:
+            type: gt
+            params:
+            - 0
+          operator:
+            type: and
+          reducer:
+            type: last
+          query:
+            params:
+            - B
+          expression: B
+    for: 1m
+    labels:
+      severity: critical
+      category: trading
+      coin: BTC
+    annotations:
+      summary: Trading agent BTC em crash loop ({{ $labels.profile }})
+      description: 'Detectados erros de loop nos últimos 5 min. Verificar: journalctl -u crypto-agent@BTC_USDT_{{ $labels.profile }} -n 50'
+    noDataState: OK
+    execErrState: OK
   - uid: alert-btc-agent-down
     title: BTC Trading Agent Down
     condition: C
@@ -1558,6 +1612,64 @@ groups:
       description: 'Variação: {{ $values.A }}%. Possível pump - considerar take profit.'
     noDataState: OK
     execErrState: OK
+- orgId: 1
+  name: Infrastructure - Ollama GPU
+  folder: Eddie Alerts
+  interval: 1m
+  rules:
+  - uid: alert-ollama-selfheal-ratelimit
+    title: Ollama Selfheal Rate-Limited
+    isPaused: false
+    condition: C
+    data:
+    - refId: A
+      relativeTimeRange:
+        from: 3600
+        to: 0
+      datasourceUid: dfc0w4yioe4u8e
+      model:
+        expr: max(increase(ollama_gpu_selfheal_restarts_total[1h])) >= 3
+        instant: true
+        refId: A
+    - refId: B
+      relativeTimeRange:
+        from: 300
+        to: 0
+      datasourceUid: __expr__
+      model:
+        expression: A
+        reducer: last
+        refId: B
+        type: reduce
+    - refId: C
+      relativeTimeRange:
+        from: 300
+        to: 0
+      datasourceUid: __expr__
+      model:
+        type: threshold
+        expression: B
+        conditions:
+        - evaluator:
+            params:
+            - 0.5
+            type: gt
+          operator:
+            type: and
+          reducer:
+            type: last
+          query:
+            params:
+            - B
+    for: 0s
+    labels:
+      severity: critical
+      category: ollama
+    annotations:
+      summary: Selfheal atingiu limite de restarts (3/hora)
+      description: 'Uma ou ambas GPUs precisaram de 3+ restarts na última hora. Intervenção manual necessária — possível problema de hardware ou VRAM.'
+    noDataState: OK
+    execErrState: Alerting
 - orgId: 1
   name: Infrastructure - Storj
   folder: Eddie Alerts

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -1558,3 +1558,126 @@ groups:
       description: 'Variação: {{ $values.A }}%. Possível pump - considerar take profit.'
     noDataState: OK
     execErrState: OK
+- orgId: 1
+  name: Infrastructure - Storj
+  folder: Eddie Alerts
+  interval: 1m
+  rules:
+
+  # storj_api_stale_seconds mede a idade do payload em cache servido pelo
+  # exporter (tools/storj_exporter.py). Sob operação normal fica em ~0.
+  # Um valor crescente indica que a API local do node parou de responder
+  # (macvlan/ARP, container preso, etc.) e o exporter está mascarando isso
+  # com o cache de até 15 min para não gerar No Data falso no dashboard.
+  # Este alerta pega esse tipo de outage silenciosamente, independente da
+  # causa raiz específica (ver incidentes de 2026-08-01: ARP flapping e
+  # depois arp_ignore=2 em storj-host0).
+  - uid: alert-storj-api-stale
+    title: Storj API Dados Desatualizados
+    condition: C
+    data:
+    - refId: A
+      relativeTimeRange:
+        from: 120
+        to: 0
+      datasourceUid: dfc0w4yioe4u8e
+      model:
+        expr: storj_api_stale_seconds
+        instant: true
+        refId: A
+    - refId: B
+      relativeTimeRange:
+        from: 120
+        to: 0
+      datasourceUid: __expr__
+      model:
+        expression: A
+        reducer: last
+        refId: B
+        type: reduce
+    - refId: C
+      relativeTimeRange:
+        from: 120
+        to: 0
+      datasourceUid: __expr__
+      model:
+        type: threshold
+        refId: C
+        conditions:
+        - evaluator:
+            type: gt
+            params:
+            - 60
+          operator:
+            type: and
+          reducer:
+            type: last
+          query:
+            params:
+            - B
+        expression: B
+    for: 1m
+    labels:
+      severity: warning
+      category: storj
+    annotations:
+      summary: Storj API servindo cache há mais de 60s
+      description: 'storj_api_stale_seconds = {{ $values.A }}s. A API local do node (14002) parou de responder; o exporter está servindo o último payload bom. Checar storj-host-shim, storj-api-proxy e ip neigh show 192.168.15.250.'
+    noDataState: OK
+    execErrState: OK
+
+  # api_up=0 sustentado além do TTL de cache (15min) = outage real, não
+  # apenas stale. Complementa o alerta acima quando o cache também expira.
+  - uid: alert-storj-api-down
+    title: Storj API Fora do Ar
+    condition: C
+    data:
+    - refId: A
+      relativeTimeRange:
+        from: 300
+        to: 0
+      datasourceUid: dfc0w4yioe4u8e
+      model:
+        expr: storj_api_up
+        instant: true
+        refId: A
+    - refId: B
+      relativeTimeRange:
+        from: 300
+        to: 0
+      datasourceUid: __expr__
+      model:
+        expression: A
+        reducer: last
+        refId: B
+        type: reduce
+    - refId: C
+      relativeTimeRange:
+        from: 300
+        to: 0
+      datasourceUid: __expr__
+      model:
+        type: threshold
+        refId: C
+        conditions:
+        - evaluator:
+            type: lt
+            params:
+            - 1
+          operator:
+            type: and
+          reducer:
+            type: last
+          query:
+            params:
+            - B
+        expression: B
+    for: 5m
+    labels:
+      severity: critical
+      category: storj
+    annotations:
+      summary: Storj API fora do ar há mais de 5 minutos
+      description: 'storj_api_up = {{ $values.A }}. Scrape do exporter chegando, mas a API local do node não responde nem via cache. Intervenção manual provável.'
+    noDataState: OK
+    execErrState: OK

--- a/scripts/install_opencode_hooks.sh
+++ b/scripts/install_opencode_hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Instala os hooks do eddie-auto-dev no opencode via symlink global.
+# O opencode auto-carrega todo arquivo em ~/.config/opencode/plugins/.
+# O plugin aplica os hooks Python (tools/copilot_hooks + tools/hooks) em
+# qualquer sessão; repo-root é descoberto com fallback /workspace/eddie-auto-dev.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_SRC="${REPO_ROOT}/.opencode/plugins/rpa4all-hooks.ts"
+PLUGIN_DST="${HOME}/.config/opencode/plugins/rpa4all-hooks.ts"
+
+if [[ ! -f "${PLUGIN_SRC}" ]]; then
+  echo "❌ Plugin não encontrado: ${PLUGIN_SRC}" >&2
+  exit 1
+fi
+
+mkdir -p "${HOME}/.config/opencode/plugins"
+ln -sfn "${PLUGIN_SRC}" "${PLUGIN_DST}"
+
+echo "✅ Symlink criado:"
+echo "   ${PLUGIN_DST} -> ${PLUGIN_SRC}"
+echo ""
+echo "Reinicie o opencode para carregar o plugin."
+echo "Verifique: opencode (settins) → Plugins, ou teste com um comando destrutivo"
+echo "ex.: 'rm -rf' deve ser bloqueado pelo pre_tool_guardrails.py."

--- a/scripts/misc/telegram_bot.py
+++ b/scripts/misc/telegram_bot.py
@@ -94,18 +94,24 @@ except ImportError:
     INTEGRATION_AVAILABLE = False
     print("⚠️ Módulo openwebui_integration não encontrado")
 
-# Configurações
-BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
-if not BOT_TOKEN:
+# Configurações — token via secrets_helper (env → Secrets Agent)
+BOT_TOKEN = ""
+try:
+    from btc_trading_agent.secrets_helper import get_telegram_bot_token
+
+    BOT_TOKEN = get_telegram_bot_token()
+except Exception:
     try:
         from tools.secrets_loader import get_telegram_token
+
         BOT_TOKEN = get_telegram_token() or ""
     except Exception:
         try:
             from tools.vault.secret_store import get_field
+
             BOT_TOKEN = get_field("shared/telegram_bot_token", "password") or ""
         except Exception:
-            BOT_TOKEN = ""
+            BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 HOMELAB_HOST = os.environ.get('HOMELAB_HOST', 'localhost')
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", f"http://{HOMELAB_HOST}:11434")
 MODEL = os.getenv("OLLAMA_MODEL", "shared-coder")

--- a/scripts/storj-macvlan-watchdog.sh
+++ b/scripts/storj-macvlan-watchdog.sh
@@ -3,9 +3,27 @@
 # Causa: reconexões ProtonVPN reiniciam storj-host-shim sem recriar macvlan no container.
 
 CONTAINER=storagenode
+SHIM_IF=${STORJ_SHIM_IF:-storj-host0}
 LOG_TAG='storj-watchdog'
 
 log() { logger -t "$LOG_TAG" "$1"; echo "$(date -u +%FT%TZ) $1"; }
+
+# 0. Guard-rail: arp_ignore=2 em storj-host0 (interface /32) faz o host parar
+#    de responder ARP para o container mesmo com a entrada PERMANENT correta
+#    (ver systemd/99-storj-host0.sysctl.conf). Sem auditd rastreando quem edita
+#    sysctl, uma reintroducao manual passa despercebida ate o proximo outage —
+#    corrige e loga aqui a cada ciclo do watchdog.
+ARP_IGNORE_PATH="/proc/sys/net/ipv4/conf/${SHIM_IF}/arp_ignore"
+if [ -e "$ARP_IGNORE_PATH" ]; then
+  CUR_ARP_IGNORE=$(cat "$ARP_IGNORE_PATH" 2>/dev/null)
+  if [ -n "$CUR_ARP_IGNORE" ] && [ "$CUR_ARP_IGNORE" != '0' ]; then
+    log "FIX: net.ipv4.conf.${SHIM_IF}.arp_ignore=${CUR_ARP_IGNORE} (esperado 0) — corrigindo"
+    sysctl -w "net.ipv4.conf.${SHIM_IF}.arp_ignore=0" >/dev/null 2>&1
+    if [ -f /etc/sysctl.d/99-storj-host0.conf ] && ! grep -q "^net.ipv4.conf.${SHIM_IF}.arp_ignore = 0" /etc/sysctl.d/99-storj-host0.conf; then
+      log "WARN: /etc/sysctl.d/99-storj-host0.conf nao reflete arp_ignore=0 — verificar reintroducao manual"
+    fi
+  fi
+fi
 
 # 1. Container rodando?
 CPID=$(docker inspect "$CONTAINER" --format '{{.State.Pid}}' 2>/dev/null)

--- a/specialized_agents/alert_digest_agent.py
+++ b/specialized_agents/alert_digest_agent.py
@@ -10,7 +10,7 @@ Uso::
 Env vars::
     ALERTMANAGER_URL   — default http://localhost:9093
     PROMETHEUS_URL     — default http://localhost:9090
-    TELEGRAM_BOT_TOKEN / TG_BOT_TOKEN
+    TELEGRAM_BOT_TOKEN / TG_BOT_TOKEN  — opcional; fallback Secrets Agent
     TELEGRAM_CHAT_ID   / TG_BOT_CHAT
     DATABASE_URL       — herdado de /etc/default/eddie-common
 """
@@ -26,6 +26,21 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(_HERE))
 
 from specialized_agents.langgraph_base import AgentState, HomelabAgent
+
+
+def _resolve_telegram_bot_token() -> str:
+    """Token via secrets_helper (env → Secrets Agent); string vazia se indisponível."""
+    try:
+        from btc_trading_agent.secrets_helper import get_telegram_bot_token
+
+        return get_telegram_bot_token()
+    except Exception:
+        try:
+            from secrets_helper import get_telegram_bot_token  # type: ignore
+
+            return get_telegram_bot_token()
+        except Exception:
+            return ""
 
 ALERTMANAGER_URL = os.environ.get("ALERTMANAGER_URL", "http://localhost:9093")
 PROMETHEUS_URL   = os.environ.get("PROMETHEUS_URL",   "http://localhost:9090")
@@ -93,19 +108,13 @@ def _format_digest(alerts: list[dict]) -> str:
 
 
 def _send_telegram(text: str) -> bool:
-    tok = (
-        os.environ.get("TELEGRAM_BOT_T" "OKEN", "")
-        or os.environ.get("TG_BOT_T" "OKEN", "")
-    )
+    tok = _resolve_telegram_bot_token()
     chat = os.environ.get("TELEGRAM_CHAT_ID", "") or os.environ.get("TG_BOT_CHAT", "")
-    if not tok or not chat:
-        # Tenta /etc/default/eddie-common
+    if not chat:
         try:
             for line in open("/etc/default/eddie-common").read().splitlines():
                 k, _, v = line.partition("=")
-                if k in ("TELEGRAM_BOT_T" "OKEN", "TG_BOT_T" "OKEN"):
-                    tok = v.strip()
-                if k in ("TELEGRAM_CHAT_ID", "TG_BOT_CHAT"):
+                if k in ("TELEGRAM_CHAT_ID", "TG_BOT_CHAT") and not chat:
                     chat = v.strip()
         except (FileNotFoundError, PermissionError):
             pass

--- a/specialized_agents/approval_gateway.py
+++ b/specialized_agents/approval_gateway.py
@@ -16,7 +16,7 @@ Uso:
 
 Variáveis de ambiente (lidas de /etc/default/eddie-common e .env):
     DATABASE_URL        — PostgreSQL DSN (/etc/default/eddie-common)
-    TELEGRAM_BOT_TOKEN  — token Telegram (/home/homelab/myClaude/.env)
+    TELEGRAM_BOT_TOKEN  — opcional; fallback Secrets Agent (shared/telegram_bot_token)
     TELEGRAM_CHAT_ID    — chat_id destino (/home/homelab/myClaude/.env)
 
     Aliases aceitos se as vars acima não estiverem definidas:
@@ -91,13 +91,20 @@ def _boot() -> bool:
     if not _DB_DSN:
         missing.append("DATABASE_URL")
 
-    # Aceitar tanto TELEGRAM_BOT_TOKEN (padrão do homelab) quanto TG_BOT_TOKEN
-    _bot_tok = (
-        os.environ.get("TELEGRAM_BOT_T" "OKEN", "")
-        or os.environ.get("TG_BOT_T" "OKEN", "")
-    )
-    if not _bot_tok:
-        missing.append("TELEGRAM_BOT_TOKEN or TG_BOT_TOKEN")
+    # Token: env (TELEGRAM_BOT_TOKEN/TG_*) ou Secrets Agent via secrets_helper
+    _bot_tok = ""
+    try:
+        from btc_trading_agent.secrets_helper import get_telegram_bot_token
+
+        _bot_tok = get_telegram_bot_token()
+    except Exception:
+        try:
+            from secrets_helper import get_telegram_bot_token  # type: ignore
+
+            _bot_tok = get_telegram_bot_token()
+        except Exception as exc:
+            log.error("TELEGRAM_BOT_TOKEN indisponível (env + Secrets Agent): %s", exc)
+            missing.append("TELEGRAM_BOT_TOKEN (env ou Secrets Agent shared/telegram_bot_token)")
 
     # Aceitar tanto TELEGRAM_CHAT_ID (padrão) quanto TG_BOT_CHAT
     _CHAT = (
@@ -109,7 +116,10 @@ def _boot() -> bool:
 
     if missing:
         log.error("Variáveis obrigatórias não definidas: %s", ", ".join(missing))
-        log.error("Fontes: /etc/default/eddie-common (DB) + /home/homelab/myClaude/.env (TG)")
+        log.error(
+            "Fontes: /etc/default/eddie-common (DB/chat) + "
+            "Secrets Agent shared/telegram_bot_token (token)"
+        )
         return False
 
     _BOT_URL = "https://api.telegram.org/bot" + _bot_tok

--- a/systemd/99-storj-host0.sysctl.conf
+++ b/systemd/99-storj-host0.sysctl.conf
@@ -1,0 +1,29 @@
+# Deploy: /etc/sysctl.d/99-storj-host0.conf
+#
+# storj-host0 é a interface macvlan (bridge mode, parent eth-wan) que o host usa
+# para falar com o container do storagenode em 192.168.15.250. Ela tem um único
+# endereço /32 (192.168.15.251/32) — não pertence a uma sub-rede real.
+#
+# Uma linha órfã em /etc/sysctl.conf fixava:
+#   net.ipv4.conf.storj-host0.arp_ignore=2
+#
+# arp_ignore=2 só responde a um ARP request se o IP de quem pergunta estiver na
+# MESMA sub-rede do endereço configurado na interface. Como storj-host0 é /32,
+# essa sub-rede é só ela mesma — o container (192.168.15.250) nunca satisfaz a
+# condição, e o host simplesmente para de responder ARP para ele. Diferente da
+# falha original (entrada ARP do container expirando, corrigida por
+# storj-pin-neigh.sh + nud permanent), este é o sentido host->container: mesmo
+# com a entrada PERMANENT do lado certo, o container fica sem rota para o host
+# porque o who-has dele nunca é respondido.
+#
+# Sintoma observado: storj_api_up cai a 0 / storj-api-proxy loga
+# "Connection timed out" mesmo com `ip neigh show 192.168.15.250` mostrando
+# PERMANENT e o MAC correto. `tcpdump -i storj-host0 arp` mostra o
+# "who-has 192.168.15.251 tell 192.168.15.250" chegando e nunca sendo
+# respondido.
+#
+# arp_ignore=0 (padrão) responde a qualquer ARP request para um IP local da
+# interface, independente da sub-rede de quem pergunta — comportamento correto
+# aqui já que storj-host0 só fala com um peer conhecido (o container) e não
+# está exposta à LAN geral.
+net.ipv4.conf.storj-host0.arp_ignore = 0

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -94,18 +94,24 @@ except ImportError:
     INTEGRATION_AVAILABLE = False
     print("⚠️ Módulo openwebui_integration não encontrado")
 
-# Configurações
-BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
-if not BOT_TOKEN:
+# Configurações — token via secrets_helper (env → Secrets Agent)
+BOT_TOKEN = ""
+try:
+    from btc_trading_agent.secrets_helper import get_telegram_bot_token
+
+    BOT_TOKEN = get_telegram_bot_token()
+except Exception:
     try:
         from tools.secrets_loader import get_telegram_token
+
         BOT_TOKEN = get_telegram_token() or ""
     except Exception:
         try:
             from tools.vault.secret_store import get_field
+
             BOT_TOKEN = get_field("shared/telegram_bot_token", "password") or ""
         except Exception:
-            BOT_TOKEN = ""
+            BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 HOMELAB_HOST = os.environ.get('HOMELAB_HOST', 'localhost')
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", f"http://{HOMELAB_HOST}:11434")
 MODEL = os.getenv("OLLAMA_MODEL", "shared-coder")

--- a/tests/test_btc_secrets_helper.py
+++ b/tests/test_btc_secrets_helper.py
@@ -143,3 +143,57 @@ def test_get_secret_uses_authentik_fallback() -> None:
             val = secrets_helper.get_secret("authentik/some/path", "password", use_cache=False)
 
     assert val == "auth-value"
+
+
+def test_get_telegram_bot_token_prefers_env() -> None:
+    """Env var TELEGRAM_BOT_TOKEN vence o cofre (mesmo padrão de get_database_url)."""
+    with patch.object(secrets_helper, "get_secret") as mock_get_secret, patch.dict(
+        "os.environ",
+        {"TELEGRAM_BOT_TOKEN": "env-token-123"},
+        clear=False,
+    ):
+        mock_get_secret.return_value = "vault-token"
+        assert secrets_helper.get_telegram_bot_token() == "env-token-123"
+    mock_get_secret.assert_not_called()
+
+
+def test_get_telegram_bot_token_accepts_tg_aliases() -> None:
+    """Aliases TG_BOT_TOKEN / TG_TOKEN também resolvem sem ir ao cofre."""
+    with patch.object(secrets_helper, "get_secret") as mock_get_secret, patch.dict(
+        "os.environ",
+        {"TELEGRAM_BOT_TOKEN": "", "TG_BOT_TOKEN": "", "TG_TOKEN": "alias-token"},
+        clear=False,
+    ):
+        mock_get_secret.return_value = "vault-token"
+        assert secrets_helper.get_telegram_bot_token() == "alias-token"
+    mock_get_secret.assert_not_called()
+
+
+def test_get_telegram_bot_token_uses_secrets_agent_password_field() -> None:
+    """Sem env, resolve shared/telegram_bot_token com field=password."""
+    with patch.object(secrets_helper, "get_secret") as mock_get_secret, patch.dict(
+        "os.environ",
+        {"TELEGRAM_BOT_TOKEN": "", "TG_BOT_TOKEN": "", "TG_TOKEN": ""},
+        clear=False,
+    ):
+        def _secret(name: str, field: str = "password", use_cache: bool = True):
+            if name == "shared/telegram_bot_token" and field == "password":
+                return "vault-token-pwd"
+            return None
+
+        mock_get_secret.side_effect = _secret
+        assert secrets_helper.get_telegram_bot_token() == "vault-token-pwd"
+
+
+def test_get_telegram_bot_token_raises_when_missing() -> None:
+    """Sem env e sem cofre, levanta RuntimeError explícito."""
+    with patch.object(secrets_helper, "get_secret", return_value=None), patch.dict(
+        "os.environ",
+        {"TELEGRAM_BOT_TOKEN": "", "TG_BOT_TOKEN": "", "TG_TOKEN": ""},
+        clear=False,
+    ):
+        try:
+            secrets_helper.get_telegram_bot_token()
+            raise AssertionError("expected RuntimeError")
+        except RuntimeError as exc:
+            assert "TELEGRAM_BOT_TOKEN" in str(exc)

--- a/tests/test_tuya_token_selfheal.py
+++ b/tests/test_tuya_token_selfheal.py
@@ -207,6 +207,76 @@ def test_should_reload_entry_expired_token_no_zero_reload() -> None:
     assert not do
 
 
+def test_partial_degraded_below_missing_threshold() -> None:
+    """Faltando poucas entidades (< PARTIAL_DEGRADED_MIN_MISSING) não é degradação."""
+    assert not selfheal.partial_degraded(80, 82)
+
+
+def test_partial_degraded_at_threshold() -> None:
+    assert selfheal.partial_degraded(72, 82)
+
+
+def test_partial_degraded_zero_active_not_covered() -> None:
+    """0 ativas é coberto por should_reload_entry/should_heal separadamente."""
+    assert not selfheal.partial_degraded(0, 82)
+
+
+def test_next_partial_degraded_streak_increments_and_resets() -> None:
+    streak = selfheal.next_partial_degraded_streak(0, 72, 82)
+    assert streak == 1
+    streak = selfheal.next_partial_degraded_streak(streak, 72, 82)
+    assert streak == 2
+    # Recuperou (missing < threshold) → zera.
+    streak = selfheal.next_partial_degraded_streak(streak, 82, 82)
+    assert streak == 0
+
+
+def test_should_reload_entry_healthy_regression_case() -> None:
+    """Caso do teste original (64/75): 11 faltando, mas streak=0 (default) — não reloada.
+
+    Confirma que o novo gatilho não regride o comportamento pré-existente
+    quando o chamador não rastreou nenhuma checagem anterior.
+    """
+    do, reason = selfheal.should_reload_entry("loaded", 64, 75, 50.0)
+    assert not do
+    assert "não necessário" in reason
+
+
+def test_should_reload_entry_partial_degraded_not_yet_sustained() -> None:
+    """72/82 (10 faltando, acima do threshold de missing) mas só 1 checagem — ainda não reloada."""
+    do, reason = selfheal.should_reload_entry(
+        "loaded", 72, 82, 50.0, partial_degraded_streak=1
+    )
+    assert not do
+
+
+def test_should_reload_entry_partial_degraded_sustained_reloads() -> None:
+    """72/82 por PARTIAL_DEGRADED_STREAK_THRESHOLD checagens seguidas → reload.
+
+    Este é o incidente 2026-08-02: entry 'loaded', token ainda válido (50 min,
+    acima do soft threshold), 10 entidades faltando — nenhuma regra anterior
+    disparava e ficou travado ~2h até coincidir com o próximo refresh.
+    """
+    do, reason = selfheal.should_reload_entry(
+        "loaded",
+        72,
+        82,
+        50.0,
+        partial_degraded_streak=selfheal.PARTIAL_DEGRADED_STREAK_THRESHOLD,
+    )
+    assert do
+    assert "faltando" in reason
+    assert "72/82" in reason
+
+
+def test_should_reload_entry_partial_degraded_ignores_small_gap() -> None:
+    """80/82 (2 faltando, abaixo de PARTIAL_DEGRADED_MIN_MISSING) não reloada mesmo com streak alto."""
+    do, reason = selfheal.should_reload_entry(
+        "loaded", 80, 82, 50.0, partial_degraded_streak=10
+    )
+    assert not do
+
+
 def test_entry_state_code() -> None:
     assert selfheal.entry_state_code("loaded", "abc") == 0
     assert selfheal.entry_state_code("setup_error", "abc") == 1

--- a/tools/homelab/tuya_token_selfheal.py
+++ b/tools/homelab/tuya_token_selfheal.py
@@ -13,6 +13,11 @@ Modos de falha cobertos (jul/2026):
    reload da config entry (self-heal antigo *não* cobria — só olhava token).
 3. 0/N entidades ativas com token aparentemente válido → reload; se bridge
    tiver token mais novo, injeta mesmo acima do soft threshold.
+4. Degradação parcial sustentada (ex.: 72/82) — nem 0 ativas nem token
+   perto de expirar, então os modos 1-3 não disparam. Descoberta em
+   2026-08-02: ficou travado ~2h até o próximo refresh proativo por
+   coincidência. Reload se faltarem >= PARTIAL_DEGRADED_MIN_MISSING
+   entidades por PARTIAL_DEGRADED_STREAK_THRESHOLD checagens seguidas.
 
 Fluxo:
 1. Se o access token (HA ou bridge) está abaixo do limiar soft, **força
@@ -68,6 +73,14 @@ TUYA_SELFHEAL_HOT_WAIT_S = int(os.environ.get("TUYA_SELFHEAL_HOT_WAIT_S", "90"))
 # Heal proativo quando o access token do HA está prestes a expirar (minutos).
 # 0 = só com token já expirado (remaining <= 0).
 HEAL_SOFT_THRESHOLD_MIN = float(os.environ.get("HEAL_SOFT_THRESHOLD_MIN", "45"))
+# Degradação parcial (nem 0 ativas, nem token perto de expirar): quantas
+# entidades faltando já valem a pena investigar, e por quantas checagens
+# seguidas isso precisa persistir antes de reload (evita heal por blip
+# transiente de 1-2 dispositivos offline).
+PARTIAL_DEGRADED_MIN_MISSING = int(os.environ.get("PARTIAL_DEGRADED_MIN_MISSING", "5"))
+PARTIAL_DEGRADED_STREAK_THRESHOLD = int(
+    os.environ.get("PARTIAL_DEGRADED_STREAK_THRESHOLD", "3")
+)
 # Client ID público da integração Tuya do Home Assistant core.
 TUYA_CLIENT_ID = os.environ.get("TUYA_CLIENT_ID", "HA_3y9q4ak7g4ephrvke")
 # site-packages do venv que tem tuya_sharing (bridge).
@@ -119,17 +132,47 @@ def valid_runtime_token(token_info: object) -> bool:
     return isinstance(token_info, dict) and REQUIRED_TOKEN_FIELDS.issubset(token_info)
 
 
+def partial_degraded(entities_active: int, entities_total: int) -> bool:
+    """True se faltam >= PARTIAL_DEGRADED_MIN_MISSING entidades (mas não todas).
+
+    Zero ativas já é coberto por ``should_reload_entry``/``should_heal``
+    separadamente; isto cobre o meio-termo (ex.: 72/82) que nenhum dos dois
+    detectava.
+    """
+    if entities_total <= 0 or entities_active <= 0:
+        return False
+    return (entities_total - entities_active) >= PARTIAL_DEGRADED_MIN_MISSING
+
+
+def next_partial_degraded_streak(
+    prev_streak: int, entities_active: int, entities_total: int
+) -> int:
+    """Incrementa o streak de degradação parcial ou zera se saudável."""
+    return prev_streak + 1 if partial_degraded(entities_active, entities_total) else 0
+
+
 def should_reload_entry(
     entry_state: str | None,
     entities_active: int,
     entities_total: int,
     remaining_min: float,
+    *,
+    partial_degraded_streak: int = 0,
 ) -> tuple[bool, str]:
     """Decide se a config entry Tuya deve ser recarregada (sem injetar token).
 
     Cobre o buraco do incidente 2026-07-25: entry em ``setup_error`` por
     timeout da API Tuya, token ainda com dezenas de minutos, 0 entidades
     ativas — o heal de token recusava com "ainda válido" e ninguém reloadava.
+
+    Também cobre o buraco do incidente 2026-08-02: degradação parcial
+    sustentada (ex.: 72/82) — nem 0 ativas nem token perto de expirar, então
+    nenhuma das regras acima disparava; ficou travado ~2h até coincidir com
+    o próximo refresh proativo. ``partial_degraded_streak`` é o nº de
+    checagens consecutivas (rastreado pelo chamador via state persistido)
+    em que a entry já estava faltando >= PARTIAL_DEGRADED_MIN_MISSING
+    entidades; só reloada ao atingir PARTIAL_DEGRADED_STREAK_THRESHOLD, para
+    não reagir a um blip transiente de 1-2 dispositivos offline.
     """
     state = (entry_state or "").strip().lower()
     if state == "setup_error":
@@ -146,6 +189,16 @@ def should_reload_entry(
             True,
             f"0/{entities_total} ativas com token ainda válido "
             f"({remaining_min:.0f} min) — reload da entry",
+        )
+    if (
+        partial_degraded(entities_active, entities_total)
+        and partial_degraded_streak >= PARTIAL_DEGRADED_STREAK_THRESHOLD
+    ):
+        missing = entities_total - entities_active
+        return (
+            True,
+            f"{missing} entidades faltando ({entities_active}/{entities_total}) "
+            f"há {partial_degraded_streak} checagens seguidas — reload da entry",
         )
     return False, "reload não necessário"
 
@@ -442,6 +495,10 @@ def render_prom(metrics: dict[str, float | int]) -> str:
         "tuya_bridge_token_remaining_minutes": ("gauge", "Minutos até expirar o token runtime do bridge"),
         "tuya_entities_active": ("gauge", "Entidades Tuya disponíveis no HA"),
         "tuya_entities_total": ("gauge", "Entidades Tuya habilitadas na entry"),
+        "tuya_partial_degraded_streak": (
+            "gauge",
+            "Checagens consecutivas com degradação parcial (>= PARTIAL_DEGRADED_MIN_MISSING faltando)",
+        ),
     }
     lines = []
     for name, value in metrics.items():
@@ -782,6 +839,7 @@ def load_state() -> dict:
             "reloads_total": 0,
             "last_heal_timestamp": 0,
             "heal_history": [],
+            "partial_degraded_streak": 0,
         }
 
 
@@ -827,6 +885,7 @@ def _prom_snapshot(
         "tuya_bridge_token_remaining_minutes": round(
             token_remaining_minutes(runtime_token) if runtime_token else -1, 1
         ),
+        "tuya_partial_degraded_streak": state.get("partial_degraded_streak", 0),
         "tuya_entities_active": (status or {}).get("entities_active", 0),
         "tuya_entities_total": (status or {}).get("entities_total", 0),
     }
@@ -837,6 +896,7 @@ def main() -> int:
     state["runs_total"] += 1
     state["heal_history"] = prune_heal_history(state.get("heal_history", []))
     state.setdefault("reloads_total", 0)
+    state.setdefault("partial_degraded_streak", 0)
 
     status = ha_tuya_status_with_retry()
     runtime_token = load_runtime_token()
@@ -862,6 +922,11 @@ def main() -> int:
     integration_dead = (
         status.get("entities_total", 0) > 0 and status.get("entities_active", 0) == 0
     ) or (status.get("entry_state") or "").lower() == "setup_error"
+    state["partial_degraded_streak"] = next_partial_degraded_streak(
+        state.get("partial_degraded_streak", 0),
+        status["entities_active"],
+        status["entities_total"],
+    )
 
     # Antes de decidir heal: renova o runtime token se o HA está na janela soft
     # OU se a integração está morta (0 ativas / setup_error).
@@ -885,6 +950,7 @@ def main() -> int:
         status["entities_active"],
         status["entities_total"],
         ha_remaining,
+        partial_degraded_streak=state["partial_degraded_streak"],
     )
     # Reload só faz sentido se o token no storage ainda pode autenticar.
     # Token já morto → pular direto para inject (reload só gasta tempo).


### PR DESCRIPTION
## Summary
Fase 3 da migração do token Telegram para o Secrets Agent (após remover o `Environment=` do `crypto-agent@`).

- Adiciona `get_telegram_bot_token()` em `btc_trading_agent/secrets_helper.py`, espelhando `get_database_url()`: env primeiro (`TELEGRAM_BOT_TOKEN` / `TG_BOT_TOKEN` / `TG_TOKEN`), depois Secrets Agent.
- Campo canônico no cofre: **`password`** (não `value` — pedir `value` falha e loga warning enganoso).
- Migra os três consumidores que só liam `os.getenv`:
  - `specialized_agents/alert_digest_agent.py` — deixa de ler o token de `/etc/default/eddie-common`
  - `specialized_agents/approval_gateway.py`
  - `telegram_bot.py` e `scripts/misc/telegram_bot.py` (cópia espelho)
- Testes unitários em `tests/test_btc_secrets_helper.py` (env, aliases, cofre, RuntimeError).

## Context
O `crypto-agent@` já resolve via `kucoin_api._resolve_telegram_bot_token()` e a frota 14/14 já roda sem o token no environ. Estes três ainda dependiam de env em texto plano.

## Test plan
- [x] `pytest tests/test_btc_secrets_helper.py` (10 passed)
- [x] `ast.parse` nos 4 arquivos migrados
- [ ] Após merge: reiniciar `approval-gateway` / `shared-telegram-bot` / digest (se ativo) **sem** `TELEGRAM_BOT_TOKEN` no unit e validar boot
- [ ] Não reinicia frota de trading neste PR