### PR TITLE
fix(ci): smoke do deploy-tuya valida nome correto da propriedade (NextElapseUSecRealtime)

### DIFF
--- a/.github/workflows/deploy-tuya-token-selfheal.yml
+++ b/.github/workflows/deploy-tuya-token-selfheal.yml
@@ -46,7 +46,7 @@ jobs:
 
           echo "✅ Units instaladas"
           systemctl status tuya-token-selfheal.timer --no-pager | grep -E "Active|Trigger"
-          test "$(systemctl show tuya-token-selfheal.timer -p NextElapseOnCalendar --value)" != ""
+          test "$(systemctl show tuya-token-selfheal.timer -p NextElapseUSecRealtime --value)" != "0"
 
       - name: Smoke test (execução única + métricas)
         run: |

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T15:39:27.224149+00:00",
+  "generated_at": "2026-08-02T15:46:23.454213+00:00",
   "repo_root": "/tmp/opencode/tuya-fix-wt",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T15:39:27.224149+00:00`
+- Generated at: `2026-08-02T15:46:23.454213+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `201`


### PR DESCRIPTION
Follow-up do PR #294. O deploy em main falhou no smoke test — o guard instalou o timer correto (OnCalendar + RandomizedDelaySec, ativo), mas validava a propriedade inexistente `NextElapseOnCalendar`. A propriedade real é `NextElapseUSecRealtime` (0 somente sem agendamento wall-clock). Corrige o nome para o guard anti-regressão valer de verdade.