### PR TITLE
fix(trading): destrava aprovacao por botao no Telegram + deploy docker compose

### DIFF
--- a/specialized_agents/approval_gateway.py
+++ b/specialized_agents/approval_gateway.py
@@ -235,7 +235,7 @@ def _poll_tg() -> list[dict[str, Any]]:
     res = _tg("getUpdates", {
         "offset":          _tg_offset,
         "timeout":         TG_LONG_POLL,
-        "allowed_updates": ["callback_query", "message"],
+        "allowed_updates": ["callback_query"],
     }, timeout=TG_LONG_POLL + 5)
     return res or []
 
@@ -346,7 +346,7 @@ def _resolve(prefix: str) -> str | None:
             (prefix + "%",)
         )
         row = cur.fetchone(); cur.close(); c.close()
-        return row[0] if row else None
+        return row["intent_id"] if row else None
     except Exception:
         return None
 
@@ -354,6 +354,28 @@ def _resolve(prefix: str) -> str | None:
 # ══════════════════════════════════════════════════════════════════════════
 # Handlers
 # ══════════════════════════════════════════════════════════════════════════
+
+def _ensure_configured() -> None:
+    """Reinicializa a config do gateway a partir do ambiente quando chamada a partir
+    de outro processo (ex: o bot). No processo do bot nao ha _DB_DSN/_BOT_URL/_CHAT
+    preenchidos; busca do env tal como _boot faz."""
+    global _DB_DSN, _BOT_URL, _CHAT
+    if not (_DB_DSN and _BOT_URL and _CHAT):
+        _boot()
+    if not (_DB_DSN and _BOT_URL and _CHAT):
+        raise RuntimeError("approval_gateway: env obrigatorio (DATABASE_URL, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID) ausente")
+
+
+def handle_telegram_callback_query(cb: dict[str, Any]) -> None:
+    """Entry-point publico para o eddie-telegram-bot rotear callback_query de aprovacao.
+
+    O bot e o UNICO long-poll do token (config TG_POLL=0). Ao receber um
+    callback_query, ele chama esta funcao para decidir/atualizar o Action
+    Journal, mantendo a logica de decisao unica aqui no gateway.
+    """
+    _ensure_configured()
+    _on_callback(cb)
+
 
 def _on_callback(cb: dict[str, Any]) -> None:
     cb_id  = cb.get("id", "")
@@ -440,7 +462,7 @@ def _on_text(msg: dict[str, Any]) -> None:
     if not row:
         return
 
-    iid = row[0]
+    iid = row["intent_id"]
     label = "approved" if is_ok else "rejected"
     _decide(iid, label, f"@{usr} (texto)")
     mid = _intent_to_msg.get(iid)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -3554,6 +3554,19 @@ class TelegramBot:
         
         print(f"[{datetime.now().strftime('%H:%M:%S')}] Bot: {response[:50]}...")
     
+
+    async def _route_approval_callback(self, cb: dict) -> None:
+        """Rota um callback_query de aprovacao (approval-gate) para a logica de
+        decisao. O gateway roda com TG_POLL=0 e concentra o processamento na
+        funcao handle_telegram_callback_query()."""
+        try:
+            from specialized_agents.approval_gateway import handle_telegram_callback_query
+        except ImportError:
+            import sys, os
+            sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+            from specialized_agents.approval_gateway import handle_telegram_callback_query
+        handle_telegram_callback_query(cb)
+
     async def run(self):
         """Loop principal"""
         print("=" * 50)
@@ -3708,6 +3721,13 @@ class TelegramBot:
                                 await self.handle_message(update["message"])
                             except Exception as msg_error:
                                 print(f"[Erro] Processando mensagem: {msg_error}")
+                                import traceback
+                                traceback.print_exc()
+                        elif "callback_query" in update:
+                            try:
+                                await self._route_approval_callback(update["callback_query"])
+                            except Exception as cb_error:
+                                print(f"[Erro] Processando callback: {cb_error}")
                                 import traceback
                                 traceback.print_exc()
                     # Pausa breve entre ciclos sem updates

--- a/tools/run_daily_agenda_broadcast.py
+++ b/tools/run_daily_agenda_broadcast.py
@@ -801,6 +801,11 @@ def _run_with_optional_approval(
         decision = wait_for_decision(
             date_str=date_str,
             timeout_minutes=timeout_minutes,
+            # Polling do Telegram é feito de forma centralizada pelo
+            # eddie-telegram-bot, unico long-poll do token. Ele roteia os botões
+            # dag:* via approval_gateway._on_callback -> daily_agenda_approval.
+            # Aguardar apenas o arquivo de estado evita 409/conflico de pollers.
+            poll_telegram=False,
         )
         if decision == "approved":
             approval_note = "Aprovado no Telegram."

--- a/tools/telegram_mcp_server.py
+++ b/tools/telegram_mcp_server.py
@@ -314,7 +314,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             analyze = bool(arguments.get("analyze_media", True))
             only_new = bool(arguments.get("only_new", False))
 
-            data = await tg_get(client, "getUpdates", limit=100, offset=-100)
+            data = await tg_get(client, "getUpdates", limit=100, offset=-100, allowed_updates=["message"])
             updates = data.get("result", [])
 
             messages = []
@@ -378,7 +378,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         elif name == "tg_context":
             n    = min(int(arguments.get("n", 10)), 50)
 
-            data = await tg_get(client, "getUpdates", limit=100, offset=-100)
+            data = await tg_get(client, "getUpdates", limit=100, offset=-100, allowed_updates=["message"])
             updates = data.get("result", [])
             messages = [u.get("message") or u.get("channel_post")
                         for u in updates if u.get("message") or u.get("channel_post")]


### PR DESCRIPTION
## Problema
O fluxo de aprovação de intents por botão no Telegram **nunca funcionou** (0 callbacks na história do approval-gateway). Dois bugs de raiz:

1. **approval_gateway.py** usa `RealDictCursor`, mas `_resolve`/`_on_text` indexavam `row[0]` (posicional) -> KeyError engolido -> sempre "Intent nao encontrado".
2. **Roteamento ausente**: servico define `TG_POLL=0` (unico poller = bot), mas `telegram_bot.py` descartava `callback_query` silenciosamente.

## Correcoes
- `approval_gateway.py`: `row[0]`->`row["intent_id"]`; adiciona `_ensure_configured()` + `handle_telegram_callback_query()` publicos.
- `telegram_bot.py`: roteia callbacks para o gateway via `_route_approval_callback`.
- `telegram_mcp_server.py`: `getUpdates` filtra `allowed_updates=["message"]`.
- `run_daily_agenda_broadcast.py`: `wait_for_decision(poll_telegram=False)` - polling centralizado no bot.

## Validacao
Aprovacao de ponta a ponta: os 2 intents pendentes ficaram approved por @Eddiejdi via botao.

## Servicos
- `networkd-dispatcher.service`: failed -> active.
- `freecash-browser-deploy`: repo Docker + compose v2, script migrado para `docker compose`, container Up, servico Result=success.
