### PR TITLE
fix(tuya): timer do selfheal morto pós-reboot — OnCalendar + guard anti-regressão

### DIFF
--- a/.github/workflows/deploy-tuya-token-selfheal.yml
+++ b/.github/workflows/deploy-tuya-token-selfheal.yml
@@ -26,6 +26,16 @@ jobs:
 
           python3 -m py_compile tools/homelab/tuya_token_selfheal.py
 
+          # Guard anti-regressão (incidente 2026-08-02): agendamento
+          # monotônico (OnBootSec/OnUnitActiveSec) sobrevive a daemon-reload
+          # mas morre em reboot (NextElapse=infinity) — o self-heal nunca
+          # volta a rodar e o token Tuya expira em ~2h. Exigir wall-clock.
+          if grep -qE '^On(BootSec|UnitActiveSec)=' systemd/tuya-token-selfheal.timer; then
+            echo "❌ Timer reintroduziu agendamento monotônico — exige OnCalendar=" >&2
+            exit 1
+          fi
+          grep -q '^OnCalendar=' systemd/tuya-token-selfheal.timer
+
           sudo install -D -m 0755 tools/homelab/tuya_token_selfheal.py /usr/local/bin/tuya_token_selfheal.py
           sudo install -D -m 0644 systemd/tuya-token-selfheal.service /etc/systemd/system/tuya-token-selfheal.service
           sudo install -D -m 0644 systemd/tuya-token-selfheal.timer /etc/systemd/system/tuya-token-selfheal.timer
@@ -36,6 +46,7 @@ jobs:
 
           echo "✅ Units instaladas"
           systemctl status tuya-token-selfheal.timer --no-pager | grep -E "Active|Trigger"
+          test "$(systemctl show tuya-token-selfheal.timer -p NextElapseOnCalendar --value)" != ""
 
       - name: Smoke test (execução única + métricas)
         run: |

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-01T22:28:51.582744+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-08-02T15:39:27.224149+00:00",
+  "repo_root": "/tmp/opencode/tuya-fix-wt",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-01T22:28:51.582744+00:00`
+- Generated at: `2026-08-02T15:39:27.224149+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`

--- a/docs/INCIDENTS/2026-08-02_TUYA_TOKEN_SELFHEAL_TIMER_MONOTONIC_AFTER_REBOOT.md
+++ b/docs/INCIDENTS/2026-08-02_TUYA_TOKEN_SELFHEAL_TIMER_MONOTONIC_AFTER_REBOOT.md
@@ -1,0 +1,77 @@
+# 2026-08-02 — Tuya: auth caiu no HA por timer monotônico do self-heal morto após reboot
+
+**Severidade:** alta (0/82 entidades Tuya ativas; integração em `setup_error`)  
+**Domínio:** integração Tuya no Home Assistant / systemd / homelab  
+**Status:** corrigido e validado (82/82 entidades ativas; timer recuperado)
+
+---
+
+## Sintoma
+
+- Integração Tuya (`edenilson.adm@gmail.com`, entry `01KTFKZCWXYD0TD70516RXDMZG`) em `setup_error` no HA.
+- **0/82 entidades** ativas; alertas de auth falhando.
+- `tuya-token-renewer` (timer 30 min) só monitorava/alertava e **não** renovava — quem renova é o `tuya-token-selfheal`.
+- Log: `Config entry 'edenilson.adm@gmail.com' for tuya integration could not authenticate: Authentication failed`.
+
+---
+
+## Diagnóstico
+
+### Causa raiz
+
+1. O `tuya-token-selfheal.timer` usava **`OnBootSec=2min` + `OnUnitActiveSec=5min`** (agendamento **monotônico**).
+2. Após reboot do host em 2026-08-01 17:20, o systemd perdeu o próximo disparo: `NextElapse=infinity` e o timer **nunca mais rodou**.
+3. Sem renovação e com token de vida curta (~2h), a sessão Tuya expirou e a integração caiu.
+4. Agravante: há **dois timers Tuya** — `tuya-token-renewer` (90min, `OnBootSec`+`OnUnitActiveSec`, **mesmo padrão monotônico**) e `tuya-token-selfheal` (5min). Os dois podiam morrer em reboot; o que de fato morreu foi o self-heal.
+
+### Confirmação
+
+- `systemctl list-timers tuya-token-selfheal` mostrava `NEXT=` vazio e `NextElapse=infinity` após o reboot.
+- Tokens (HA `/config/.storage/core.config_entries` e bridge `/var/lib/pandaplus-bridge/tuya_tokens_runtime.json`) ambos expirados.
+- Prova de que QR não nasce expirado: token gerado via `tuya_sharing.LoginControl` num QR **ligado**, e o server polling retornava `E0020003 Login failed, please scan and try again!` enquanto aguardava scan.
+
+---
+
+## Mitigação (código)
+
+| Área | Mudança |
+|------|---------|
+| Timer `tuya-token-selfheal` | `OnCalendar=*:00/5` + `RandomizedDelaySec=10` (relógio real, não monotônico) |
+| `Persistent=true` | mantido (pega ciclos perdidos) |
+| Redeploys | workflow `deploy-tuya-token-selfheal` cobre `systemd/tuya-token-selfheal.timer` |
+
+Arquivos principais:
+
+- `systemd/tuya-token-selfheal.timer`
+- `systemd/tuya-token-renewer.timer` (mesmo padrão; não alterado nesta correção)
+- `tools/homelab/tuya_token_selfheal.py`
+
+Feedback: token novo foi injetado na entry do HA (`/config/.storage/core.config_entries`), atualizado também no runtime do bridge (`/var/lib/pandaplus-bridge/tuya_tokens_runtime.json`), e o entry foi recarregado via API. O selfheal assumiu o loop com `hot apply` (serviço `tuya_token_inject.apply`) a partir do runtime novo.
+
+---
+
+## Prova de saúde restaurada
+
+| Campo | Valor |
+|-------|--------|
+| Reinício runtime | 2026-08-02T12:17:36 (hot apply, `t=1785683709141`) |
+| Entidades | **82/82 ativas** (`Heal OK (hot)`) |
+| Config entry | `loaded` |
+| Próximo disparo timer | `OnCalendar=*:00/5` verificado (NEXT agendado) |
+
+---
+
+## Lições
+
+1. **Timers críticos com `OnBootSec`/`OnUnitActiveSec` morrem em reboot** — para serviços que mantêm sessão (tokens, tunnel, watchdog) a reserva de wall-clock (`OnCalendar`) + `Persistent=true` é mais robusta.
+2. **Um mesmo padrão em dois arquivos**: consertar um dos timers sem atacá-lo do outro (renewer D escopia o mesmo bug — falta corrigir).
+3. **QR Tuya não "nasce" expirado**: janela de 5 min começa ao gerar; erro E_* no cron/polling é só "aguardando scan".
+4. **Reauth manual: token novo na entrada + runtime + reload do entry; o selfheal assume loop após.**
+
+---
+
+## Follow-ups (pendentes)
+
+- [ ] Corrigir `systemd/tuya-token-renewer.timer` (mesmo `OnBootSec`+`OnUnitActiveSec` monotônico) para `OnCalendar=` + `Persistent=true`.
+- [ ] Guard anti-regressão: teste CI que **falha** se `tuya-token-selfheal.timer` (e `-renewer`) reintroduzir `OnBootSec`/`OnUnitActiveSec`.
+- [ ] Adicionar o guard no workflow `deploy-tuya-token-selfheal.yml` para não regredir em deploy.

--- a/systemd/tuya-token-selfheal.timer
+++ b/systemd/tuya-token-selfheal.timer
@@ -3,9 +3,9 @@ Description=Roda o self-heal do token Tuya a cada 5 minutos
 After=network-online.target
 
 [Timer]
-OnBootSec=2min
-OnUnitActiveSec=5min
+OnCalendar=*:00/5
 Persistent=true
+RandomizedDelaySec=10
 Unit=tuya-token-selfheal.service
 
 [Install]

--- a/tests/test_tuya_timer_anti_regression.py
+++ b/tests/test_tuya_timer_anti_regression.py
@@ -1,0 +1,60 @@
+"""Guard anti-regressão do timer do tuya-token-selfheal.
+
+Incidente 2026-08-02: o timer usava OnBootSec/OnUnitActiveSec (agendamento
+monotônico). Após reboot do host o systemd perdeu o disparo
+(NextElapse=infinity) e o self-heal nunca mais rodou → token Tuya expirou
+e a integração caiu em setup_error (0/82 entidades).
+
+Um timer wall-clock (OnCalendar) + Persistent=true é imune a essa perda.
+Estes testes falham se alguém reintroduzir o agendamento monotônico.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TIMER = REPO_ROOT / "systemd" / "tuya-token-selfheal.timer"
+
+
+def _timer_text() -> str:
+    return TIMER.read_text(encoding="utf-8")
+
+
+def test_timer_exists() -> None:
+    assert TIMER.is_file()
+
+
+def test_timer_uses_calendar_not_monotonic() -> None:
+    text = _timer_text()
+    assert "OnCalendar=" in text, "onCalendar ausente — reintroduziu monotônico?"
+    assert "OnBootSec=" not in text
+    assert "OnUnitActiveSec=" not in text
+
+
+def test_timer_has_randomized_delay() -> None:
+    assert "RandomizedDelaySec=" in _timer_text()
+
+
+def test_timer_is_persistent() -> None:
+    assert "Persistent=true" in _timer_text()
+
+
+def test_timer_target() -> None:
+    assert "[Install]" in _timer_text()
+    assert "WantedBy=timers.target" in _timer_text()
+
+
+def test_timer_activates_selfheal_service() -> None:
+    assert "Unit=tuya-token-selfheal.service" in _timer_text()
+    assert (REPO_ROOT / "systemd" / "tuya-token-selfheal.service").is_file()
+
+
+def test_deploy_workflow_guards_timer() -> None:
+    """O deploy do selfheal precisa reinstalar o timer — regressão aqui
+    faria um dex de 'só o script' recair no agendamento bugado."""
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "deploy-tuya-token-selfheal.yml"
+    ).read_text(encoding="utf-8")
+    assert "tuya-token-selfheal.timer" in workflow
+    assert "systemctl" in workflow


### PR DESCRIPTION
## Contexto
Incidente 2026-08-02: integração Tuya no HA caiu para `setup_error` (0/82 entidades).

### Causa raiz
O `tuya-token-selfheal.timer` usava agendamento **monotônico** (`OnBootSec` + `OnUnitActiveSec`). Após reboot do host, o systemd perdeu o disparo (`NextElapse=infinity`) e o self-heal **nunca mais rodou** — com token de vida 2h, a sessão Tuya expirou e a integração caiu.

## Mudanças
| Arquivo | Mudança |
|---------|---------|
| `systemd/tuya-token-selfheal.timer` | `OnCalendar=*:00/5` + `RandomizedDelaySec=10` (wall-clock, imune a reboot) + mantém `Persistent=true` |
| `.github/workflows/deploy-tuya-token-selfheal.yml` | Guard: **aborta deploy** se timer reintroduzir `OnBootSec`/`OnUnitActiveSec`; smoke valida `NextElapseOnCalendar` |
| `tests/test_tuya_timer_anti_regression.py` | 7 testes que **falham** se reintroduzir agendamento monotônico |
| `docs/INCIDENTS/…_TIMER_MONOTONIC_AFTER_REBOOT.md` | Registro completo do incidente + lições + follow-ups |

## Validação
- `pytest tests/test_tuya_timer_anti_regression.py tests/test_tuya_token_selfheal.py` → **pass (36 testes)**
- Timer aplicado em produção: 82/82 entidades ativas, entry `loaded`, NEXT agendado
- Wiki-sync publikou o doc do incidente

## Nota (fora do escopo desta PR)
`tuya-token-renewer.timer` tem o **mesmo padrão** monotônico e (host: 30min vs repo: 90min). Guarda como follow-up no doc.