### PR TITLE
feat(lto): fluxo Nextcloud -> staging -> fita — implementa gaps G1-G20

### DIFF
--- a/.variables-catalog/catalog.json
+++ b/.variables-catalog/catalog.json
@@ -1,193 +1,9 @@
 {
   "catalogVersion": "1.0.0",
-  "generatedAt": "2026-07-31T21:11:53.969995",
+  "generatedAt": "2026-08-02T21:57:52.597871",
   "environment": "production",
   "categories": {
     "services": {
-      "WIKI_API": {
-        "name": "WIKI_API",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "test_variable_registry_validate"
-        ]
-      },
-      "WIKI_PUBLIC": {
-        "name": "WIKI_PUBLIC",
-        "type": "url",
-        "source": ".env",
-        "value": "https://wiki.rpa4all.com",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 4
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 3
-          },
-          {
-            "file": ".env",
-            "line": 4
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_API": {
-        "name": "WIKI_OLLAMA_API",
-        "type": "url",
-        "source": ".env",
-        "value": "http://192.168.15.2:11437/api",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 6
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 5
-          },
-          {
-            "file": ".env",
-            "line": 6
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_OLLAMA_MODEL": {
-        "name": "WIKI_OLLAMA_MODEL",
-        "type": "string",
-        "source": ".env",
-        "value": "qwen3:8b",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 7
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 6
-          },
-          {
-            "file": ".env",
-            "line": 7
-          }
-        ],
-        "contexts": []
-      },
-      "WIKI_LOCALE": {
-        "name": "WIKI_LOCALE",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "wiki_agent",
-          "server_error_alert"
-        ]
-      },
-      "WIKI_TIMEOUT": {
-        "name": "WIKI_TIMEOUT",
-        "type": "integer",
-        "source": ".env",
-        "value": "90",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 9
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 8
-          },
-          {
-            "file": ".env",
-            "line": 9
-          }
-        ],
-        "contexts": []
-      },
-      "PAGES_FILE": {
-        "name": "PAGES_FILE",
-        "type": "string",
-        "source": ".env",
-        "value": "wiki_pages.json",
-        "locations": [
-          {
-            "file": ".env",
-            "line": 10
-          },
-          {
-            "file": ".env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-            "line": 9
-          },
-          {
-            "file": ".env",
-            "line": 10
-          }
-        ],
-        "contexts": []
-      },
       "OPENAI_COMPATIBLE_ENABLED": {
         "name": "OPENAI_COMPATIBLE_ENABLED",
         "type": "string",
@@ -221,51 +37,51 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_bridge",
-          "ollama_client",
-          "tape_quality_ollama_narrator",
-          "github_agent_streamlit",
-          "home_assistant_integration",
-          "bn_acervo_agent",
-          "debug_ollama",
-          "github_agent",
-          "user_management",
-          "llm_compatibility",
-          "test_github_agent",
-          "agenda_media_router",
-          "streamlit_app",
-          "rss_sentiment_exporter",
-          "run_sentiment_finetune",
-          "rss_llm_trainer",
-          "whatsapp_persona_panel_server",
-          "ollama_finetune_batch",
-          "gmail_expurgo_inteligente",
           "llm_tool_client",
-          "nextcloud_agent",
-          "coordinator",
-          "finetune_whatsapp_model",
-          "telegram_bot",
-          "openwebui_integration",
-          "test_ollama_quick",
-          "process_all_messages_from_tmp",
-          "config",
-          "test_improvements",
+          "user_management",
           "ollama_warmup",
-          "email_trainer",
-          "proxy_tool_interceptor",
-          "agent_documentation_manager",
-          "trading_selfheal_exporter",
-          "test_models",
-          "job_application_agent",
-          "llm_system_demo",
-          "apply_real_job",
-          "llm_log_panel_server",
-          "compatibility_allinone",
           "train_llm_on_conversations",
-          "ollama_offloader",
+          "llm_log_panel_server",
+          "apply_real_job",
+          "process_all_messages_from_tmp",
+          "streamlit_app",
+          "finetune_whatsapp_model",
+          "ollama_mcp_bridge",
+          "github_agent",
+          "github_agent_streamlit",
+          "telegram_bot",
+          "compatibility_allinone",
+          "test_models",
+          "bn_acervo_agent",
+          "job_application_agent",
+          "tape_quality_ollama_narrator",
+          "home_assistant_integration",
+          "rss_sentiment_exporter",
+          "llm_compatibility",
+          "nextcloud_agent",
+          "agent_documentation_manager",
+          "email_trainer",
+          "coordinator",
+          "ollama_finetune_batch",
+          "test_improvements",
+          "rss_llm_trainer",
+          "ollama_client",
+          "debug_ollama",
+          "whatsapp_bot",
+          "whatsapp_persona_panel_server",
+          "proxy_tool_interceptor",
+          "openwebui_integration",
           "github_agent_server",
+          "llm_system_demo",
+          "gmail_expurgo_inteligente",
+          "ollama_offloader",
+          "test_github_agent",
           "create_dev_agent",
-          "whatsapp_bot"
+          "run_sentiment_finetune",
+          "trading_selfheal_exporter",
+          "agenda_media_router",
+          "config",
+          "test_ollama_quick"
         ]
       },
       "OLLAMA_MODEL": {
@@ -274,27 +90,27 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_client",
-          "tape_quality_ollama_narrator",
+          "llm_tool_client",
+          "user_management",
+          "streamlit_app",
+          "test_sell_target_backtest",
           "github_agent_streamlit",
           "github_agent",
-          "user_management",
-          "test_github_agent",
-          "streamlit_app",
-          "llm_tool_client",
-          "nas_ai_assessor",
-          "nextcloud_agent",
           "telegram_bot",
           "extract_whatsapp_train",
-          "config",
-          "test_sell_target_backtest",
-          "trading_selfheal_exporter",
-          "agent_documentation_manager",
           "job_application_agent",
-          "ollama_offloader",
+          "tape_quality_ollama_narrator",
+          "nextcloud_agent",
+          "agent_documentation_manager",
+          "ollama_client",
+          "whatsapp_bot",
           "github_agent_server",
+          "nas_ai_assessor",
+          "ollama_offloader",
+          "test_github_agent",
           "create_dev_agent",
-          "whatsapp_bot"
+          "trading_selfheal_exporter",
+          "config"
         ]
       },
       "OLLAMA_HOST_GPU1": {
@@ -305,16 +121,16 @@
         "contexts": [
           "ollama_client",
           "rss_sentiment_exporter",
-          "run_sentiment_finetune",
-          "rss_llm_trainer",
-          "tape_quality_ollama_narrator",
-          "config",
-          "ollama_finetune_batch",
-          "ollama_offloader",
-          "real_workload",
+          "ollama_warmup",
           "nextcloud_agent",
           "bn_acervo_agent",
-          "ollama_warmup"
+          "tape_quality_ollama_narrator",
+          "real_workload",
+          "ollama_finetune_batch",
+          "ollama_offloader",
+          "run_sentiment_finetune",
+          "rss_llm_trainer",
+          "config"
         ]
       },
       "OLLAMA_MODEL_GPU1": {
@@ -333,101 +149,11 @@
         "value": "5",
         "locations": [
           {
-            "file": ".env",
-            "line": 22
-          },
-          {
             "file": ".env.openai-compatible.example",
             "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.openai-compatible.example",
-            "line": 39
-          },
-          {
-            "file": ".env",
-            "line": 22
           }
         ],
         "contexts": []
-      },
-      "NEXTCLOUD_URL": {
-        "name": "NEXTCLOUD_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config",
-          "nextcloud_agent",
-          "configure_authentik_nextcloud_oidc",
-          "user_management",
-          "storage_portal_api"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_USER": {
-        "name": "NEXTCLOUD_ADMIN_USER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_CONTAINER": {
-        "name": "NEXTCLOUD_CONTAINER",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_AGENT_ENABLED": {
-        "name": "NEXTCLOUD_AGENT_ENABLED",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_GPU": {
-        "name": "NEXTCLOUD_OLLAMA_GPU",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "NEXTCLOUD_OLLAMA_TIMEOUT": {
-        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
-      },
-      "NEXTCLOUD_DEFAULT_DRY_RUN": {
-        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
       },
       "GEMINI_ENABLED": {
         "name": "GEMINI_ENABLED",
@@ -447,18 +173,6 @@
           {
             "file": ".env.consolidated",
             "line": 21
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 21
           }
         ],
         "contexts": []
@@ -469,11 +183,11 @@
         "source": "docker-compose",
         "value": "${MAILU_DOMAIN:-mail.rpa4all.com}",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-backend"
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-dovecot",
+          "mailu-postfix"
         ]
       },
       "ADMIN_EMAIL": {
@@ -484,18 +198,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 28
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 28
           }
         ],
@@ -510,18 +212,6 @@
           {
             "file": ".env.consolidated",
             "line": 29
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 29
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 29
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 29
           }
         ],
         "contexts": []
@@ -534,18 +224,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 33
           }
         ],
@@ -560,18 +238,6 @@
           {
             "file": ".env.consolidated",
             "line": 34
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 34
           }
         ],
         "contexts": []
@@ -584,18 +250,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 35
           }
         ],
@@ -610,18 +264,6 @@
           {
             "file": ".env.consolidated",
             "line": 36
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 36
           }
         ],
         "contexts": []
@@ -634,18 +276,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 37
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 37
           }
         ],
@@ -660,18 +290,6 @@
           {
             "file": ".env.consolidated",
             "line": 38
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 38
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 38
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 38
           }
         ],
         "contexts": []
@@ -684,18 +302,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 39
           }
         ],
@@ -710,18 +316,6 @@
           {
             "file": ".env.consolidated",
             "line": 40
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 40
           }
         ],
         "contexts": []
@@ -734,18 +328,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 41
           }
         ],
@@ -760,18 +342,6 @@
           {
             "file": ".env.consolidated",
             "line": 42
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 42
           }
         ],
         "contexts": []
@@ -784,18 +354,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 43
           }
         ],
@@ -810,18 +368,6 @@
           {
             "file": ".env.consolidated",
             "line": 44
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 44
           }
         ],
         "contexts": []
@@ -834,18 +380,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 52
           }
         ],
@@ -860,18 +394,6 @@
           {
             "file": ".env.consolidated",
             "line": 53
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 53
           }
         ],
         "contexts": []
@@ -884,18 +406,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 60
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 60
           }
         ],
@@ -910,18 +420,6 @@
           {
             "file": ".env.consolidated",
             "line": 61
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 61
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 61
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 61
           }
         ],
         "contexts": []
@@ -934,18 +432,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 91
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 91
           }
         ],
@@ -960,18 +446,6 @@
           {
             "file": ".env.consolidated",
             "line": 121
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 121
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 121
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 121
           }
         ],
         "contexts": []
@@ -984,18 +458,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 122
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 122
           }
         ],
@@ -1028,18 +490,90 @@
           {
             "file": ".env.consolidated",
             "line": 125
-          },
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_API": {
+        "name": "WIKI_API",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "test_variable_registry_validate"
+        ]
+      },
+      "WIKI_PUBLIC": {
+        "name": "WIKI_PUBLIC",
+        "type": "url",
+        "source": ".env",
+        "value": "https://wiki.rpa4all.com",
+        "locations": [
           {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 125
-          },
+            "file": ".env.example.wiki",
+            "line": 3
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_API": {
+        "name": "WIKI_OLLAMA_API",
+        "type": "url",
+        "source": ".env",
+        "value": "http://<homelab-ip>:11437/api",
+        "locations": [
           {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 125
-          },
+            "file": ".env.example.wiki",
+            "line": 5
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_OLLAMA_MODEL": {
+        "name": "WIKI_OLLAMA_MODEL",
+        "type": "string",
+        "source": ".env",
+        "value": "mistral:7b",
+        "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 125
+            "file": ".env.example.wiki",
+            "line": 6
+          }
+        ],
+        "contexts": []
+      },
+      "WIKI_LOCALE": {
+        "name": "WIKI_LOCALE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "server_error_alert",
+          "wiki_agent"
+        ]
+      },
+      "WIKI_TIMEOUT": {
+        "name": "WIKI_TIMEOUT",
+        "type": "integer",
+        "source": ".env",
+        "value": "90",
+        "locations": [
+          {
+            "file": ".env.example.wiki",
+            "line": 8
+          }
+        ],
+        "contexts": []
+      },
+      "PAGES_FILE": {
+        "name": "PAGES_FILE",
+        "type": "string",
+        "source": ".env",
+        "value": "wiki_pages.json",
+        "locations": [
+          {
+            "file": ".env.example.wiki",
+            "line": 9
           }
         ],
         "contexts": []
@@ -1050,18 +584,6 @@
         "source": ".env",
         "value": "127.0.0.1",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 6
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 6
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 6
@@ -1076,18 +598,6 @@
         "value": "18091",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 7
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 7
           }
@@ -1101,18 +611,6 @@
         "value": "127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 8
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 8
           }
@@ -1125,18 +623,6 @@
         "source": ".env",
         "value": "18092",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 9
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 9
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 9
@@ -1169,18 +655,6 @@
         "value": "auth.rpa4all.com netbox.cmdb.local localhost 127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 14
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 14
           }
@@ -1193,18 +667,6 @@
         "source": ".env",
         "value": "https://auth.rpa4all.com",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 15
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 15
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 15
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 15
@@ -1228,18 +690,6 @@
         "value": "true",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 17
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 17
           }
@@ -1252,18 +702,6 @@
         "source": ".env",
         "value": "https://auth.rpa4all.com/outpost.goauthentik.io/sign_out",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 18
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 18
@@ -1287,18 +725,6 @@
         "value": "v4.6-5.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 31
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 31
           }
@@ -1311,18 +737,6 @@
         "source": ".env",
         "value": "latest",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 34
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 34
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 34
@@ -1337,18 +751,6 @@
         "value": "1.29-alpine",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 36
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 36
           }
@@ -1361,18 +763,6 @@
         "source": ".env",
         "value": "cmdb-admin",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 45
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 45
@@ -1387,18 +777,6 @@
         "value": "cmdb-admin@local",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 46
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 46
           }
@@ -1411,18 +789,6 @@
         "source": ".env",
         "value": "cmdb@local",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 48
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 48
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 48
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 48
@@ -1437,18 +803,6 @@
         "value": "localhost",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 49
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 49
           }
@@ -1461,18 +815,6 @@
         "source": ".env",
         "value": "25",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 50
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 50
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 50
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 50
@@ -1487,18 +829,6 @@
         "value": "false",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 51
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 51
           }
@@ -1512,18 +842,6 @@
         "value": "false",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 52
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 52
           }
@@ -1536,18 +854,6 @@
         "source": ".env",
         "value": "false",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 53
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 53
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 53
@@ -1598,8 +904,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_orchestrator",
+          "tape_manager",
           "ltfs_recovery"
         ]
       },
@@ -1611,18 +917,6 @@
         "locations": [
           {
             "file": "systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 3
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
             "line": 3
           }
         ],
@@ -1637,18 +931,6 @@
           {
             "file": "systemd/ltfs-lto6-sg1.env",
             "line": 4
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-            "line": 4
           }
         ],
         "contexts": []
@@ -1662,18 +944,6 @@
           {
             "file": "systemd/ltfs-lto6-sg1.env",
             "line": 5
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-            "line": 5
           }
         ],
         "contexts": []
@@ -1684,10 +954,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
+          "ltfs_checkpoint_writer",
           "tape_orchestrator",
-          "ltfs_recovery",
-          "ltfs_checkpoint_writer"
+          "tape_manager",
+          "ltfs_recovery"
         ]
       },
       "LTFS_TAPE_DEVICE": {
@@ -1696,8 +966,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_orchestrator",
+          "tape_manager",
           "ltfs_recovery"
         ]
       },
@@ -1734,11 +1004,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_safe_eject",
+          "tape_orchestrator",
           "ltfs_recovery",
           "tape_component_quality_agent",
-          "tape_orchestrator"
+          "tape_manager"
         ]
       },
       "LTFS_SELF_HEAL_STATE_FILE": {
@@ -1778,18 +1048,6 @@
         "locations": [
           {
             "file": "deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-            "line": 13
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
             "line": 13
           }
         ],
@@ -1831,18 +1089,6 @@
           {
             "file": "tools/authentik_management/configs/grafana.env",
             "line": 24
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/grafana.env",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/grafana.env",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/grafana.env",
-            "line": 24
           }
         ],
         "contexts": []
@@ -1854,16 +1100,8 @@
         "value": "trading-analyst",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/crypto-agent/models.env",
-            "line": 8
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/crypto-agent/models.env",
-            "line": 8
-          },
-          {
             "file": "deploy/crypto-agent/models.env",
-            "line": 8
+            "line": 18
           }
         ],
         "contexts": []
@@ -1874,9 +1112,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nextcloud_agent",
           "ollama_client",
-          "ollama_offloader"
+          "ollama_offloader",
+          "nextcloud_agent"
         ]
       },
       "OLLAMA_PLAN_MODEL": {
@@ -2068,8 +1306,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "user_management",
           "storage_portal_api",
+          "user_management",
           "2_user_management"
         ]
       },
@@ -2196,10 +1434,10 @@
         "source": "docker-compose",
         "value": "America/Sao_Paulo",
         "contexts": [
+          "netbox-postgres",
           "grafana",
-          "glpi",
           "glpi-db",
-          "netbox-postgres"
+          "glpi"
         ]
       },
       "GF_DEFAULT_TIMEZONE": {
@@ -2343,8 +1581,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_ALLOWED_HOSTS:-*}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "CORS_ORIGIN_ALLOW_ALL": {
@@ -2353,8 +1591,8 @@
         "source": "docker-compose",
         "value": "True",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "CSRF_TRUSTED_ORIGINS": {
@@ -2363,8 +1601,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_CSRF_TRUSTED_ORIGINS:-}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_FROM": {
@@ -2373,8 +1611,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_FROM:-cmdb@local}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_PORT": {
@@ -2383,8 +1621,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_PORT:-25}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_SERVER": {
@@ -2393,8 +1631,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_SERVER:-localhost}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_TIMEOUT": {
@@ -2403,8 +1641,8 @@
         "source": "docker-compose",
         "value": "5",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_USE_SSL": {
@@ -2413,8 +1651,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_SSL:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "EMAIL_USE_TLS": {
@@ -2423,8 +1661,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_EMAIL_USE_TLS:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "GRAPHQL_ENABLED": {
@@ -2433,8 +1671,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "LOGIN_REQUIRED": {
@@ -2443,8 +1681,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGIN_REQUIRED:-true}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "LOGOUT_REDIRECT_URL": {
@@ -2453,8 +1691,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_LOGOUT_REDIRECT_URL:-/}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "METRICS_ENABLED": {
@@ -2463,8 +1701,8 @@
         "source": "docker-compose",
         "value": "true",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_EMAIL": {
@@ -2473,8 +1711,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_EMAIL:-cmdb-admin@local}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_NAME": {
@@ -2483,8 +1721,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SUPERUSER_NAME:-cmdb-admin}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SKIP_SUPERUSER": {
@@ -2493,8 +1731,8 @@
         "source": "docker-compose",
         "value": "${NETBOX_SKIP_SUPERUSER:-false}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "TIME_ZONE": {
@@ -2503,8 +1741,8 @@
         "source": "docker-compose",
         "value": "${CMDB_TIMEZONE:-America/Sao_Paulo}",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "BAUDRATE": {
@@ -2558,36 +1796,37 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "diretor",
-          "daily-agenda-panel",
-          "crypto-agent@",
-          "agent-network-exporter",
-          "marketing-x-posts",
-          "meeting-translator",
-          "trading-analyst-weekly-retrain",
-          "candle-collector",
-          "whatsapp-toolcall-chunked-train",
-          "marketing-api",
-          "marketing-daily-report",
-          "marketing-email-drip",
-          "notebook-power-agent",
-          "eddie-expurgo",
-          "coordinator",
           "kucoin-usdt-rebalance",
-          "tape-component-quality-exporter",
-          "trading-daily-report",
-          "daily-agenda-broadcast",
-          "kucoin-postgres-sync",
           "decisions-track-record-rollup",
-          "clear-trading-agent",
-          "eddie-telegram-bot",
+          "daily-agenda-panel",
+          "diretor",
           "bn-acervo-agent",
-          "rss-sentiment-exporter",
-          "nas-ollama-load",
-          "approval-gateway",
+          "marketing-api",
+          "notebook-power-agent",
+          "meeting-translator",
           "ollama-gpu-coordinator",
+          "marketing-email-drip",
+          "eddie-telegram-bot",
+          "eddie-expurgo",
           "eddie-calendar",
-          "banking-metrics-exporter"
+          "candle-collector",
+          "marketing-x-posts",
+          "banking-metrics-exporter",
+          "tape-component-quality-exporter",
+          "agent-network-exporter",
+          "daily-agenda-broadcast",
+          "trading-analyst-weekly-retrain",
+          "whatsapp-toolcall-chunked-train",
+          "coordinator",
+          "nas-ollama-load",
+          "crypto-agent@",
+          "trading-daily-report",
+          "approval-gateway",
+          "marketing-daily-report",
+          "nas-ram-exporter",
+          "rss-sentiment-exporter",
+          "kucoin-postgres-sync",
+          "clear-trading-agent"
         ]
       },
       "TG_LONG_POLL": {
@@ -2605,8 +1844,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "mcp_tool_bridge",
-          "approval_gateway"
+          "approval_gateway",
+          "mcp_tool_bridge"
         ]
       },
       "BANKING_EXPORTER_PORT": {
@@ -2643,11 +1882,11 @@
         "value": "1",
         "contexts": [
           "whatsapp-persona-panel",
-          "decisions-track-record-rollup",
-          "ollama-finetune",
-          "candle-collector",
           "llm-log-panel",
-          "rss-sentiment-exporter"
+          "decisions-track-record-rollup",
+          "rss-sentiment-exporter",
+          "candle-collector",
+          "ollama-finetune"
         ]
       },
       "HOME": {
@@ -2656,12 +1895,12 @@
         "source": "systemd",
         "value": "/apps/crypto-trader",
         "contexts": [
-          "decisions-track-record-rollup",
-          "crypto-agent@",
-          "ollama-finetune",
-          "candle-collector",
           "llm-log-panel",
-          "rss-sentiment-exporter"
+          "decisions-track-record-rollup",
+          "rss-sentiment-exporter",
+          "candle-collector",
+          "crypto-agent@",
+          "ollama-finetune"
         ]
       },
       "PYTHONPATH": {
@@ -2670,17 +1909,17 @@
         "source": "systemd",
         "value": "/apps/crypto-trader/trading",
         "contexts": [
+          "marketing-daily-report",
+          "llm-log-panel",
           "decisions-track-record-rollup",
           "marketing-email-drip",
+          "rss-sentiment-exporter",
+          "candle-collector",
           "marketing-x-posts",
+          "marketing-api",
           "ollama-finetune",
           "clear-trading-agent",
-          "candle-collector",
-          "tape-component-quality-exporter",
-          "llm-log-panel",
-          "rss-sentiment-exporter",
-          "marketing-api",
-          "marketing-daily-report"
+          "tape-component-quality-exporter"
         ]
       },
       "CLEAR_CONFIG_FILE": {
@@ -2708,16 +1947,16 @@
         "source": "systemd",
         "value": "/usr/local/bin:/usr/bin:/bin",
         "contexts": [
-          "crypto-agent@",
+          "kucoin-usdt-rebalance",
+          "homelab-dashboard",
           "eddie-whatsapp-bot",
+          "kucoin-postgres-sync",
+          "crypto-agent@",
           "specialized_agents-dashboard",
           "github-agent",
-          "kucoin-usdt-rebalance",
-          "tape-component-quality-exporter",
           "job-monitor",
-          "homelab-dashboard",
-          "rpa4all-validation",
-          "kucoin-postgres-sync"
+          "tape-component-quality-exporter",
+          "rpa4all-validation"
         ]
       },
       "ADMIN_CHAT_ID": {
@@ -2726,16 +1965,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "send_pending_report",
-          "kucoin_api",
-          "github_agent_streamlit",
-          "gmail_expurgo_inteligente",
+          "telegram_bot",
           "calendar_reminder_service",
+          "send_pending_report",
           "mt5_api",
+          "gmail_expurgo_inteligente",
           "coordinator",
-          "storj_payout_monitor",
+          "kucoin_api",
           "trading_selfheal_exporter",
-          "telegram_bot"
+          "storj_payout_monitor",
+          "github_agent_streamlit"
         ]
       },
       "OLLAMA_PLAN_HOST": {
@@ -2744,9 +1983,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "position_manager_mixin",
           "compare_ollama_replay",
-          "trading_agent"
+          "trading_agent",
+          "position_manager_mixin"
         ]
       },
       "OLLAMA_TRADE_PARAMS_HOST": {
@@ -2927,8 +2166,8 @@
         "source": "systemd",
         "value": "http://192.168.15.2:11437",
         "contexts": [
-          "crypto-agent@BTC_USDT_aggressive.service/zz-direct-ollama.conf",
-          "crypto-agent@BTC_USDT_conservative.service/zz-direct-ollama.conf"
+          "crypto-agent@BTC_USDT_conservative.service/zz-direct-ollama.conf",
+          "crypto-agent@BTC_USDT_aggressive.service/zz-direct-ollama.conf"
         ]
       },
       "AGENDA_LLM_COORD_HOST": {
@@ -3064,10 +2303,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "extract_whatsapp_train",
-          "config",
           "calendar_reminder_service",
+          "extract_whatsapp_train",
           "google_calendar_integration",
+          "config",
           "whatsapp_bot"
         ]
       },
@@ -3105,16 +2344,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "github_agent_streamlit",
+          "wait_and_run_whatsapp_test",
+          "search_waha_nil",
+          "apply_real_job",
+          "test_whatsapp",
+          "gmail_expurgo_inteligente",
           "setup_waha",
           "process_all_messages_from_tmp",
-          "test_whatsapp",
-          "github_agent_streamlit",
-          "gmail_expurgo_inteligente",
-          "search_waha_nil",
-          "wait_and_run_whatsapp_test",
-          "whatsapp_manager",
-          "apply_real_job",
-          "whatsapp_bot"
+          "whatsapp_bot",
+          "whatsapp_manager"
         ]
       },
       "GMAIL_DATA_DIR": {
@@ -3123,8 +2362,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "gmail_expurgo_inteligente",
-          "run_full_expurgo"
+          "run_full_expurgo",
+          "gmail_expurgo_inteligente"
         ]
       },
       "ADMIN_PHONE": {
@@ -3215,8 +2454,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "telegram_bot",
-          "whatsapp_bot"
+          "whatsapp_bot",
+          "telegram_bot"
         ]
       },
       "OLLAMA_NUM_PREDICT": {
@@ -3261,14 +2500,14 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "homelab_mcp_server",
-          "openwebui_validator_agent",
           "install_webui_function_api",
-          "capture_login_playwright",
-          "ask_director_coordinator",
+          "homelab_mcp_server",
           "report_test_to_diretor",
-          "create_director_model",
+          "openwebui_validator_agent",
+          "capture_login_playwright",
           "list_webui",
+          "ask_director_coordinator",
+          "create_director_model",
           "codex_mcp_server"
         ]
       },
@@ -3335,14 +2574,68 @@
           "ethwan-selfheal"
         ]
       },
+      "WHISPER_MODEL": {
+        "name": "WHISPER_MODEL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
+      "WHISPER_DEVICE": {
+        "name": "WHISPER_DEVICE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
+      "WHISPER_COMPUTE_TYPE": {
+        "name": "WHISPER_COMPUTE_TYPE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
+      "WHISPER_CACHE_DIR": {
+        "name": "WHISPER_CACHE_DIR",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
+      "WHISPER_HOST": {
+        "name": "WHISPER_HOST",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
+      "WHISPER_PORT": {
+        "name": "WHISPER_PORT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "faster_whisper_api"
+        ]
+      },
       "OLLAMA_PORT": {
         "name": "OLLAMA_PORT",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_github_agent",
           "github_agent_server",
+          "test_github_agent",
           "github_agent_streamlit",
           "github_agent"
         ]
@@ -3371,8 +2664,9 @@
         "source": "systemd",
         "value": "nextcloud",
         "contexts": [
-          "homelab-tape-log-drain-sg1",
-          "homelab-tape-log-drain-nextcloud"
+          "homelab-tape-log-drain-nextcloud",
+          "tape-log-spool-drain-nextcloud",
+          "homelab-tape-log-drain-sg1"
         ]
       },
       "ROUTE_TARGET_ROOT": {
@@ -3381,8 +2675,9 @@
         "source": "systemd",
         "value": "/mnt/pretape/lto6-cache/logs",
         "contexts": [
-          "homelab-tape-log-drain-sg1",
-          "homelab-tape-log-drain-nextcloud"
+          "homelab-tape-log-drain-nextcloud",
+          "tape-log-spool-drain-nextcloud",
+          "homelab-tape-log-drain-sg1"
         ]
       },
       "BYPASS_CONF": {
@@ -3418,10 +2713,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "job_monitor_continuous",
           "scan_whatsapp_llm",
+          "llm_system_demo",
           "apply_real_job",
-          "llm_system_demo"
+          "job_monitor_continuous"
         ]
       },
       "MAX_CHATS_PER_RUN": {
@@ -3466,8 +2761,17 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "llm_log_panel_server",
-          "openwebui_agent_coordinator_function"
+          "openwebui_agent_coordinator_function",
+          "llm_log_panel_server"
+        ]
+      },
+      "JRNL_REPLICA_NAS": {
+        "name": "JRNL_REPLICA_NAS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
         ]
       },
       "TAPE_ACCESS_LOCKFILE": {
@@ -3476,8 +2780,8 @@
         "source": "systemd",
         "value": "/run/lock/tape-access-sg0.lock",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
         ]
       },
@@ -3487,8 +2791,8 @@
         "source": "systemd",
         "value": "/run/tape-queue-sg0",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
         ]
       },
@@ -3498,8 +2802,8 @@
         "source": "systemd",
         "value": "/run/tape-queue-sg0/current",
         "contexts": [
-          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nextcloud-tape-backup.service/35-sg0-tape-access-scope.conf",
+          "ltfs-lto6.service/65-sg0-tape-access-scope.conf",
           "nvme-tape-drain.service/35-sg0-tape-access-scope.conf"
         ]
       },
@@ -3537,9 +2841,18 @@
         "value": null,
         "contexts": [
           "ollama_gpu_coordinator",
-          "trading_analyst_finetune_batch",
           "nas_ollama_load",
+          "trading_analyst_finetune_batch",
           "trading_analyst_shadow_eval"
+        ]
+      },
+      "NAS_RAM_EXPORTER_PORT": {
+        "name": "NAS_RAM_EXPORTER_PORT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "nas_ram_exporter"
         ]
       },
       "GPU_CLOCK_MAX": {
@@ -3566,10 +2879,10 @@
         "source": "systemd",
         "value": "0",
         "contexts": [
-          "ollama-gpu1",
-          "ollama.service/zz-gpu0-visible-device.conf",
           "ollama-finetune",
-          "ollama-gpu1.service/zz-gpu1-visible-device.conf"
+          "ollama-gpu1.service/zz-gpu1-visible-device.conf",
+          "ollama-gpu1",
+          "ollama.service/zz-gpu0-visible-device.conf"
         ]
       },
       "PYTORCH_CUDA_ALLOC_CONF": {
@@ -3599,6 +2912,15 @@
           "ollama_gpu_coordinator"
         ]
       },
+      "OLLAMA_NAS_RAM_EXPORTER_HOST": {
+        "name": "OLLAMA_NAS_RAM_EXPORTER_HOST",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
       "GPU_COORD_PORT": {
         "name": "GPU_COORD_PORT",
         "type": "string",
@@ -3614,13 +2936,67 @@
         "source": "systemd",
         "value": "10",
         "contexts": [
+          "ollama-gpu-coordinator.service/busy-wait.conf",
           "ollama-gpu-coordinator",
-          "ollama-gpu-coordinator.service/zz-dual-gpu-routing.conf",
-          "ollama-gpu-coordinator.service/busy-wait.conf"
+          "ollama-gpu-coordinator.service/zz-dual-gpu-routing.conf"
         ]
       },
       "GPU_COORD_REQUEST_TIMEOUT_SEC": {
         "name": "GPU_COORD_REQUEST_TIMEOUT_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_SOFT_PIN": {
+        "name": "GPU_COORD_SOFT_PIN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_SOFT_PIN_BUSY": {
+        "name": "GPU_COORD_SOFT_PIN_BUSY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_AUX_MAX_VRAM_MB": {
+        "name": "GPU_COORD_AUX_MAX_VRAM_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_RAM_MARGIN_MB": {
+        "name": "GPU_COORD_NAS_RAM_MARGIN_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_RAM_MODEL_OVERHEAD_MB": {
+        "name": "GPU_COORD_NAS_RAM_MODEL_OVERHEAD_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_NAS_MIN_FREE_RAM_MB": {
+        "name": "GPU_COORD_NAS_MIN_FREE_RAM_MB",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -3738,9 +3114,9 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
+          "ollama.service/zz-perf-containment.conf",
           "ollama.service/zz-concurrency-limit.conf",
           "ollama-gpu1",
-          "ollama.service/zz-perf-containment.conf",
           "ollama.service/ollama-optimized.conf"
         ]
       },
@@ -3750,15 +3126,15 @@
         "source": "systemd",
         "value": "1",
         "contexts": [
-          "ollama-gpu1",
           "ollama-gpu1.service/zzzz-idle-power.conf",
-          "ollama.service/ollama-optimized.conf",
-          "ollama.service/zzzz-idle-power.conf",
-          "ollama.service/zzzzz-idle-power-final.conf",
-          "ollama.service/zzzz-warmup-curl.conf",
           "ollama.service/zzz-dual-model.conf",
+          "ollama.service/zzzz-idle-power.conf",
+          "ollama-gpu1",
+          "ollama.service/zzzzz-idle-power-final.conf",
           "ollama-gpu1.service/zzzzz-idle-power-final.conf",
-          "ollama-nas.service/zzzz-idle-power.conf"
+          "ollama.service/zzzz-warmup-curl.conf",
+          "ollama-nas.service/zzzz-idle-power.conf",
+          "ollama.service/ollama-optimized.conf"
         ]
       },
       "OLLAMA_GPU_OVERHEAD": {
@@ -3797,8 +3173,8 @@
         "value": "4",
         "contexts": [
           "ollama.service/zz-perf-containment.conf",
-          "ollama-gpu1",
           "ollama-gpu1.service/zz-perf-containment.conf",
+          "ollama-gpu1",
           "ollama.service/ollama-optimized.conf"
         ]
       },
@@ -3809,8 +3185,8 @@
         "value": "4",
         "contexts": [
           "ollama.service/zz-perf-containment.conf",
-          "ollama-gpu1",
           "ollama-gpu1.service/zz-perf-containment.conf",
+          "ollama-gpu1",
           "ollama.service/ollama-optimized.conf"
         ]
       },
@@ -3821,8 +3197,8 @@
         "value": "4",
         "contexts": [
           "ollama.service/zz-perf-containment.conf",
-          "ollama-gpu1",
           "ollama-gpu1.service/zz-perf-containment.conf",
+          "ollama-gpu1",
           "ollama.service/ollama-optimized.conf"
         ]
       },
@@ -3927,8 +3303,8 @@
         "source": "systemd",
         "value": "4",
         "contexts": [
-          "ollama.service/zz-concurrency-limit.conf",
-          "ollama.service/zz-perf-containment.conf"
+          "ollama.service/zz-perf-containment.conf",
+          "ollama.service/zz-concurrency-limit.conf"
         ]
       },
       "WAIT_SECONDS": {
@@ -4072,10 +3448,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tuya_token_selfheal",
+          "iot_presence_watchdog",
           "tuya_local_key_selfheal",
-          "storj_payout_monitor",
-          "iot_presence_watchdog"
+          "tuya_token_selfheal",
+          "storj_payout_monitor"
         ]
       },
       "STORJ_PAYOUT_HTTP_TIMEOUT": {
@@ -4085,6 +3461,33 @@
         "value": null,
         "contexts": [
           "storj_payout_monitor"
+        ]
+      },
+      "DESTINATION": {
+        "name": "DESTINATION",
+        "type": "string",
+        "source": "systemd",
+        "value": "journald",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
+        ]
+      },
+      "RETENTION_DAYS": {
+        "name": "RETENTION_DAYS",
+        "type": "integer",
+        "source": "systemd",
+        "value": "7",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
+        ]
+      },
+      "MAX_FILE_SIZE_MB": {
+        "name": "MAX_FILE_SIZE_MB",
+        "type": "integer",
+        "source": "systemd",
+        "value": "100",
+        "contexts": [
+          "tape-log-spool-drain-nextcloud"
         ]
       },
       "NARRATOR_STATE_FILE": {
@@ -4129,8 +3532,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tuya_token_renewer",
-          "tuya_token_selfheal"
+          "tuya_token_selfheal",
+          "tuya_token_renewer"
         ]
       },
       "HA_CONFIG_ENTRIES": {
@@ -4149,8 +3552,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tuya_token_selfheal",
-          "iot_presence_watchdog"
+          "iot_presence_watchdog",
+          "tuya_token_selfheal"
         ]
       },
       "MAX_HEALS_24H": {
@@ -4233,8 +3636,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_persona_panel_server",
-          "whatsapp_bot"
+          "whatsapp_bot",
+          "whatsapp_persona_panel_server"
         ]
       },
       "WHATSAPP_PERSONA_MODELFILE": {
@@ -4252,8 +3655,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "FT_EPOCHS": {
@@ -4262,10 +3665,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "SMTP_HOST": {
@@ -4274,9 +3677,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "storage_portal_api",
           "email_nurturing",
-          "user_management",
-          "storage_portal_api"
+          "user_management"
         ]
       },
       "SMTP_PORT": {
@@ -4285,9 +3688,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "storage_portal_api",
           "email_nurturing",
-          "user_management",
-          "storage_portal_api"
+          "user_management"
         ]
       },
       "SMTP_USERNAME": {
@@ -4296,8 +3699,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "user_management",
-          "storage_portal_api"
+          "storage_portal_api",
+          "user_management"
         ]
       },
       "SMTP_FROM_EMAIL": {
@@ -4306,8 +3709,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "user_management",
-          "storage_portal_api"
+          "storage_portal_api",
+          "user_management"
         ]
       },
       "SMTP_FROM_NAME": {
@@ -4316,8 +3719,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "user_management",
-          "storage_portal_api"
+          "storage_portal_api",
+          "user_management"
         ]
       },
       "SMTP_STARTTLS": {
@@ -4326,9 +3729,22 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "storage_portal_api",
           "email_nurturing",
+          "user_management"
+        ]
+      },
+      "NEXTCLOUD_URL": {
+        "name": "NEXTCLOUD_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
           "user_management",
-          "storage_portal_api"
+          "nextcloud_agent",
+          "storage_portal_api",
+          "config",
+          "configure_authentik_nextcloud_oidc"
         ]
       },
       "NEXTCLOUD_BASE_PATH": {
@@ -4402,11 +3818,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "coordinator",
-          "list_agents",
           "telegram_bot",
-          "whatsapp_bot",
-          "homelab_test"
+          "homelab_test",
+          "list_agents",
+          "coordinator",
+          "whatsapp_bot"
         ]
       },
       "OPENWEBUI_HOST": {
@@ -4416,8 +3832,8 @@
         "value": null,
         "contexts": [
           "openwebui_integration",
-          "telegram_bot",
-          "whatsapp_bot"
+          "whatsapp_bot",
+          "telegram_bot"
         ]
       },
       "HOMELAB_HOST": {
@@ -4426,48 +3842,48 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_ssh_mcp",
-          "test_ai_interactive",
-          "install_function_webui",
-          "fix_director_model",
-          "test_embed",
-          "train_coordinator",
-          "index_new_knowledge",
-          "test_final",
-          "gmail_weekly_cleaner",
-          "update_rag_simple",
-          "test_assistant",
-          "generate_learning_evolution_graph",
-          "generate_learning_dashboard",
-          "fix_model",
           "populate_grafana_dashboard",
-          "deploy_grafana_server_selector",
-          "test_github_agent",
+          "openwebui_agent_coordinator_function",
+          "install_function_webui",
+          "test_printer_function",
           "force_activate_persistent",
           "ask_director_coordinator",
-          "test_endpoints_final",
+          "extract_and_train",
+          "test_rpa_selenium",
           "configure_diretor_model",
           "telegram_bot",
-          "openwebui_agent_coordinator_function",
-          "recreate_printer_complete",
-          "test_ollama_quick",
-          "check_diretor_status",
-          "config",
-          "test_rpa_selenium",
           "rag_dashboard",
+          "server_knowledge_generator",
+          "gmail_weekly_cleaner",
           "check_model",
+          "web_search",
           "create_neural_dashboard",
-          "test_printer_function",
+          "train_coordinator",
+          "diagnose_phomemo_connection",
+          "test_final",
+          "test_assistant",
+          "test_ai_interactive",
+          "deploy_grafana_server_selector",
+          "control_panel",
+          "check_diretor_status",
+          "generate_learning_evolution_graph",
+          "install_printer_function",
+          "index_new_knowledge",
+          "test_embed",
+          "test_endpoints_final",
+          "generate_learning_dashboard",
+          "test_llm_quick",
           "ui_smoke_tests",
           "fix_diretor_model",
-          "test_llm_quick",
-          "web_search",
-          "install_printer_function",
-          "server_knowledge_generator",
-          "extract_and_train",
-          "diagnose_phomemo_connection",
+          "fix_director_model",
           "test_ollama_create",
-          "control_panel"
+          "test_ssh_mcp",
+          "recreate_printer_complete",
+          "test_github_agent",
+          "update_rag_simple",
+          "config",
+          "fix_model",
+          "test_ollama_quick"
         ]
       },
       "RAG_API": {
@@ -4476,11 +3892,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "web_search",
-          "train_coordinator",
-          "index_new_knowledge",
+          "telegram_bot",
           "rag_dashboard",
-          "telegram_bot"
+          "index_new_knowledge",
+          "web_search",
+          "train_coordinator"
         ]
       },
       "DEPLOY_HOST": {
@@ -4570,8 +3986,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_btc_secrets_helper",
           "secret_store",
+          "test_btc_secrets_helper",
           "secrets_helper"
         ]
       },
@@ -4687,12 +4103,42 @@
           "nextcloud_agent"
         ]
       },
+      "NEXTCLOUD_ADMIN_USER": {
+        "name": "NEXTCLOUD_ADMIN_USER",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_CONTAINER": {
+        "name": "NEXTCLOUD_CONTAINER",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
+          "nextcloud_agent"
+        ]
+      },
       "NEXTCLOUD_CONTAINER_CANDIDATES": {
         "name": "NEXTCLOUD_CONTAINER_CANDIDATES",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_TIMEOUT": {
+        "name": "NEXTCLOUD_OLLAMA_TIMEOUT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config",
           "nextcloud_agent"
         ]
       },
@@ -4734,6 +4180,15 @@
       },
       "WG_PEER_RANGE_END": {
         "name": "WG_PEER_RANGE_END",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "nextcloud_agent"
+        ]
+      },
+      "NEXTCLOUD_BRUTE_FORCE_ALLOWLIST": {
+        "name": "NEXTCLOUD_BRUTE_FORCE_ALLOWLIST",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -5012,6 +4467,33 @@
           "config"
         ]
       },
+      "NEXTCLOUD_AGENT_ENABLED": {
+        "name": "NEXTCLOUD_AGENT_ENABLED",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_OLLAMA_GPU": {
+        "name": "NEXTCLOUD_OLLAMA_GPU",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "NEXTCLOUD_DEFAULT_DRY_RUN": {
+        "name": "NEXTCLOUD_DEFAULT_DRY_RUN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
       "REMOTE_ORCHESTRATOR_ENABLED": {
         "name": "REMOTE_ORCHESTRATOR_ENABLED",
         "type": "string",
@@ -5028,8 +4510,8 @@
         "value": null,
         "contexts": [
           "populate_grafana_dashboard",
-          "deploy_grafana_server_selector",
-          "config"
+          "config",
+          "deploy_grafana_server_selector"
         ]
       },
       "HOMELAB_BASE_DIR": {
@@ -5191,8 +4673,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "app_patched",
-          "app"
+          "app",
+          "app_patched"
         ]
       },
       "MAX_OUTPUT_SIZE": {
@@ -5201,8 +4683,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "app_patched",
-          "app"
+          "app",
+          "app_patched"
         ]
       },
       "MAX_MEMORY_MB": {
@@ -5211,8 +4693,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "app_patched",
-          "app"
+          "app",
+          "app_patched"
         ]
       },
       "OLLAMA_GENERATE_HOST": {
@@ -5221,8 +4703,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "LLM_GPU0_HOST": {
@@ -5231,8 +4713,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "LLM_GPU1_HOST": {
@@ -5241,8 +4723,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "LLM_NAS_HOST": {
@@ -5251,8 +4733,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "ollama_mcp_server",
-          "llm"
+          "llm",
+          "ollama_mcp_server"
         ]
       },
       "OLLAMA_STRUCTURED_CROSS_MODEL_FALLBACK": {
@@ -5335,8 +4817,8 @@
         "value": null,
         "contexts": [
           "streamlit_app",
-          "run_diretor_service",
           "eddie_whatsapp_exporter",
+          "run_diretor_service",
           "run_coordinator_service"
         ]
       },
@@ -5391,8 +4873,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "coordinator",
-          "agent"
+          "agent",
+          "coordinator"
         ]
       },
       "SQUAD_MAX": {
@@ -5401,8 +4883,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "coordinator",
-          "agent"
+          "agent",
+          "coordinator"
         ]
       },
       "EDDIE_ASSISTANT_MODEL": {
@@ -5605,11 +5087,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "playwright_click_and_check",
-          "test_rpa_selenium",
-          "github_agent_server",
+          "capture_streamlit_screenshot",
           "run_headless_ui_test",
-          "capture_streamlit_screenshot"
+          "github_agent_server",
+          "playwright_click_and_check",
+          "test_rpa_selenium"
         ]
       },
       "INTERCEPTOR_API": {
@@ -5618,8 +5100,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "print_convs_html",
-          "run_headless_ui_test"
+          "run_headless_ui_test",
+          "print_convs_html"
         ]
       },
       "TEST_TEXT": {
@@ -5693,10 +5175,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_DATASET_DIR": {
@@ -5705,10 +5187,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_OUTPUT_DIR": {
@@ -5717,10 +5199,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_MAX_SEQ": {
@@ -5729,10 +5211,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_BATCH": {
@@ -5741,10 +5223,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_GRAD_ACCUM": {
@@ -5753,10 +5235,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_LORA_RANK": {
@@ -5765,10 +5247,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_LORA_ALPHA": {
@@ -5777,10 +5259,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_LR": {
@@ -5789,10 +5271,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_WARMUP": {
@@ -5801,10 +5283,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_MIN_SAMPLES": {
@@ -5813,10 +5295,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "eddie_persona_finetune_peft",
           "whatsapp_toolcall_finetune_peft",
           "trading_analyst_finetune_batch",
-          "trading_analyst_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "trading_analyst_finetune_peft"
         ]
       },
       "FT_SAVE_STEPS": {
@@ -5825,8 +5307,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "FT_SAVE_TOTAL_LIMIT": {
@@ -5835,8 +5317,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "whatsapp_toolcall_finetune_peft",
-          "eddie_persona_finetune_peft"
+          "eddie_persona_finetune_peft",
+          "whatsapp_toolcall_finetune_peft"
         ]
       },
       "NEXTCLOUD_BASE_URL": {
@@ -5883,8 +5365,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "list_agents",
-          "homelab_test"
+          "homelab_test",
+          "list_agents"
         ]
       },
       "DAILY_AGENDA_ARTIFACTS_DIR": {
@@ -5902,8 +5384,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_LOG_JSON_TAIL": {
@@ -5912,8 +5394,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_LOG_FLUSH_SECONDS": {
@@ -5922,8 +5404,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "daily_agenda_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server"
         ]
       },
       "DAILY_AGENDA_JOB_STALE_SECONDS": {
@@ -5978,8 +5460,8 @@
         "value": null,
         "contexts": [
           "llm_system_demo",
-          "process_all_messages_from_tmp",
-          "llm_compatibility"
+          "llm_compatibility",
+          "process_all_messages_from_tmp"
         ]
       },
       "WAHA_MESSAGES_PER_CHAT": {
@@ -6106,8 +5588,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "capture_streamlit_screenshot",
           "github_agent_server",
+          "capture_streamlit_screenshot",
           "set_interceptor_url"
         ]
       },
@@ -6144,9 +5626,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
+          "ltfs_button_watch",
           "tape_orchestrator",
-          "ltfs_button_watch"
+          "tape_manager"
         ]
       },
       "LTFS_CURSOR_VOLSER_FILE": {
@@ -6155,8 +5637,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_orchestrator",
+          "tape_manager",
           "ltfs_recovery"
         ]
       },
@@ -6184,8 +5666,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_orchestrator",
+          "tape_manager",
           "ltfs_recovery"
         ]
       },
@@ -6195,8 +5677,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "send_diretor_response",
-          "portal_flow"
+          "portal_flow",
+          "send_diretor_response"
         ]
       },
       "LTFS_BUTTON_POLL_INTERVAL": {
@@ -6334,6 +5816,43 @@
         "value": null,
         "contexts": [
           "ollama_gpu_selfheal"
+        ]
+      },
+      "LTFS_JOURNAL_DIR": {
+        "name": "LTFS_JOURNAL_DIR",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_checkpoint_writer",
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_REPLICA_EXTRA": {
+        "name": "JRNL_REPLICA_EXTRA",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_RSYNC_OPTS": {
+        "name": "JRNL_RSYNC_OPTS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
+        ]
+      },
+      "JRNL_DRY_RUN": {
+        "name": "JRNL_DRY_RUN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_journal_replicate"
         ]
       },
       "COORD_POLL_INTERVAL": {
@@ -6516,33 +6035,6 @@
           "ollama_gpu_coordinator"
         ]
       },
-      "GPU_COORD_AUX_MAX_VRAM_MB": {
-        "name": "GPU_COORD_AUX_MAX_VRAM_MB",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_SOFT_PIN": {
-        "name": "GPU_COORD_SOFT_PIN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_SOFT_PIN_BUSY": {
-        "name": "GPU_COORD_SOFT_PIN_BUSY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
       "GPU_COORD_PG_DSN": {
         "name": "GPU_COORD_PG_DSN",
         "type": "string",
@@ -6558,9 +6050,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "ha_grafana_sync",
           "tuya_local_key_selfheal",
-          "tuya_token_selfheal",
-          "ha_grafana_sync"
+          "tuya_token_selfheal"
         ]
       },
       "EDDIE_API_URL": {
@@ -6569,8 +6061,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "proxy_tool_interceptor",
-          "openwebui_tool_executor"
+          "openwebui_tool_executor",
+          "proxy_tool_interceptor"
         ]
       },
       "TOOL_MAX_ROUNDS": {
@@ -6597,9 +6089,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "evoke_handler",
           "diretor_latency_exporter",
-          "app",
-          "evoke_handler"
+          "app"
         ]
       },
       "POLL": {
@@ -6890,8 +6382,8 @@
           "ltfs_checkpoint_writer"
         ]
       },
-      "LTFS_JOURNAL_DIR": {
-        "name": "LTFS_JOURNAL_DIR",
+      "GLOBAL_TAPE_LOCK_TIMEOUT": {
+        "name": "GLOBAL_TAPE_LOCK_TIMEOUT",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -7157,6 +6649,15 @@
           "ltfs_recovery"
         ]
       },
+      "LTFS_KNOWN_ISSUES_EXTRA_FILE": {
+        "name": "LTFS_KNOWN_ISSUES_EXTRA_FILE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_recovery"
+        ]
+      },
       "LTFS_SELFHEAL_ESCALATOR_SERVICE": {
         "name": "LTFS_SELFHEAL_ESCALATOR_SERVICE",
         "type": "string",
@@ -7298,18 +6799,18 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "fix_diretor_model",
-          "install_printer_function",
-          "check_diretor_status",
           "fix_director_model",
-          "install_copilot_function",
           "test_final",
           "github_agent_server",
+          "check_diretor_status",
           "install_terminal_function",
-          "fix_model",
-          "configure_diretor_model",
+          "install_printer_function",
+          "screenshot_openwebui",
+          "install_copilot_function",
           "install_whatsapp_function",
-          "screenshot_openwebui"
+          "fix_model",
+          "fix_diretor_model",
+          "configure_diretor_model"
         ]
       },
       "VALIDATOR_CHECK_PHRASE": {
@@ -7408,13 +6909,13 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "webui_function_manager",
+          "install_webui_function_api",
+          "install_function_webui",
           "install_ocr_function",
           "recreate_printer_complete",
-          "install_function_webui",
-          "webui_function_manager",
-          "force_activate_persistent",
-          "install_webui_function_api",
-          "test_printer_function"
+          "test_printer_function",
+          "force_activate_persistent"
         ]
       },
       "WEBUI_EMAIL": {
@@ -7423,9 +6924,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_webui_install",
+          "install_webui_function_api",
           "install_ocr_function",
-          "install_webui_function_api"
+          "test_webui_install"
         ]
       },
       "WEBUI_PASS": {
@@ -7587,9 +7088,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "migrate_to_bw",
+          "github_agent_server",
           "secret_store",
-          "github_agent_server"
+          "migrate_to_bw"
         ]
       },
       "PTBR_GUARDRAIL_MODE": {
@@ -7625,22 +7126,22 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "test_llm_quick",
-          "extract_whatsapp_train",
-          "test_ai_interactive",
-          "test_embed",
-          "extract_and_train",
+          "test_ollama_create",
           "test_final",
+          "extract_whatsapp_train",
+          "test_assistant",
+          "openwebui_agent_coordinator_function",
+          "test_ai_interactive",
           "nas_ai_assessor",
           "gmail_weekly_cleaner",
-          "check_model",
-          "update_rag_simple",
-          "test_sell_target_backtest",
-          "test_assistant",
           "generate_learning_evolution_graph",
+          "check_model",
           "generate_learning_dashboard",
-          "test_ollama_create",
-          "openwebui_agent_coordinator_function"
+          "test_embed",
+          "update_rag_simple",
+          "extract_and_train",
+          "test_llm_quick",
+          "test_sell_target_backtest"
         ]
       },
       "REQUEST_TIMEOUT_SECONDS": {
@@ -7650,6 +7151,105 @@
         "value": null,
         "contexts": [
           "nas_ai_assessor"
+        ]
+      },
+      "PVPN_IFACE": {
+        "name": "PVPN_IFACE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_CONF": {
+        "name": "PVPN_CONF",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_CANDIDATES": {
+        "name": "PVPN_CANDIDATES",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_STATE": {
+        "name": "PVPN_STATE",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_METRICS": {
+        "name": "PVPN_METRICS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_MIN_GAIN_PCT": {
+        "name": "PVPN_MIN_GAIN_PCT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_MIN_DWELL_SEC": {
+        "name": "PVPN_MIN_DWELL_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_PING_COUNT": {
+        "name": "PVPN_PING_COUNT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_PING_FWMARK": {
+        "name": "PVPN_PING_FWMARK",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_HANDSHAKE_TIMEOUT_SEC": {
+        "name": "PVPN_HANDSHAKE_TIMEOUT_SEC",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
+        ]
+      },
+      "PVPN_LOSS_PENALTY_MS": {
+        "name": "PVPN_LOSS_PENALTY_MS",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "protonvpn_best_server"
         ]
       },
       "GROK_SESSION_ID": {
@@ -7992,8 +7592,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "rss_llm_trainer",
-          "extract_and_train"
+          "extract_and_train",
+          "rss_llm_trainer"
         ]
       },
       "AGENT_CHAT_URL": {
@@ -8056,13 +7656,13 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "server_knowledge_generator",
+          "generate_learning_evolution_graph",
           "recreate_printer_complete",
           "generate_learning_dashboard",
           "force_activate_persistent",
-          "server_knowledge_generator",
-          "diagnose_phomemo_connection",
-          "generate_learning_evolution_graph",
-          "test_endpoints_final"
+          "test_endpoints_final",
+          "diagnose_phomemo_connection"
         ]
       },
       "WAHA_SESSION": {
@@ -8071,8 +7671,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "wait_and_run_whatsapp_test",
           "extract_whatsapp_train",
+          "wait_and_run_whatsapp_test",
           "test_whatsapp"
         ]
       },
@@ -8083,6 +7683,17 @@
         "value": null,
         "contexts": [
           "test_calculadora"
+        ]
+      },
+      "LINKEDIN_EMAIL": {
+        "name": "LINKEDIN_EMAIL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "linkedin_job_scanner",
+          "linkedin_content_purger",
+          "linkedin_content_purger_pw"
         ]
       },
       "LLM_TIMEOUT": {
@@ -8217,8 +7828,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "apply_real_job",
-          "llm_system_demo"
+          "llm_system_demo",
+          "apply_real_job"
         ]
       },
       "VAULTWARDEN_ENABLED": {
@@ -8318,15 +7929,6 @@
         "value": null,
         "contexts": [
           "compatibility_semantic"
-        ]
-      },
-      "LINKEDIN_EMAIL": {
-        "name": "LINKEDIN_EMAIL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "linkedin_job_scanner"
         ]
       },
       "MISSING_METRICS_PORT": {
@@ -8695,13 +8297,14 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_alerts",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8711,13 +8314,14 @@
         "source": "yaml",
         "value": "30s",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8727,12 +8331,13 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_service_up == 0",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8742,13 +8347,14 @@
         "source": "yaml",
         "value": "5m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8758,13 +8364,14 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8775,8 +8382,9 @@
         "value": "rpa4all-snapshot",
         "contexts": [
           "ollama_coord_error_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "gpu_coord_failover_rules",
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_SUMMARY": {
@@ -8785,13 +8393,14 @@
         "source": "yaml",
         "value": "\ud83d\udd34 RPA4All Snapshot Service DOWN",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8801,13 +8410,14 @@
         "source": "yaml",
         "value": "O servi\u00e7o rpa4all-snapshot.service n\u00e3o est\u00e1 rodando por mais de 5 minutos",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8835,12 +8445,13 @@
         "source": "yaml",
         "value": "rpa4all_snapshot_hung == 1",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8850,13 +8461,14 @@
         "source": "yaml",
         "value": "3m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8866,13 +8478,14 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8883,8 +8496,9 @@
         "value": "rpa4all-snapshot",
         "contexts": [
           "ollama_coord_error_rules",
-          "rpa4all-snapshot-alerts",
-          "gpu_coord_failover_rules"
+          "gpu_coord_failover_rules",
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts"
         ]
       },
       "GROUPS_0_RULES_1_ANNOTATIONS_SUMMARY": {
@@ -8893,13 +8507,14 @@
         "source": "yaml",
         "value": "\u23f8\ufe0f RPA4All Snapshot HUNG (Travado)",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8909,13 +8524,14 @@
         "source": "yaml",
         "value": "Lock file com idade {{ $value | humanizeDuration }}. Snapshot pode estar travado em I/O ou rede",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -8943,10 +8559,11 @@
         "source": "yaml",
         "value": "(time() - rpa4all_snapshot_last_run_timestamp) > 86400",
         "contexts": [
+          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_2_FOR": {
@@ -8955,11 +8572,12 @@
         "source": "yaml",
         "value": "1m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_SEVERITY": {
@@ -8968,11 +8586,12 @@
         "source": "yaml",
         "value": "warning",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_COMPONENT": {
@@ -8981,6 +8600,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -8990,11 +8610,12 @@
         "source": "yaml",
         "value": "\u23f3 RPA4All Snapshot \u2014 \u00daltima execu\u00e7\u00e3o > 24h",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DESCRIPTION": {
@@ -9003,11 +8624,12 @@
         "source": "yaml",
         "value": "\u00daltima execu\u00e7\u00e3o bem-sucedida h\u00e1 {{ $value | humanizeDuration }}. Timer pode estar desabilitado",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "alert_rules",
-          "rules",
           "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "ltfs-selfheal-rules",
+          "rpa4all-snapshot-alerts",
+          "rules",
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_2_ANNOTATIONS_DASHBOARD": {
@@ -9025,10 +8647,11 @@
         "source": "yaml",
         "value": "increase(rpa4all_snapshot_failed_total[1h]) > 3",
         "contexts": [
+          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_FOR": {
@@ -9038,9 +8661,10 @@
         "value": "5m",
         "contexts": [
           "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_SEVERITY": {
@@ -9050,9 +8674,10 @@
         "value": "warning",
         "contexts": [
           "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_COMPONENT": {
@@ -9061,6 +8686,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9071,9 +8697,10 @@
         "value": "\u26a0\ufe0f RPA4All Snapshot \u2014 Taxa de Falha Elevada",
         "contexts": [
           "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DESCRIPTION": {
@@ -9083,9 +8710,10 @@
         "value": "{{ $value }} falhas de snapshot na \u00faltima hora",
         "contexts": [
           "ltfs-selfheal-rules",
-          "alert_rules",
+          "rpa4all-snapshot-alerts",
           "rules",
-          "rpa4all-snapshot-alerts"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ANNOTATIONS_DASHBOARD": {
@@ -9104,8 +8732,9 @@
         "value": "rpa4all_snapshot_backup_size_bytes > 500000000000",
         "contexts": [
           "ltfs-selfheal-rules",
-          "selfhealing_rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_4_FOR": {
@@ -9115,8 +8744,9 @@
         "value": "10m",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_SEVERITY": {
@@ -9126,8 +8756,9 @@
         "value": "warning",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_COMPONENT": {
@@ -9136,6 +8767,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9146,8 +8778,9 @@
         "value": "\u26a0\ufe0f RPA4All Backup \u2014 Tamanho Anormal",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DESCRIPTION": {
@@ -9157,8 +8790,9 @@
         "value": "\u00daltimo backup com {{ $value | humanize1024 }}B. Poss\u00edvel duplica\u00e7\u00e3o ou bloat",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_4_ANNOTATIONS_DASHBOARD": {
@@ -9177,6 +8811,7 @@
         "value": "increase(rpa4all_snapshot_recovery_triggered_total[1h]) > 0",
         "contexts": [
           "ltfs-selfheal-rules",
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9187,8 +8822,9 @@
         "value": "1m",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_SEVERITY": {
@@ -9198,8 +8834,9 @@
         "value": "info",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_COMPONENT": {
@@ -9208,6 +8845,7 @@
         "source": "yaml",
         "value": "rpa4all-snapshot",
         "contexts": [
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -9218,8 +8856,9 @@
         "value": "\u2139\ufe0f RPA4All Snapshot \u2014 Recupera\u00e7\u00e3o Acionada",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DESCRIPTION": {
@@ -9229,8 +8868,9 @@
         "value": "{{ $value }} recupera\u00e7\u00f5es autom\u00e1ticas acionadas na \u00faltima hora",
         "contexts": [
           "ltfs-selfheal-rules",
-          "rules",
-          "rpa4all-snapshot-alerts"
+          "lto-staging-tape-alerts",
+          "rpa4all-snapshot-alerts",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_5_ANNOTATIONS_DASHBOARD": {
@@ -11410,8 +11050,8 @@
         "source": "yaml",
         "value": "selfheal",
         "contexts": [
-          "selfhealing_rules",
-          "pandaplus_bridge_rules"
+          "pandaplus_bridge_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_0_ANNOTATIONS_ACTION": {
@@ -11429,8 +11069,8 @@
         "source": "yaml",
         "value": "notify",
         "contexts": [
-          "selfhealing_rules",
-          "pandaplus_bridge_rules"
+          "pandaplus_bridge_rules",
+          "selfhealing_rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_ACTION": {
@@ -11556,10 +11196,10 @@
         "source": "yaml",
         "value": "ollama",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules",
           "ollama_coord_error_rules",
-          "gpu_coord_failover_rules"
+          "ltfs-selfheal-rules",
+          "gpu_coord_failover_rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_1_LABELS_CATEGORY": {
@@ -11568,10 +11208,10 @@
         "source": "yaml",
         "value": "ollama",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules",
           "ollama_coord_error_rules",
-          "gpu_coord_failover_rules"
+          "ltfs-selfheal-rules",
+          "gpu_coord_failover_rules",
+          "rules"
         ]
       },
       "GROUPS_0_RULES_2_LABELS_CATEGORY": {
@@ -11580,8 +11220,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_3_LABELS_CATEGORY": {
@@ -11590,8 +11230,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_4_LABELS_CATEGORY": {
@@ -11600,8 +11240,8 @@
         "source": "yaml",
         "value": "ltfs",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_5_LABELS_CATEGORY": {
@@ -11610,8 +11250,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_EXPR": {
@@ -11620,6 +11260,7 @@
         "source": "yaml",
         "value": "up{job=\"nas-node-exporter\",instance=\"rpa4all-nas-001\"} == 0",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -11629,8 +11270,9 @@
         "source": "yaml",
         "value": "2m",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_SEVERITY": {
@@ -11639,8 +11281,9 @@
         "source": "yaml",
         "value": "critical",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_LABELS_CATEGORY": {
@@ -11649,8 +11292,8 @@
         "source": "yaml",
         "value": "infrastructure",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_SUMMARY": {
@@ -11659,8 +11302,9 @@
         "source": "yaml",
         "value": "NAS offline no Prometheus: rpa4all-nas-001",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_6_ANNOTATIONS_DESCRIPTION": {
@@ -11669,8 +11313,9 @@
         "source": "yaml",
         "value": "Prometheus n\u00e3o consegue coletar m\u00e9tricas da NAS 192.168.15.4 h\u00e1 mais de 2 minutos. Verificar energia, boot loop, rede e exporter.",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "rules"
+          "rules",
+          "lto-staging-tape-alerts",
+          "ltfs-selfheal-rules"
         ]
       },
       "GROUPS_0_RULES_0_LABELS_SERVICE": {
@@ -11698,10 +11343,10 @@
         "value": "1",
         "contexts": [
           "authentik-http",
-          "datasources",
-          "rules",
-          "contactpoints",
           "policies",
+          "contactpoints",
+          "rules",
+          "datasources",
           "dashboards"
         ]
       },
@@ -21144,6 +20789,231 @@
           "datasources"
         ]
       },
+      "GROUPS_0_RULES_6_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_6_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-tape",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_EXPR": {
+        "name": "GROUPS_0_RULES_7_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(ltfs_cache_flush_runs_total{status=\"error\"}[1h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_FOR": {
+        "name": "GROUPS_0_RULES_7_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_7_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_7_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-flush",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_7_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS cache flush job failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_7_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_7_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Cache flush job failed on {{ $labels.instance }} in the last hour.\nCheck journal for ltfs-cache-flush.service.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_EXPR": {
+        "name": "GROUPS_0_RULES_8_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "time() - ltfs_cache_flush_last_run_timestamp > 7200\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_FOR": {
+        "name": "GROUPS_0_RULES_8_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "5m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_8_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_8_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-flush",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_8_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS cache flush job stale (>2h)",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_8_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "No successful cache flush run in the last 2 hours on {{ $labels.instance }}.\nTimer may be stuck or jobs failing silently.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_EXPR": {
+        "name": "GROUPS_0_RULES_9_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(ltfs_catalog_verify_total{status=\"failed\"}[24h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_FOR": {
+        "name": "GROUPS_0_RULES_9_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_9_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "critical",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_9_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "lto-catalog",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_9_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS catalog verification failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_9_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Catalog verification found inconsistencies on {{ $labels.instance }}.\nCheck ltfs-catalog-verify.service journal.\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_EXPR": {
+        "name": "GROUPS_0_RULES_10_EXPR",
+        "type": "string",
+        "source": "yaml",
+        "value": "increase(tape_log_spool_drain_runs_total{status=\"error\"}[1h]) > 0\n",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_FOR": {
+        "name": "GROUPS_0_RULES_10_FOR",
+        "type": "string",
+        "source": "yaml",
+        "value": "0m",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_LABELS_SEVERITY": {
+        "name": "GROUPS_0_RULES_10_LABELS_SEVERITY",
+        "type": "string",
+        "source": "yaml",
+        "value": "warning",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_LABELS_COMPONENT": {
+        "name": "GROUPS_0_RULES_10_LABELS_COMPONENT",
+        "type": "string",
+        "source": "yaml",
+        "value": "tape-logs",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ANNOTATIONS_SUMMARY": {
+        "name": "GROUPS_0_RULES_10_ANNOTATIONS_SUMMARY",
+        "type": "string",
+        "source": "yaml",
+        "value": "Tape log spool drain failed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ANNOTATIONS_DESCRIPTION": {
+        "name": "GROUPS_0_RULES_10_ANNOTATIONS_DESCRIPTION",
+        "type": "string",
+        "source": "yaml",
+        "value": "Log drain for route {{ $labels.route }} failed on {{ $labels.instance }}.\nLogs may accumulate in staging.",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
       "TUNNEL": {
         "name": "TUNNEL",
         "type": "string",
@@ -21385,60 +21255,6 @@
         "value": "30s",
         "contexts": [
           "cloudflared-rpa4all-ide"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_GPU",
-        "type": "string",
-        "source": "yaml",
-        "value": "rtx2060super",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_VRAM",
-        "type": "string",
-        "source": "yaml",
-        "value": "8gb",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_HOST",
-        "type": "string",
-        "source": "yaml",
-        "value": "nas",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT": {
-        "name": "SCRAPE_CONFIGS_20_STATIC_CONFIGS_0_LABELS_ENDPOINT",
-        "type": "string",
-        "source": "yaml",
-        "value": "nas",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_SERVICE",
-        "type": "string",
-        "source": "yaml",
-        "value": "gpu-coordinator",
-        "contexts": [
-          "prometheus"
-        ]
-      },
-      "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST": {
-        "name": "SCRAPE_CONFIGS_21_STATIC_CONFIGS_0_LABELS_HOST",
-        "type": "string",
-        "source": "yaml",
-        "value": "homelab",
-        "contexts": [
-          "prometheus"
         ]
       },
       "OPENAPI": {
@@ -22035,18 +21851,6 @@
       }
     },
     "authentication": {
-      "WIKI_TOKEN": {
-        "name": "WIKI_TOKEN",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "wiki_sync",
-          "create_wiki_page",
-          "wiki_agent",
-          "wiki_bulk_publish"
-        ]
-      },
       "OPENAI_COMPATIBLE_API_KEY": {
         "name": "OPENAI_COMPATIBLE_API_KEY",
         "type": "string",
@@ -22063,50 +21867,11 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".env",
-            "line": 17
-          },
-          {
             "file": ".env.example",
             "line": 1
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".env",
-            "line": 17
           }
         ],
         "contexts": []
-      },
-      "DB_PASSWORD": {
-        "name": "DB_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "investigate_btc"
-        ]
-      },
-      "NEXTCLOUD_ADMIN_PASSWORD": {
-        "name": "NEXTCLOUD_ADMIN_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "nextcloud_agent",
-          "config"
-        ]
       },
       "GOOGLE_AI_API_KEY": {
         "name": "GOOGLE_AI_API_KEY",
@@ -22126,18 +21891,6 @@
           {
             "file": ".env.consolidated",
             "line": 16
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 16
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 16
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 16
           }
         ],
         "contexts": []
@@ -22150,18 +21903,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 20
           }
         ],
@@ -22176,18 +21917,6 @@
           {
             "file": ".env.consolidated",
             "line": 22
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 22
           }
         ],
         "contexts": []
@@ -22198,11 +21927,11 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-dovecot",
-          "mailu-roundcube",
-          "mailu-postfix",
           "mailu-frontend",
-          "mailu-backend"
+          "mailu-backend",
+          "mailu-roundcube",
+          "mailu-dovecot",
+          "mailu-postfix"
         ]
       },
       "MAILU_DB_PASSWORD": {
@@ -22213,18 +21942,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 31
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 31
           }
         ],
@@ -22239,18 +21956,6 @@
           {
             "file": ".env.consolidated",
             "line": 32
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 32
           }
         ],
         "contexts": []
@@ -22263,18 +21968,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 45
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 45
           }
         ],
@@ -22289,18 +21982,6 @@
           {
             "file": ".env.consolidated",
             "line": 54
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 54
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 54
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 54
           }
         ],
         "contexts": []
@@ -22314,21 +21995,19 @@
           {
             "file": ".env.consolidated",
             "line": 59
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 59
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 59
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 59
           }
         ],
         "contexts": []
+      },
+      "DB_PASSWORD": {
+        "name": "DB_PASSWORD",
+        "type": "string",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
       },
       "SHARED_IPC_SECRET": {
         "name": "SHARED_IPC_SECRET",
@@ -22338,18 +22017,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 92
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 92
           }
         ],
@@ -22361,34 +22028,46 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_playwright",
-          "secrets_loader",
-          "github_agent_streamlit",
           "send_pending_report",
-          "kucoin_api",
-          "setup_telegram",
-          "coordinator",
-          "test_telegram",
-          "job_monitor_continuous",
-          "storj_payout_monitor",
-          "telegram_bot",
-          "ltfs_button_watch",
           "telegram_mcp_server",
-          "config",
+          "iot_presence_watchdog",
+          "setup_telegram",
+          "ltfs_recovery",
+          "setup_trading_telegram_channel",
+          "ci_watcher",
+          "github_agent_streamlit",
+          "telegram_bot",
+          "smart_ir_selfheal",
           "mt5_api",
+          "akash_sweep_to_kucoin",
+          "job_monitor_continuous",
           "linkedin_job_scanner",
+          "server_error_alert",
+          "coordinator",
+          "kucoin_api",
+          "alertmanager_telegram_webhook",
+          "ollama_gpu_selfheal",
+          "test_telegram",
+          "trading_daily_report",
+          "secrets_loader",
+          "test_playwright",
+          "ltfs_button_watch",
           "trading_analyst_rollout_report",
           "trading_selfheal_exporter",
-          "alertmanager_telegram_webhook",
-          "ci_watcher",
-          "iot_presence_watchdog",
-          "trading_daily_report",
-          "setup_trading_telegram_channel",
-          "server_error_alert",
-          "ollama_gpu_selfheal",
-          "akash_sweep_to_kucoin",
-          "ltfs_recovery",
-          "smart_ir_selfheal"
+          "config",
+          "storj_payout_monitor"
+        ]
+      },
+      "WIKI_TOKEN": {
+        "name": "WIKI_TOKEN",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "create_wiki_page",
+          "wiki_bulk_publish",
+          "wiki_sync",
+          "wiki_agent"
         ]
       },
       "NETBOX_REMOTE_AUTH_ENABLED": {
@@ -22397,18 +22076,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 19
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 19
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 19
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 19
@@ -22423,18 +22090,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 20
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 20
           }
@@ -22447,18 +22102,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 21
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 21
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 21
@@ -22473,18 +22116,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 22
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 22
           }
@@ -22497,18 +22128,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 23
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 23
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 23
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 23
@@ -22523,18 +22142,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 24
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 24
           }
@@ -22547,18 +22154,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 25
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 25
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 25
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 25
@@ -22573,18 +22168,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 26
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 26
           }
@@ -22597,18 +22180,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 27
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 27
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 27
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 27
@@ -22623,18 +22194,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 41
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 41
           }
@@ -22647,18 +22206,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 42
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 42
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 42
@@ -22673,18 +22220,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 43
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 43
           }
@@ -22698,18 +22233,6 @@
         "value": "***REDACTED***",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 44
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 44
           }
@@ -22722,18 +22245,6 @@
         "source": ".env",
         "value": "***REDACTED***",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 47
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 47
@@ -22759,18 +22270,6 @@
           {
             "file": "deploy/production_autonomous.env",
             "line": 17
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
-            "line": 17
           }
         ],
         "contexts": []
@@ -22781,13 +22280,13 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "telegram_bot",
+          "control_panel",
+          "test_github_push",
           "test_github_agent",
           "config",
           "setup_deploy_key",
-          "test_github_push",
-          "github_agent",
-          "telegram_bot",
-          "control_panel"
+          "github_agent"
         ]
       },
       "TUNNEL_API_TOKEN": {
@@ -22958,10 +22457,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
+          "wikijs-db",
           "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
           "netbox-postgres"
         ]
       },
@@ -23106,8 +22605,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_PASSWORD": {
@@ -23116,10 +22615,10 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker",
           "netbox-redis-cache",
-          "netbox-redis"
+          "netbox-redis",
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_AUTO_CREATE_USER": {
@@ -23128,8 +22627,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_ENABLED": {
@@ -23138,8 +22637,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_HEADER": {
@@ -23148,8 +22647,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SEPARATOR": {
@@ -23158,8 +22657,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_GROUP_SYNC_ENABLED": {
@@ -23168,8 +22667,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_HEADER": {
@@ -23178,8 +22677,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_STAFF_GROUPS": {
@@ -23188,8 +22687,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_SUPERUSER_GROUPS": {
@@ -23198,8 +22697,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REMOTE_AUTH_USER_EMAIL": {
@@ -23208,8 +22707,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SECRET_KEY": {
@@ -23218,8 +22717,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "SUPERUSER_PASSWORD": {
@@ -23228,8 +22727,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_PASSWORD": {
@@ -23256,26 +22755,26 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "tuya_token_renewer",
-          "homelab_mcp_server",
-          "generate_ollama_api_key",
-          "home_assistant_integration",
           "secrets_agent",
-          "test_secrets_agent",
+          "homelab_mcp_server",
+          "cmdb_validate",
+          "audit_and_migrate_secrets",
+          "setup_trading_telegram_channel",
+          "generate_gemini_api_key",
+          "x_agent",
+          "smart_ir_selfheal",
+          "generate_ollama_api_key",
+          "akash_sweep_to_kucoin",
+          "tuya_token_renewer",
+          "home_assistant_integration",
+          "configure_authentik_nas_ldap",
           "kucoin_api",
           "ollama_finetune_batch",
-          "audit_and_migrate_secrets",
-          "generate_gemini_api_key",
-          "storj_payout_monitor",
-          "cmdb_validate",
-          "secrets_agent_client",
-          "setup_trading_telegram_channel",
           "tuya_move_license",
+          "secrets_agent_client",
           "secrets_helper",
-          "x_agent",
-          "akash_sweep_to_kucoin",
-          "smart_ir_selfheal"
+          "test_secrets_agent",
+          "storj_payout_monitor"
         ]
       },
       "SECRETS_AGENT_URL": {
@@ -23284,25 +22783,25 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "configure_authentik_nas_ldap",
-          "tuya_token_renewer",
           "homelab_mcp_server",
-          "generate_ollama_api_key",
-          "home_assistant_integration",
-          "kucoin_api",
-          "ollama_finetune_batch",
           "audit_and_migrate_secrets",
-          "generate_gemini_api_key",
-          "storj_payout_monitor",
-          "wikijs_authentik_oidc",
-          "secrets_agent_client",
-          "agent_documentation_manager",
           "setup_trading_telegram_channel",
-          "tuya_move_license",
-          "secrets_helper",
+          "generate_gemini_api_key",
           "x_agent",
+          "smart_ir_selfheal",
+          "generate_ollama_api_key",
           "akash_sweep_to_kucoin",
-          "smart_ir_selfheal"
+          "tuya_token_renewer",
+          "home_assistant_integration",
+          "configure_authentik_nas_ldap",
+          "agent_documentation_manager",
+          "kucoin_api",
+          "wikijs_authentik_oidc",
+          "ollama_finetune_batch",
+          "tuya_move_license",
+          "secrets_agent_client",
+          "secrets_helper",
+          "storj_payout_monitor"
         ]
       },
       "SECRETS_AGENT_DATA": {
@@ -23311,11 +22810,11 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_btc_secrets_helper",
-          "test_secrets_agent",
-          "secrets_helper",
           "secret_store",
-          "secrets_agent"
+          "secrets_agent",
+          "test_btc_secrets_helper",
+          "secrets_helper",
+          "test_secrets_agent"
         ]
       },
       "WAHA_API_KEY": {
@@ -23324,18 +22823,18 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "reports_integration",
-          "extract_whatsapp_train",
-          "process_all_messages_from_tmp",
-          "test_whatsapp",
           "scan_whatsapp_llm",
-          "github_agent_streamlit",
-          "search_waha_nil",
-          "job_match_pipeline",
+          "extract_whatsapp_train",
           "wait_and_run_whatsapp_test",
-          "search_waha_production",
+          "search_waha_nil",
           "apply_real_job",
-          "whatsapp_bot"
+          "test_whatsapp",
+          "job_match_pipeline",
+          "search_waha_production",
+          "reports_integration",
+          "process_all_messages_from_tmp",
+          "whatsapp_bot",
+          "github_agent_streamlit"
         ]
       },
       "BRIDGE_RUNTIME_TOKENS": {
@@ -23363,21 +22862,21 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "register_governance_app",
+          "secrets_agent",
+          "user_management",
+          "authentik_rotate_secrets_agent_token",
           "configure_authentik_nas_ldap",
-          "authentik_user_manager",
-          "secrets_helper",
+          "storage_portal_api",
+          "install_authentik_os_login",
           "register_nextcloud_access_panel",
           "authentik_secret_fetcher",
-          "authentik_rotate_secrets_agent_token",
+          "authentik_user_manager",
+          "secrets_helper",
           "2_user_management",
-          "secrets_agent",
-          "install_authentik_os_login",
-          "configure_authentik_nextcloud_oidc",
-          "register_whatsapp_persona_panel",
-          "register_governance_app",
-          "user_management",
           "register_llm_prompt_audit_panel",
-          "storage_portal_api"
+          "configure_authentik_nextcloud_oidc",
+          "register_whatsapp_persona_panel"
         ]
       },
       "AUTHENTIK_TOKEN": {
@@ -23386,20 +22885,20 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "register_governance_app",
+          "secrets_agent",
+          "user_management",
           "configure_authentik_nas_ldap",
-          "authentik_user_manager",
-          "secrets_helper",
+          "register_mailu_authentik",
+          "storage_portal_api",
+          "install_authentik_os_login",
           "register_nextcloud_access_panel",
           "authentik_secret_fetcher",
-          "secrets_agent",
-          "install_authentik_os_login",
-          "configure_authentik_nextcloud_oidc",
-          "register_whatsapp_persona_panel",
-          "register_governance_app",
-          "register_mailu_authentik",
-          "user_management",
+          "authentik_user_manager",
+          "secrets_helper",
           "register_llm_prompt_audit_panel",
-          "storage_portal_api"
+          "configure_authentik_nextcloud_oidc",
+          "register_whatsapp_persona_panel"
         ]
       },
       "AUTHENTIK_VERIFY_TLS": {
@@ -23418,8 +22917,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "user_management",
-          "storage_portal_api"
+          "storage_portal_api",
+          "user_management"
         ]
       },
       "AUTHENTIK_PUBLIC_URL": {
@@ -23437,9 +22936,19 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_btc_secrets_helper",
           "secret_store",
+          "test_btc_secrets_helper",
           "secrets_helper"
+        ]
+      },
+      "NEXTCLOUD_ADMIN_PASSWORD": {
+        "name": "NEXTCLOUD_ADMIN_PASSWORD",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "config",
+          "nextcloud_agent"
         ]
       },
       "WG_SERVER_PUBKEY": {
@@ -23504,11 +23013,11 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "config",
+          "populate_grafana_dashboard",
+          "deploy_grafana_server_selector",
           "generate_learning_evolution_graph",
           "generate_learning_dashboard",
-          "populate_grafana_dashboard",
-          "deploy_grafana_server_selector"
+          "config"
         ]
       },
       "CONUBE_ACTION_TOKEN": {
@@ -23601,10 +23110,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "zte_modem_admin",
           "router_network_config",
           "router_udp_port_forward",
-          "zte_akash_portforward",
-          "zte_modem_admin"
+          "zte_akash_portforward"
         ]
       },
       "SECRETS_API_KEY": {
@@ -23613,10 +23122,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "zte_modem_admin",
           "router_network_config",
           "router_udp_port_forward",
-          "zte_akash_portforward",
-          "zte_modem_admin"
+          "zte_akash_portforward"
         ]
       },
       "PANEL_API_KEY": {
@@ -23625,10 +23134,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "daily_agenda_panel_server",
-          "llm_log_panel_server",
           "whatsapp_persona_panel_server",
-          "daily_agenda_job_status"
+          "daily_agenda_job_status",
+          "daily_agenda_panel_server",
+          "llm_log_panel_server"
         ]
       },
       "AUTHENTIK_ADMIN_TOKEN": {
@@ -23836,9 +23345,9 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
+          "create_neural_dashboard_remote",
           "nas_ai_assessor",
-          "create_neural_dashboard",
-          "create_neural_dashboard_remote"
+          "create_neural_dashboard"
         ]
       },
       "HA_TOKEN_FILE": {
@@ -24153,8 +23662,19 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "test_webui_install",
-          "install_webui_function_api"
+          "install_webui_function_api",
+          "test_webui_install"
+        ]
+      },
+      "LINKEDIN_PASSWORD": {
+        "name": "LINKEDIN_PASSWORD",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "linkedin_job_scanner",
+          "linkedin_content_purger",
+          "linkedin_content_purger_pw"
         ]
       },
       "GCAL_OAUTH_PORT": {
@@ -24262,18 +23782,9 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "update_grafana_panels_phase2",
           "update_grafana_dashboard_phase2",
-          "grafana_learning_dashboard"
-        ]
-      },
-      "LINKEDIN_PASSWORD": {
-        "name": "LINKEDIN_PASSWORD",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "linkedin_job_scanner"
+          "grafana_learning_dashboard",
+          "update_grafana_panels_phase2"
         ]
       },
       "ATS_PASSWORD": {
@@ -24484,77 +23995,400 @@
         ]
       }
     },
-    "database": {
-      "DATABASE_URL": {
-        "name": "DATABASE_URL",
+    "integrations": {
+      "GOOGLE_SDM_PROJECT": {
+        "name": "GOOGLE_SDM_PROJECT",
+        "type": "string",
+        "source": ".env",
+        "value": "projects/your_project_id",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 17
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_NUMBER": {
+        "name": "GOOGLE_SDM_PROJECT_NUMBER",
+        "type": "string",
+        "source": ".env",
+        "value": "your_project_number",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 18
+          }
+        ],
+        "contexts": []
+      },
+      "GOOGLE_SDM_PROJECT_ID": {
+        "name": "GOOGLE_SDM_PROJECT_ID",
         "type": "string",
         "source": "python-config",
         "value": null,
         "contexts": [
-          "kucoin_postgres_sync",
-          "prometheus_exporter",
-          "homelab_mcp_server",
-          "db_migrate",
-          "training_db",
-          "test_agent_memory",
-          "query_deposits",
+          "setup_google_home_oauth"
+        ]
+      },
+      "TELEGRAM_CHAT_ID": {
+        "name": "TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "telegram_mcp_server",
+          "iot_presence_watchdog",
+          "setup_telegram",
+          "ltfs_recovery",
+          "ci_watcher",
+          "approval_gateway",
+          "alert_digest_agent",
+          "smart_ir_selfheal",
+          "pre_tool_guardrails",
+          "akash_sweep_to_kucoin",
+          "delivery_approval",
+          "job_monitor_continuous",
+          "linkedin_job_scanner",
+          "kucoin_api",
+          "alertmanager_telegram_webhook",
+          "ollama_gpu_selfheal",
+          "test_telegram",
           "daily_report",
-          "operations_agent",
-          "search_whatsapp_postgres",
-          "2_user_management",
-          "eddie_central_missing_metrics",
-          "user_management",
-          "example_agent_memory",
-          "fetch_autocoinbot_trades",
-          "trading_conversation",
-          "setup_grafana_home",
-          "btc_signals_exporter",
-          "validate_trades_sync",
-          "agent_ipc",
-          "rss_sentiment_exporter",
-          "run_sentiment_finetune",
-          "rss_llm_trainer",
-          "decisions_track_record_rollup",
-          "news_sentiment_patch",
-          "ollama_finetune_batch",
-          "backfill_pnl",
-          "journal_ingestor",
-          "migrate_trading_profile_schema",
-          "diretor_latency_exporter",
-          "migrate_whatsapp_to_postgres",
-          "ollama_gpu_coordinator",
-          "candle_collector",
-          "trading_agent_desk_test",
-          "whatsapp_knowledge_finetune_dataset_builder",
-          "migrate_sqlite_to_postgres",
-          "export_trading_pnl_portfolio",
-          "watch_coordinator_db",
-          "restore_trading_history",
-          "run_migration",
-          "config",
-          "test_sell_target_backtest",
-          "test_integration_sentiment",
-          "autonomous_remediator",
-          "validate_sell_fix_final",
-          "telegram_trading",
-          "x_post_scheduler",
-          "email_nurturing",
-          "langgraph_base",
-          "agent_network_exporter",
+          "trading_daily_report",
+          "secrets_loader",
+          "test_playwright",
+          "ltfs_button_watch",
           "trading_analyst_rollout_report",
           "trading_selfheal_exporter",
-          "trading_daily_report",
-          "calibrate_rss_sentiment",
-          "llm_log_panel_server",
-          "train_llm_on_conversations",
-          "secrets_helper",
-          "approval_gateway",
-          "grafana_query",
+          "config",
           "lead_capture_api",
-          "eddie_central_extended_metrics",
-          "deploy_multiposition",
-          "whatsapp_bot"
+          "storj_payout_monitor"
         ]
+      },
+      "WEBHOOKS_ENABLED": {
+        "name": "WEBHOOKS_ENABLED",
+        "type": "boolean",
+        "source": "docker-compose",
+        "value": "***REDACTED***",
+        "contexts": [
+          "netbox-worker",
+          "netbox"
+        ]
+      },
+      "MARKETING_TELEGRAM_NOTIFY": {
+        "name": "MARKETING_TELEGRAM_NOTIFY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "lead_capture_api"
+        ]
+      },
+      "TELEGRAM_BOT_T": {
+        "name": "TELEGRAM_BOT_T",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "approval_gateway",
+          "alert_digest_agent",
+          "pre_tool_guardrails"
+        ]
+      },
+      "GITHUB_AGENT_URL": {
+        "name": "GITHUB_AGENT_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "config"
+        ]
+      },
+      "GOOGLE_CHROME_BIN": {
+        "name": "GOOGLE_CHROME_BIN",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "conube_agent"
+        ]
+      },
+      "CONUBE_TELEGRAM_NOTIFY": {
+        "name": "CONUBE_TELEGRAM_NOTIFY",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "conube_remediation"
+        ]
+      },
+      "TELEGRAM_PROXY_URL": {
+        "name": "TELEGRAM_PROXY_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "position_manager_mixin"
+        ]
+      },
+      "TELEGRAM_ERROR_CHAT_ID": {
+        "name": "TELEGRAM_ERROR_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "server_error_alert"
+        ]
+      },
+      "GITHUB_REPO": {
+        "name": "GITHUB_REPO",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "setup_deploy_key"
+        ]
+      },
+      "AGENDA_TELEGRAM_CHAT_ID": {
+        "name": "AGENDA_TELEGRAM_CHAT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "secrets_loader",
+          "daily_agenda_config"
+        ]
+      },
+      "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT": {
+        "name": "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_recovery"
+        ]
+      },
+      "LTFS_TELEGRAM_POLL_INTERVAL": {
+        "name": "LTFS_TELEGRAM_POLL_INTERVAL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ltfs_recovery"
+        ]
+      },
+      "WEBHOOK_PORT": {
+        "name": "WEBHOOK_PORT",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram_webhook"
+        ]
+      },
+      "WEBHOOK_URL": {
+        "name": "WEBHOOK_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": "***REDACTED***",
+        "contexts": [
+          "whatsapp_manager"
+        ]
+      },
+      "GITHUB_CLIENT_ID": {
+        "name": "GITHUB_CLIENT_ID",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "github_agent_server",
+          "github_agent_streamlit"
+        ]
+      },
+      "GITHUB_REDIRECT_URI": {
+        "name": "GITHUB_REDIRECT_URI",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "github_agent_server",
+          "github_agent_streamlit"
+        ]
+      },
+      "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram",
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram",
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID",
+        "type": "integer",
+        "source": "yaml",
+        "value": "948686300",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE",
+        "type": "json",
+        "source": "yaml",
+        "value": "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} - {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "True",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager.production"
+        ]
+      },
+      "GLOBAL_TELEGRAM_API_URL": {
+        "name": "GLOBAL_TELEGRAM_API_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "https://api.telegram.org/bot",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
+        "type": "url",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
+        "type": "boolean",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      },
+      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
+        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
+        "type": "string",
+        "source": "yaml",
+        "value": "***REDACTED***",
+        "contexts": [
+          "alertmanager_telegram"
+        ]
+      }
+    },
+    "database": {
+      "MAILU_DATABASE_URL": {
+        "name": "MAILU_DATABASE_URL",
+        "type": "url",
+        "source": ".env",
+        "value": "***REDACTED***",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 46
+          }
+        ],
+        "contexts": []
+      },
+      "MAILU_REDIS_URL": {
+        "name": "MAILU_REDIS_URL",
+        "type": "url",
+        "source": ".env",
+        "value": "redis://:${MAILU_REDIS_PASSWORD}@mailu-redis",
+        "locations": [
+          {
+            "file": ".env.consolidated",
+            "line": 47
+          }
+        ],
+        "contexts": []
       },
       "DB_HOST": {
         "name": "DB_HOST",
@@ -24562,8 +24396,8 @@
         "source": "docker-compose",
         "value": "wikijs-db",
         "contexts": [
-          "netbox",
           "netbox-worker",
+          "netbox",
           "wikijs"
         ]
       },
@@ -24582,8 +24416,8 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "netbox",
           "netbox-worker",
+          "netbox",
           "wikijs"
         ]
       },
@@ -24593,60 +24427,82 @@
         "source": "docker-compose",
         "value": "wikijs",
         "contexts": [
-          "netbox",
           "netbox-worker",
+          "netbox",
           "wikijs"
         ]
       },
-      "MAILU_DATABASE_URL": {
-        "name": "MAILU_DATABASE_URL",
-        "type": "url",
-        "source": ".env",
-        "value": "***REDACTED***",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 46
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 46
-          }
-        ],
-        "contexts": []
-      },
-      "MAILU_REDIS_URL": {
-        "name": "MAILU_REDIS_URL",
-        "type": "url",
-        "source": ".env",
-        "value": "redis://:${MAILU_REDIS_PASSWORD}@mailu-redis",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 47
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 47
-          }
-        ],
-        "contexts": []
+      "DATABASE_URL": {
+        "name": "DATABASE_URL",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "email_nurturing",
+          "user_management",
+          "prometheus_exporter",
+          "etl_agent_executions_to_training",
+          "migrate_trading_profile_schema",
+          "homelab_mcp_server",
+          "llm_log_panel_server",
+          "train_llm_on_conversations",
+          "whatsapp_knowledge_finetune_dataset_builder",
+          "grafana_query",
+          "candle_collector",
+          "test_sell_target_backtest",
+          "calibrate_rss_sentiment",
+          "setup_grafana_home",
+          "approval_gateway",
+          "ollama_gpu_coordinator",
+          "export_trading_pnl_portfolio",
+          "news_sentiment_patch",
+          "validate_trades_sync",
+          "test_integration_sentiment",
+          "run_migration",
+          "backfill_pnl",
+          "btc_signals_exporter",
+          "search_whatsapp_postgres",
+          "2_user_management",
+          "query_deposits",
+          "migrate_sqlite_to_postgres",
+          "eddie_central_missing_metrics",
+          "watch_coordinator_db",
+          "trading_agent_desk_test",
+          "rss_sentiment_exporter",
+          "deploy_multiposition",
+          "example_agent_memory",
+          "eddie_central_extended_metrics",
+          "journal_ingestor",
+          "kucoin_postgres_sync",
+          "fetch_autocoinbot_trades",
+          "migrate_whatsapp_to_postgres",
+          "ollama_finetune_batch",
+          "operations_agent",
+          "rss_llm_trainer",
+          "langgraph_base",
+          "whatsapp_bot",
+          "diretor_latency_exporter",
+          "daily_report",
+          "trading_daily_report",
+          "autonomous_remediator",
+          "test_agent_memory",
+          "agent_ipc",
+          "db_migrate",
+          "trading_conversation",
+          "training_db",
+          "agent_network_exporter",
+          "trading_analyst_rollout_report",
+          "restore_trading_history",
+          "validate_sell_fix_final",
+          "decisions_track_record_rollup",
+          "secrets_helper",
+          "telegram_trading",
+          "run_sentiment_finetune",
+          "config",
+          "trading_selfheal_exporter",
+          "lead_capture_api",
+          "x_post_scheduler"
+        ]
       },
       "CMDB_TIMEZONE": {
         "name": "CMDB_TIMEZONE",
@@ -24654,18 +24510,6 @@
         "source": ".env",
         "value": "America/Sao_Paulo",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 1
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 1
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 1
@@ -24680,18 +24524,6 @@
         "value": "127.0.0.1",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 4
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 4
           }
@@ -24704,18 +24536,6 @@
         "source": ".env",
         "value": "18090",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 5
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 5
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 5
@@ -24730,18 +24550,6 @@
         "value": "18-alpine",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 32
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 32
           }
@@ -24754,18 +24562,6 @@
         "source": ".env",
         "value": "9.0-alpine",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 33
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 33
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 33
@@ -24780,18 +24576,6 @@
         "value": "11",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 35
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 35
           }
@@ -24805,18 +24589,6 @@
         "value": "netbox",
         "locations": [
           {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 39
-          },
-          {
             "file": "deploy/cmdb/.env.example",
             "line": 39
           }
@@ -24829,18 +24601,6 @@
         "source": ".env",
         "value": "netbox",
         "locations": [
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-            "line": 40
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
-            "line": 40
-          },
           {
             "file": "deploy/cmdb/.env.example",
             "line": 40
@@ -24872,10 +24632,10 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
+          "wikijs-db",
           "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
           "netbox-postgres"
         ]
       },
@@ -24885,10 +24645,10 @@
         "source": "docker-compose",
         "value": "roundcube",
         "contexts": [
+          "wikijs-db",
           "mailu-db",
           "postgres",
           "mail-db",
-          "wikijs-db",
           "netbox-postgres"
         ]
       },
@@ -24952,8 +24712,8 @@
         "source": "docker-compose",
         "value": "***REDACTED***",
         "contexts": [
-          "mailu-roundcube",
-          "mailu-backend"
+          "mailu-backend",
+          "mailu-roundcube"
         ]
       },
       "GF_DATABASE_TYPE": {
@@ -25025,8 +24785,8 @@
         "source": "docker-compose",
         "value": "1",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_CACHE_HOST": {
@@ -25035,8 +24795,8 @@
         "source": "docker-compose",
         "value": "netbox-redis-cache",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_DATABASE": {
@@ -25045,8 +24805,8 @@
         "source": "docker-compose",
         "value": "0",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "REDIS_HOST": {
@@ -25055,8 +24815,8 @@
         "source": "docker-compose",
         "value": "netbox-redis",
         "contexts": [
-          "netbox",
-          "netbox-worker"
+          "netbox-worker",
+          "netbox"
         ]
       },
       "MARIADB_DATABASE": {
@@ -25213,10 +24973,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
           "kucoin_api",
-          "restore_trading_history"
+          "restore_trading_history",
+          "secrets_helper",
+          "test_kucoin_api"
         ]
       },
       "KUCOIN_API_SECRET": {
@@ -25225,10 +24985,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
           "kucoin_api",
-          "restore_trading_history"
+          "restore_trading_history",
+          "secrets_helper",
+          "test_kucoin_api"
         ]
       },
       "KUCOIN_API_PASSPHRASE": {
@@ -25237,10 +24997,10 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "secrets_helper",
-          "test_kucoin_api",
           "kucoin_api",
-          "restore_trading_history"
+          "restore_trading_history",
+          "secrets_helper",
+          "test_kucoin_api"
         ]
       },
       "KUCOIN_ALLOWED_IP": {
@@ -25251,18 +25011,6 @@
         "locations": [
           {
             "file": ".env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 69
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
             "line": 69
           }
         ],
@@ -25310,11 +25058,11 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "validate_btc_config",
           "prometheus_exporter",
           "fix_prometheus_exporter",
           "kucoin_api",
-          "trading_agent",
-          "validate_btc_config"
+          "trading_agent"
         ]
       },
       "COMPATIBILITY_METHOD": {
@@ -25323,8 +25071,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "apply_real_job",
-          "llm_system_demo"
+          "llm_system_demo",
+          "apply_real_job"
         ]
       },
       "BTC_AGENT_DIR": {
@@ -25333,8 +25081,26 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "kucoin_postgres_sync",
-          "validate_trades_sync"
+          "validate_trades_sync",
+          "kucoin_postgres_sync"
+        ]
+      },
+      "GPU_COORD_TRADING_EXCLUSIVE_GPU0": {
+        "name": "GPU_COORD_TRADING_EXCLUSIVE_GPU0",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
+        ]
+      },
+      "GPU_COORD_TRADING_HEADROOM_MB": {
+        "name": "GPU_COORD_TRADING_HEADROOM_MB",
+        "type": "string",
+        "source": "python-config",
+        "value": null,
+        "contexts": [
+          "ollama_gpu_coordinator"
         ]
       },
       "COINGECKO_PRICE_URL": {
@@ -25352,8 +25118,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "nas_ai_assessor",
           "populate_grafana_dashboard",
+          "nas_ai_assessor",
           "tape_quality_ollama_narrator",
           "alert_digest_agent"
         ]
@@ -25364,9 +25130,9 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
           "ollama_mcp_bridge",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "TELEGRAM_TRADING_CHAT_ID": {
@@ -25384,10 +25150,10 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "mt5_api",
-          "secrets_helper",
           "test_mt5_bridge",
-          "bridge_api"
+          "mt5_api",
+          "bridge_api",
+          "secrets_helper"
         ]
       },
       "COIN_SYMBOL": {
@@ -25396,8 +25162,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "kucoin_api",
-          "prometheus_exporter"
+          "prometheus_exporter",
+          "kucoin_api"
         ]
       },
       "TRADING_CONVERSATION_SYMBOLS": {
@@ -25424,8 +25190,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "homelab_mcp_server"
+          "homelab_mcp_server",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_HOST": {
@@ -25434,8 +25200,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_PORT": {
@@ -25444,8 +25210,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_USER": {
@@ -25454,8 +25220,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_PASSWORD": {
@@ -25464,8 +25230,8 @@
         "source": "python-config",
         "value": "***REDACTED***",
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "BTC_TRADING_DB_NAME": {
@@ -25474,8 +25240,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "trading_conversation",
-          "trading_daily_report"
+          "trading_daily_report",
+          "trading_conversation"
         ]
       },
       "TRADING_STATUS_SYMBOL": {
@@ -25670,24 +25436,6 @@
       },
       "GPU_COORD_TRADING_GPU0_NAME": {
         "name": "GPU_COORD_TRADING_GPU0_NAME",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_TRADING_EXCLUSIVE_GPU0": {
-        "name": "GPU_COORD_TRADING_EXCLUSIVE_GPU0",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ollama_gpu_coordinator"
-        ]
-      },
-      "GPU_COORD_TRADING_HEADROOM_MB": {
-        "name": "GPU_COORD_TRADING_HEADROOM_MB",
         "type": "string",
         "source": "python-config",
         "value": null,
@@ -26128,398 +25876,6 @@
         ]
       }
     },
-    "integrations": {
-      "GOOGLE_SDM_PROJECT": {
-        "name": "GOOGLE_SDM_PROJECT",
-        "type": "string",
-        "source": ".env",
-        "value": "projects/your_project_id",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 17
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 17
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_NUMBER": {
-        "name": "GOOGLE_SDM_PROJECT_NUMBER",
-        "type": "string",
-        "source": ".env",
-        "value": "your_project_number",
-        "locations": [
-          {
-            "file": ".env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-            "line": 18
-          },
-          {
-            "file": ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-            "line": 18
-          }
-        ],
-        "contexts": []
-      },
-      "GOOGLE_SDM_PROJECT_ID": {
-        "name": "GOOGLE_SDM_PROJECT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "setup_google_home_oauth"
-        ]
-      },
-      "TELEGRAM_CHAT_ID": {
-        "name": "TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "test_playwright",
-          "alert_digest_agent",
-          "pre_tool_guardrails",
-          "secrets_loader",
-          "daily_report",
-          "delivery_approval",
-          "kucoin_api",
-          "setup_telegram",
-          "test_telegram",
-          "job_monitor_continuous",
-          "storj_payout_monitor",
-          "ltfs_button_watch",
-          "telegram_mcp_server",
-          "config",
-          "linkedin_job_scanner",
-          "trading_analyst_rollout_report",
-          "trading_selfheal_exporter",
-          "alertmanager_telegram_webhook",
-          "ci_watcher",
-          "trading_daily_report",
-          "iot_presence_watchdog",
-          "ollama_gpu_selfheal",
-          "approval_gateway",
-          "akash_sweep_to_kucoin",
-          "ltfs_recovery",
-          "lead_capture_api",
-          "smart_ir_selfheal"
-        ]
-      },
-      "WEBHOOKS_ENABLED": {
-        "name": "WEBHOOKS_ENABLED",
-        "type": "boolean",
-        "source": "docker-compose",
-        "value": "***REDACTED***",
-        "contexts": [
-          "netbox",
-          "netbox-worker"
-        ]
-      },
-      "MARKETING_TELEGRAM_NOTIFY": {
-        "name": "MARKETING_TELEGRAM_NOTIFY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "lead_capture_api"
-        ]
-      },
-      "TELEGRAM_BOT_T": {
-        "name": "TELEGRAM_BOT_T",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "approval_gateway",
-          "alert_digest_agent",
-          "pre_tool_guardrails"
-        ]
-      },
-      "GITHUB_AGENT_URL": {
-        "name": "GITHUB_AGENT_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "config"
-        ]
-      },
-      "GOOGLE_CHROME_BIN": {
-        "name": "GOOGLE_CHROME_BIN",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "conube_agent"
-        ]
-      },
-      "CONUBE_TELEGRAM_NOTIFY": {
-        "name": "CONUBE_TELEGRAM_NOTIFY",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "conube_remediation"
-        ]
-      },
-      "TELEGRAM_PROXY_URL": {
-        "name": "TELEGRAM_PROXY_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "position_manager_mixin"
-        ]
-      },
-      "TELEGRAM_ERROR_CHAT_ID": {
-        "name": "TELEGRAM_ERROR_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "server_error_alert"
-        ]
-      },
-      "GITHUB_REPO": {
-        "name": "GITHUB_REPO",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "setup_deploy_key"
-        ]
-      },
-      "AGENDA_TELEGRAM_CHAT_ID": {
-        "name": "AGENDA_TELEGRAM_CHAT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "daily_agenda_config",
-          "secrets_loader"
-        ]
-      },
-      "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT": {
-        "name": "LTFS_TELEGRAM_CONFIRMATION_TIMEOUT",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ltfs_recovery"
-        ]
-      },
-      "LTFS_TELEGRAM_POLL_INTERVAL": {
-        "name": "LTFS_TELEGRAM_POLL_INTERVAL",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "ltfs_recovery"
-        ]
-      },
-      "WEBHOOK_PORT": {
-        "name": "WEBHOOK_PORT",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram_webhook"
-        ]
-      },
-      "WEBHOOK_URL": {
-        "name": "WEBHOOK_URL",
-        "type": "string",
-        "source": "python-config",
-        "value": "***REDACTED***",
-        "contexts": [
-          "whatsapp_manager"
-        ]
-      },
-      "GITHUB_CLIENT_ID": {
-        "name": "GITHUB_CLIENT_ID",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "github_agent_server",
-          "github_agent_streamlit"
-        ]
-      },
-      "GITHUB_REDIRECT_URI": {
-        "name": "GITHUB_REDIRECT_URI",
-        "type": "string",
-        "source": "python-config",
-        "value": null,
-        "contexts": [
-          "github_agent_server",
-          "github_agent_streamlit"
-        ]
-      },
-      "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_0_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram",
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_CHAT_ID",
-        "type": "integer",
-        "source": "yaml",
-        "value": "948686300",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_MESSAGE",
-        "type": "json",
-        "source": "yaml",
-        "value": "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} - {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_2_TELEGRAM_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "True",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_3_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_4_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager.production"
-        ]
-      },
-      "GLOBAL_TELEGRAM_API_URL": {
-        "name": "GLOBAL_TELEGRAM_API_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "https://api.telegram.org/bot",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_1_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_URL",
-        "type": "url",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_SEND_RESOLVED",
-        "type": "boolean",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      },
-      "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE": {
-        "name": "RECEIVERS_2_WEBHOOK_CONFIGS_0_HEADERS_X-ALERT-TYPE",
-        "type": "string",
-        "source": "yaml",
-        "value": "***REDACTED***",
-        "contexts": [
-          "alertmanager_telegram"
-        ]
-      }
-    },
     "infrastructure": {
       "LTFS_MOUNT_POINT": {
         "name": "LTFS_MOUNT_POINT",
@@ -26527,8 +25883,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "tape_manager",
           "tape_orchestrator",
+          "tape_manager",
           "ltfs_recovery"
         ]
       },
@@ -26610,8 +25966,8 @@
         "source": "python-config",
         "value": null,
         "contexts": [
-          "create_dev_agent",
-          "config"
+          "config",
+          "create_dev_agent"
         ]
       },
       "LTFS_MAX_MOUNT_ATTEMPTS": {
@@ -26712,16 +26068,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "update_grafana_dashboard_phase2",
           "selenium_grafana_action",
-          "validate_eddie_central_api",
-          "update_grafana_panels_phase2",
-          "tape_quality_ollama_narrator",
           "deploy_grafana",
           "nas_ai_assessor",
+          "tape_quality_ollama_narrator",
+          "validate_eddie_central_api",
           "test_grafana_selenium",
-          "create_neural_dashboard",
           "grafana_query",
-          "update_grafana_dashboard_phase2"
+          "create_neural_dashboard",
+          "update_grafana_panels_phase2"
         ]
       },
       "GRAFANA_CONTAINER": {
@@ -26757,16 +26113,16 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "populate_grafana_dashboard",
           "selenium_grafana_action",
-          "validate_eddie_central_api",
-          "update_grafana_panels_phase2",
-          "tape_quality_ollama_narrator",
+          "deploy_grafana_server_selector",
           "deploy_grafana",
           "nas_ai_assessor",
+          "tape_quality_ollama_narrator",
+          "validate_eddie_central_api",
           "test_grafana_selenium",
           "grafana_query",
-          "populate_grafana_dashboard",
-          "deploy_grafana_server_selector"
+          "update_grafana_panels_phase2"
         ]
       },
       "GRAFANA_PASS": {
@@ -26775,15 +26131,15 @@
         "source": "python-config",
         "value": null,
         "contexts": [
+          "populate_grafana_dashboard",
           "selenium_grafana_action",
-          "validate_eddie_central_api",
-          "update_grafana_panels_phase2",
-          "tape_quality_ollama_narrator",
+          "deploy_grafana_server_selector",
           "deploy_grafana",
+          "tape_quality_ollama_narrator",
+          "validate_eddie_central_api",
           "test_grafana_selenium",
           "grafana_query",
-          "populate_grafana_dashboard",
-          "deploy_grafana_server_selector"
+          "update_grafana_panels_phase2"
         ]
       },
       "GRAFANA_PANEL_ID": {
@@ -26938,12 +26294,13 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotServiceDown",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -26953,12 +26310,13 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotHung",
         "contexts": [
-          "ltfs-selfheal-rules",
-          "pandaplus_bridge_rules",
-          "alert_rules",
-          "ollama_coord_error_rules",
           "selfhealing_rules",
+          "ollama_coord_error_rules",
+          "pandaplus_bridge_rules",
           "rpa4all-snapshot-alerts",
+          "ltfs-selfheal-rules",
+          "alert_rules",
+          "lto-staging-tape-alerts",
           "gpu_coord_failover_rules"
         ]
       },
@@ -26968,10 +26326,11 @@
         "source": "yaml",
         "value": "RPA4AllSnapshotLastRunTooOld",
         "contexts": [
+          "selfhealing_rules",
           "ltfs-selfheal-rules",
-          "alert_rules",
           "rpa4all-snapshot-alerts",
-          "selfhealing_rules"
+          "alert_rules",
+          "lto-staging-tape-alerts"
         ]
       },
       "GROUPS_0_RULES_3_ALERT": {
@@ -26982,6 +26341,7 @@
         "contexts": [
           "ltfs-selfheal-rules",
           "alert_rules",
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -26992,6 +26352,7 @@
         "value": "RPA4AllBackupSizeUnusual",
         "contexts": [
           "ltfs-selfheal-rules",
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -27002,6 +26363,7 @@
         "value": "RPA4AllSnapshotRecoveryTriggered",
         "contexts": [
           "ltfs-selfheal-rules",
+          "lto-staging-tape-alerts",
           "rpa4all-snapshot-alerts"
         ]
       },
@@ -27087,6 +26449,7 @@
         "source": "yaml",
         "value": "NASNodeExporterDown",
         "contexts": [
+          "lto-staging-tape-alerts",
           "ltfs-selfheal-rules"
         ]
       },
@@ -27098,56 +26461,58 @@
         "contexts": [
           "contactpoints"
         ]
+      },
+      "GROUPS_0_RULES_7_ALERT": {
+        "name": "GROUPS_0_RULES_7_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CacheFlushJobFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_8_ALERT": {
+        "name": "GROUPS_0_RULES_8_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CacheFlushJobStale",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_9_ALERT": {
+        "name": "GROUPS_0_RULES_9_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "LTFS_CatalogVerificationFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
+      },
+      "GROUPS_0_RULES_10_ALERT": {
+        "name": "GROUPS_0_RULES_10_ALERT",
+        "type": "string",
+        "source": "yaml",
+        "value": "TapeLogSpoolDrainFailed",
+        "contexts": [
+          "lto-staging-tape-alerts"
+        ]
       }
     }
   },
   "metadata": {
-    "totalVariables": 2711,
+    "totalVariables": 2766,
     "sourceFiles": [
-      ".env",
       ".env.openai-compatible.example",
       ".env.example",
       ".env.consolidated",
       ".env.example.wiki",
-      ".claude/worktrees/elegant-burnell-19147f/.env.openai-compatible.example",
-      ".claude/worktrees/elegant-burnell-19147f/.env.example",
-      ".claude/worktrees/elegant-burnell-19147f/.env.consolidated",
-      ".claude/worktrees/elegant-burnell-19147f/.env.example.wiki",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.openai-compatible.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.consolidated",
-      ".claude/worktrees/trusting-chatelet-ffb338/.env.example.wiki",
-      ".claude/worktrees/zen-bohr-5c1270/.env.openai-compatible.example",
-      ".claude/worktrees/zen-bohr-5c1270/.env.example",
-      ".claude/worktrees/zen-bohr-5c1270/.env.consolidated",
-      ".claude/worktrees/zen-bohr-5c1270/.env.example.wiki",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/.env.example",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/.env.example",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/.env.example",
       "deploy/cmdb/.env.example",
-      ".env",
       "btc_trading_agent/BTC_USDT_shadow.env",
       "systemd/ltfs-lto6-sg1.env",
       "deploy/production_autonomous.env",
       "tools/authentik_management/configs/openwebui.env",
       "tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/zen-bohr-5c1270/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/zen-bohr-5c1270/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/production_autonomous.env",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/crypto-agent/models.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/production_autonomous.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/grafana.env",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/crypto-agent/models.env",
-      ".claude/worktrees/elegant-burnell-19147f/btc_trading_agent/BTC_USDT_shadow.env",
-      ".claude/worktrees/elegant-burnell-19147f/systemd/ltfs-lto6-sg1.env",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/production_autonomous.env",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/openwebui.env",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/grafana.env",
       "deploy/crypto-agent/models.env",
       "docker/docker-compose.gdrive.yml",
       "docker/docker-compose.simple-mail.yml",
@@ -27161,45 +26526,6 @@
       "docker/docker-compose.ntopng.yml",
       "tools/vaultwarden/docker-compose.yml",
       "tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/zen-bohr-5c1270/deploy/printshare/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/deploy/printshare/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.gdrive.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.simple-mail.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.mailu.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.grafana.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.opensearch.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose-exporters.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.wikijs.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.email-simple.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/docker-compose.ntopng.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/vaultwarden/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/authentik_management/configs/docker-compose.override.yml",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/cmdb/docker-compose.yml",
-      ".claude/worktrees/elegant-burnell-19147f/deploy/printshare/docker-compose.yml",
       "deploy/cmdb/docker-compose.yml",
       "deploy/printshare/docker-compose.yml",
       "systemd/agent-network-exporter.service",
@@ -27251,6 +26577,8 @@
       "systemd/eddie-whatsapp-bot.service.d/env.conf",
       "systemd/eddie_central_extended_metrics.service",
       "systemd/ethwan-selfheal.service",
+      "systemd/faster-whisper-api.service",
+      "systemd/fix-staging-perms.service",
       "systemd/github-agent.service",
       "systemd/grafana-dashboard-sync.service",
       "systemd/grafana-selfheal.service",
@@ -27282,7 +26610,12 @@
       "systemd/ltfs-button-watch.service",
       "systemd/ltfs-cache-flush.service.d/60-tape-gate.conf",
       "systemd/ltfs-cache-flush.service.d/70-rearm-timer-on-exit.conf",
+      "systemd/ltfs-cache-flush.timer",
+      "systemd/ltfs-catalog-verify.service",
+      "systemd/ltfs-catalog-verify.timer",
       "systemd/ltfs-deep-recovery.service",
+      "systemd/ltfs-journal-replicate.service",
+      "systemd/ltfs-journal-replicate.timer",
       "systemd/ltfs-log-rotation.service",
       "systemd/ltfs-log-rotation.timer",
       "systemd/ltfs-lto6-selfheal-escalator.service",
@@ -27313,6 +26646,7 @@
       "systemd/nas-ai-assessor.service.d/override.conf",
       "systemd/nas-ai-assessor.timer.d/10-power.conf",
       "systemd/nas-ollama-load.service",
+      "systemd/nas-ram-exporter.service",
       "systemd/nextcloud-tape-backup.service.d/30-no-overlap.conf",
       "systemd/nextcloud-tape-backup.service.d/35-sg0-tape-access-scope.conf",
       "systemd/nextcloud-tape-backup.timer.d/20-no-ltfs-require.conf",
@@ -27359,6 +26693,8 @@
       "systemd/pandaplus-telegram-bridge.service",
       "systemd/pihole-ipv6-dns-fix.service",
       "systemd/post-boot-check.service",
+      "systemd/protonvpn-best-server.service",
+      "systemd/protonvpn-best-server.timer",
       "systemd/protonvpn-boot-selfheal.service",
       "systemd/protonvpn-unit-selfheal.service",
       "systemd/protonvpn-unit-selfheal.timer",
@@ -27383,6 +26719,8 @@
       "systemd/storj-payout-monitor.service",
       "systemd/storj-payout-monitor.timer",
       "systemd/tape-component-quality-exporter.service",
+      "systemd/tape-log-spool-drain-nextcloud.service",
+      "systemd/tape-log-spool-drain-nextcloud.timer",
       "systemd/tape-quality-ollama-narrator.service",
       "systemd/tape-quality-ollama-narrator.timer",
       "systemd/tape-safe-eject.service",
@@ -27422,6 +26760,7 @@
       "tests/test_storj_withdraw.py",
       "tests/test_ollama_finetune_batch.py",
       "tests/test_hop_executor_dry_run.py",
+      "tests/test_protonvpn_best_server.py",
       "tests/test_server_error_alert.py",
       "tests/test_telegram_trading.py",
       "tests/test_catalog_variables.py",
@@ -27482,6 +26821,7 @@
       "tests/test_vpn_deb.py",
       "tests/test_storj_selfheal_exporter.py",
       "tests/test_final_boot_status_agent.py",
+      "tests/test_tuya_timer_anti_regression.py",
       "tests/test_ai_plan_fallback.py",
       "tests/test_taxonomy_meta.py",
       "tests/test_cmdb_agent.py",
@@ -27525,6 +26865,7 @@
       "tests/test_rss_llm_trainer.py",
       "tests/test_cloudflared_insert_ssh.py",
       "tests/test_configure_authentik_nextcloud_oidc.py",
+      "tests/test_whatsapp_toolcall_chunked_train_script.py",
       "tests/test_ntopng_auth_deploy.py",
       "tests/_variables_catalog_config.py",
       "tests/test_daily_agenda_approval.py",
@@ -27623,7 +26964,6 @@
       "tests/test_systemd_dropin_parity.py",
       "tests/test_storj_sync_public_address.py",
       "tests/test_llm_log_panel_server.py",
-      "philco10b_raspios/download_iso_libtorrent.py",
       "specialized_agents/telegram_notify.py",
       "specialized_agents/wiki_refactor.py",
       "specialized_agents/copilot_routes.py",
@@ -27717,6 +27057,7 @@
       "scripts/run_dev_tester_fix.py",
       "scripts/cloudflared_insert_ssh.py",
       "scripts/dump_zte_js.py",
+      "scripts/etl_agent_executions_to_training.py",
       "scripts/test_openai_compatible_model.py",
       "scripts/server_error_alert.py",
       "scripts/generate_swagger.py",
@@ -27773,6 +27114,7 @@
       "scripts/analyze_deposit_detection.py",
       "scripts/whatsapp_knowledge_finetune_dataset_builder.py",
       "scripts/daily_agenda_panel_server.py",
+      "scripts/faster_whisper_api.py",
       "scripts/trading_analyst_rollout_report.py",
       "scripts/trading_analyst_finetune_dataset_builder.py",
       "scripts/patch_training_db.py",
@@ -27808,7 +27150,6 @@
       "scripts/trading_analyst_shadow_eval.py",
       "scripts/wikijs_configure.py",
       "tasks/process_documentation_task.py",
-      ".tmp/parse_ha_cross.py",
       "content_automation/logging_setup.py",
       "content_automation/__init__.py",
       "content_automation/models.py",
@@ -27820,14 +27161,6 @@
       "content_automation/trends.py",
       "content_automation/main.py",
       "content_automation/storage.py",
-      "tmp/check_kcs_fee_status.py",
-      "tmp/publish_rss_wiki.py",
-      "tmp/buy_kcs_with_usdt.py",
-      "tmp/publish_kiosk_wiki.py",
-      "tmp/backtest_verify.py",
-      "tmp/regression_4h.py",
-      "tmp/investigate_btc.py",
-      "tmp/regression_20d.py",
       "tools/capture_streamlit_screenshot.py",
       "tools/tape_manager.py",
       "tools/rclone_progress_pessoal.py",
@@ -27845,6 +27178,7 @@
       "tools/daily_agenda_config.py",
       "tools/build_flavio_bolsonaro_agenda_source.py",
       "tools/daily_agenda_job_status.py",
+      "tools/ltfs_cache_flush.py",
       "tools/force_diretor_response.py",
       "tools/run_network_exporter.py",
       "tools/extract_and_store_secrets.py",
@@ -27859,6 +27193,7 @@
       "tools/gdrive_download_and_process.py",
       "tools/ui_smoke_tests.py",
       "tools/send_to_coordinator.py",
+      "tools/ltfs_journal_replicate.py",
       "tools/get_last_telegram_photo.py",
       "tools/tape_dual_recovery.py",
       "tools/watch_coordinator_db.py",
@@ -27872,6 +27207,8 @@
       "tools/parse_playwright_add_loop_results.py",
       "tools/collect_agent_responses.py",
       "tools/invoke_director.py",
+      "tools/ltfs_catalog_verify.py",
+      "tools/tape_log_spool_drain.py",
       "tools/test_record_trade.py",
       "tools/ollama_offloader.py",
       "tools/agent_documentation_manager.py",
@@ -27898,6 +27235,7 @@
       "tools/diretor_latency_exporter.py",
       "tools/agenda_media_router.py",
       "tools/test_cpu_tts_from_generated_text.py",
+      "tools/fix_staging_perms.py",
       "tools/daily_agenda_segments.py",
       "tools/remediate_trading_topology.py",
       "tools/mercadopago_oauth_setup.py",
@@ -27966,6 +27304,7 @@
       "tools/restore_trading_history.py",
       "tools/watch_agent_logs.py",
       "tools/ollama_warmup.py",
+      "tools/nas_ram_exporter.py",
       "tools/audit_undocumented_agents.py",
       "tools/telegram_listener.py",
       "tools/attach_and_dump_bus.py",
@@ -28012,6 +27351,7 @@
       "tools/homelab/tuya_token_renewer.py",
       "tools/homelab/nas_ai_assessor.py",
       "tools/homelab/ha_tuya_mq_watchdog.py",
+      "tools/homelab/protonvpn_best_server.py",
       "tools/homelab/patch_homeassistant_tuya_online_flags.py",
       "tools/homelab/iot_presence_watchdog.py",
       "tools/homelab/tuya_token_selfheal.py",
@@ -28269,8 +27609,10 @@
       "scripts/testing/test_complete_interception.py",
       "scripts/system/__init__.py",
       "scripts/system/legacy_wifi_probe.py",
+      "scripts/misc/debug_delete_probe5.py",
       "scripts/misc/lote2_processor.py",
       "scripts/misc/dry_run_scan.py",
+      "scripts/misc/linkedin_content_purger.py",
       "scripts/misc/fix_ltfs_xml.py",
       "scripts/misc/index_documentation.py",
       "scripts/misc/export_openwebui_roster.py",
@@ -28281,6 +27623,7 @@
       "scripts/misc/index_new_knowledge.py",
       "scripts/misc/install_director.py",
       "scripts/misc/install_webui_function.py",
+      "scripts/misc/debug_delete_probe3.py",
       "scripts/misc/activate_function_correct.py",
       "scripts/misc/llm_compatibility.py",
       "scripts/misc/send_via_curl.py",
@@ -28327,6 +27670,7 @@
       "scripts/misc/find_webui_users.py",
       "scripts/misc/force_interactions.py",
       "scripts/misc/google_calendar_integration.py",
+      "scripts/misc/debug_delete_probe4.py",
       "scripts/misc/ipv6-proxy-multi.py",
       "scripts/misc/lotes3to10_robust.py",
       "scripts/misc/dashboard_validations.py",
@@ -28348,6 +27692,7 @@
       "scripts/misc/home_assistant_integration.py",
       "scripts/misc/restore_grafana_authentik_login.py",
       "scripts/misc/send_pending_report.py",
+      "scripts/misc/debug_delete_probe2.py",
       "scripts/misc/impl_metrics_helper.py",
       "scripts/misc/report_validation_summary.py",
       "scripts/misc/start_waha.py",
@@ -28363,7 +27708,9 @@
       "scripts/misc/validation_scheduler.py",
       "scripts/misc/install_function_webui.py",
       "scripts/misc/web_search.py",
+      "scripts/misc/debug_delete_probe6.py",
       "scripts/misc/list_webui.py",
+      "scripts/misc/linkedin_content_purger_pw.py",
       "scripts/misc/openwebui_tool_executor.py",
       "scripts/misc/try_login.py",
       "scripts/misc/compatibility_semantic.py",
@@ -28409,6 +27756,7 @@
       "scripts/misc/force_activate_persistent.py",
       "scripts/misc/volume_server.py",
       "scripts/misc/delivery_approval.py",
+      "scripts/misc/debug_delete_probe.py",
       "scripts/misc/phomemo_print.py",
       "scripts/misc/phomemo_ble_print.py",
       "scripts/misc/cdp_screenshot.py",
@@ -28516,65 +27864,6 @@
       "config/inventory_homelab.yml",
       "tools/alerting/alertmanager.production.yml",
       "tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/elegant-burnell-19147f/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/zen-bohr-5c1270/rpa4all-snapshot-alerts.yml",
-      ".claude/worktrees/zen-bohr-5c1270/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/alert_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/config/prometheus-config.yml",
-      ".claude/worktrees/zen-bohr-5c1270/config/inventory_homelab.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/alerting/alertmanager.production.yml",
-      ".claude/worktrees/zen-bohr-5c1270/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/ollama_coord_error_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/gpu_coord_failover_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/prometheus/pandaplus_bridge_rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/zen-bohr-5c1270/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/zen-bohr-5c1270/site/deploy/cloudflared-rpa4all-ide.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/alert_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/config/prometheus-config.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/config/inventory_homelab.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/alerting/alertmanager.production.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/ollama_coord_error_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/gpu_coord_failover_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/prometheus/pandaplus_bridge_rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/trusting-chatelet-ffb338/site/deploy/cloudflared-rpa4all-ide.yml",
-      ".claude/worktrees/elegant-burnell-19147f/docker/deploy_selfhealing.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana_gpu_alert_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/alert_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/config/prometheus-config.yml",
-      ".claude/worktrees/elegant-burnell-19147f/config/inventory_homelab.yml",
-      ".claude/worktrees/elegant-burnell-19147f/tools/alerting/alertmanager_telegram.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus/selfhealing_rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/prometheus/ltfs-selfheal-rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/datasources.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/policies.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/rules.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/alerting/contactpoints.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/dashboards/dashboards.yml",
-      ".claude/worktrees/elegant-burnell-19147f/monitoring/grafana/provisioning/datasources/datasources.yml",
-      ".claude/worktrees/elegant-burnell-19147f/site/deploy/cloudflared-rpa4all-ide.yml",
       "monitoring/prometheus/selfhealing_rules.yml",
       "monitoring/prometheus/ollama_coord_error_rules.yml",
       "monitoring/prometheus/gpu_coord_failover_rules.yml",
@@ -28586,45 +27875,17 @@
       "monitoring/grafana/provisioning/alerting/contactpoints.yml",
       "monitoring/grafana/provisioning/dashboards/dashboards.yml",
       "monitoring/grafana/provisioning/datasources/datasources.yml",
+      "monitoring/prometheus/rules/lto-staging-tape-alerts.yml",
       "site/deploy/cloudflared-rpa4all-ide.yml",
       "docs/openapi.yaml",
       "docs/openapi.generated.yaml",
       "content_automation/settings.yaml",
-      ".venv/lib/python3.13/site-packages/markdown_it/port.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/docs/openapi.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/docs/openapi.generated.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/settings.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/zen-bohr-5c1270/grafana/provisioning/datasources/authentik-http.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docs/openapi.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/docs/openapi.generated.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/settings.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/trusting-chatelet-ffb338/grafana/provisioning/datasources/authentik-http.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/docs/openapi.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/docs/openapi.generated.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/settings.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/curiosidades.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/cripto.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/content_automation/data/prompts/viral_trends.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/.continue/mcpServers/new-mcp-server.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/.continue/mcpServers/homelab.yaml",
-      ".claude/worktrees/elegant-burnell-19147f/grafana/provisioning/datasources/authentik-http.yaml",
       "content_automation/data/prompts/curiosidades.yaml",
       "content_automation/data/prompts/cripto.yaml",
       "content_automation/data/prompts/viral_trends.yaml",
       ".continue/mcpServers/new-mcp-server.yaml",
       ".continue/mcpServers/homelab.yaml",
-      "grafana/provisioning/datasources/authentik-http.yaml",
-      "philco10b_raspios/.venv/lib/python3.13/site-packages/markdown_it/port.yaml"
+      "grafana/provisioning/datasources/authentik-http.yaml"
     ],
     "serviceCount": 0
   }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,20 +1,20 @@
 {
-  "generated_at": "2026-08-02T15:46:23.454213+00:00",
-  "repo_root": "/tmp/opencode/tuya-fix-wt",
+  "generated_at": "2026-08-03T01:01:42.685033+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 201,
+    "repo_services": 211,
     "trading_instances": 12,
-    "critical_services": 77,
+    "critical_services": 85,
     "domains": {
       "identity": 4,
-      "monitoring": 18,
+      "monitoring": 19,
       "network": 23,
-      "operations": 113,
-      "storage": 32,
+      "operations": 115,
+      "storage": 39,
       "trading": 11
     }
   },
@@ -322,6 +322,14 @@
       "domain": "monitoring",
       "kind": "systemd",
       "source": "systemd/monitoring-containers-bootstrap.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nas-ram-exporter.service",
+      "domain": "monitoring",
+      "kind": "systemd",
+      "source": "systemd/nas-ram-exporter.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -966,10 +974,26 @@
       "candidate_system": "GLPI review"
     },
     {
+      "name": "faster-whisper-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/faster-whisper-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
       "name": "final-boot-status-agent.service",
       "domain": "operations",
       "kind": "systemd",
       "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "fix-staging-perms.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/fix-staging-perms.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -1574,10 +1598,50 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "ltfs-cache-flush.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-cache-flush.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "ltfs-deep-recovery.service",
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1690,6 +1754,22 @@
       "domain": "storage",
       "kind": "systemd",
       "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -2159,6 +2239,13 @@
         "critical": true
       },
       {
+        "name": "nas-ram-exporter.service",
+        "domain": "monitoring",
+        "source": "systemd/nas-ram-exporter.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "rss-sentiment-exporter.service",
         "domain": "monitoring",
         "source": "systemd/rss-sentiment-exporter.service",
@@ -2460,9 +2547,44 @@
         "critical": true
       },
       {
+        "name": "ltfs-cache-flush.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-cache-flush.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "ltfs-deep-recovery.service",
         "domain": "storage",
         "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2561,6 +2683,20 @@
         "name": "storj-macvlan-watchdog.timer",
         "domain": "storage",
         "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.service",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.timer",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
         "kind": "systemd",
         "critical": true
       },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,20 +1,20 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-02T15:46:23.454213+00:00`
+- Generated at: `2026-08-03T01:01:42.685033+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `201`
-- Critical services flagged for MVP: `77`
+- Repo services discovered: `211`
+- Critical services flagged for MVP: `85`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
 ## Domain counts
 
 - `identity`: 4
-- `monitoring`: 18
+- `monitoring`: 19
 - `network`: 23
-- `operations`: 113
-- `storage`: 32
+- `operations`: 115
+- `storage`: 39
 - `trading`: 11
 
 ## Trading profile instances (`12`)
@@ -54,6 +54,7 @@
 - `grafana-selfheal.service` (monitoring, systemd) from `systemd/grafana-selfheal.service`
 - `job-monitor.service` (monitoring, systemd) from `systemd/job-monitor.service`
 - `monitoring-containers-bootstrap.service` (monitoring, systemd) from `systemd/monitoring-containers-bootstrap.service`
+- `nas-ram-exporter.service` (monitoring, systemd) from `systemd/nas-ram-exporter.service`
 - `rss-sentiment-exporter.service` (monitoring, systemd) from `systemd/rss-sentiment-exporter.service`
 - `storj-exporter.service` (monitoring, systemd) from `deploy/storj-exporter.service`
 - `storj-payout-monitor.service` (monitoring, systemd) from `systemd/storj-payout-monitor.service`
@@ -77,7 +78,6 @@
 - `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
 - `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
 - `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
-- `protonvpn-unit-selfheal.service` (network, systemd) from `systemd/protonvpn-unit-selfheal.service`
 
 ## Serviços anotados manualmente
 

--- a/docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md
+++ b/docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md
@@ -1,0 +1,236 @@
+# Revisão do Fluxo Nextcloud → Staging → Fita LTO
+
+**Data:** 2026-08-02  
+**Baseado em:** Código em `specialized_agents/nextcloud_agent.py`, `tools/lto6-drain-backups`, `tools/ltfs_checkpoint_writer.py`, `tools/ltfs_recovery.py`, `systemd/*`, `tests/validate_nextcloud_flow.sh`, docs de arquitetura e incidentes.
+
+---
+
+## Resumo da Arquitetura Atual
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           FLUXO COMPLETO                                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────┐     ┌──────────────┐     ┌──────────────────┐                │
+│  │ Nextcloud│────▶│ Staging Disk │────▶│   LTFS Tape      │                │
+│  │  (LTO)   │     │ /mnt/raid1/  │     │   (NAS)          │                │
+│  │  Users   │     │ lto6-cache   │     │                  │                │
+│  └──────────┘     └──────┬───────┘     └────────┬─────────┘                │
+│                          │                      │                          │
+│                   bind mount                  LTFS                         │
+│                   /mnt/lto6-nc                mount                        │
+│                          │                      │                          │
+│                   ┌──────▼───────┐     ┌────────▼────────┐                 │
+│                   │ Container NC │     │  ltfs-lto6.svc  │                 │
+│                   │ /var/www/    │     │  /mnt/tape/lto6 │                 │
+│                   │ html/external│     │                 │                 │
+│                   │ /LTO         │     │  Cache Flush    │                 │
+│                   └──────────────┘     │  Worker         │                 │
+│                                        └────────┬────────┘                 │
+│                                                 │                          │
+│                                        ┌────────▼────────┐                 │
+│                                        │ CIFS / SMB      │                 │
+│                                        │ /mnt/lto6-smb-  │                 │
+│                                        │ proof           │                 │
+│                                        └────────┬────────┘                 │
+│                                                 │                          │
+│                    ┌────────────────────────────┼────────────────────┐    │
+│                    │                            │                    │    │
+│            ┌───────▼────────┐          ┌────────▼────────┐   ┌────────▼──┐ │
+│            │ lto6-drain-    │          │ ltfs_checkpoint_│   │tape-log-  │ │
+│            │ backups        │          │ writer          │   │spool-drain│ │
+│            │ (snapshots)    │          │ (checkpoint/    │   │(logs)     │ │
+│            └────────────────┘          │ recovery)       │   └───────────┘ │
+│                                        └─────────────────┘                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Invariantes Críticas (do `NEXTCLOUD_LTO_STAGING_ARCHITECTURE_2026-04-23.md`)
+
+1. **Nextcloud NUNCA grava direto na LTFS** — `/LTO` é staging em disco
+2. **Staging:** `/mnt/raid1/lto6-cache` → bind mount `/mnt/lto6-nc` → container `/var/www/html/external/LTO`
+3. **Único escritor de fita:** `ltfs-cache-flush.service` (serializado por lock `/run/ltfs-cache-flush.lock`)
+4. **Janelas controladas:** mount → copy → sync → verify → catalog → unmount limpo
+5. **Proibido:** bind-mount LTFS em `/srv/nextcloud/external/LTO`, `/home/homelab/nextcloud/external_local/LTO` ou home de usuários
+
+---
+
+## G19 — Boundary entre os dois pipelines de fita (documentado)
+
+Existem **dois** pipelines independentes escrevendo na fita LTO, com semânticas
+diferentes. **Não unificar** — manter separados, com boundary explícita:
+
+| | Pipeline A: `ltfs-cache-flush` | Pipeline B: `lto6-drain-backups` |
+|---|---|---|
+| **O quê** | Dados do staging Nextcloud (`/mnt/raid1/lto6-cache`) | Snapshots de backup (rotinas de backup do homelab) |
+| **Trigger** | Timer `ltfs-cache-flush.timer` (30min) | Service/agendamento de snapshot |
+| **Lock** | `/run/ltfs-cache-flush.lock` + lock global `tape-exclusive-wrap` | Lock global `tape-exclusive-wrap` |
+| **Destino** | `//192.168.15.4/LTO6_CACHE` (LTFS `lto6-cache`) | `//192.168.15.4/LTO6_SG1` (LTFS `sg1`) |
+| **Verificação** | SHA256 + catalog.jsonl | rsync + checkpoint writer |
+| **Consumidor** | Usuários Nextcloud via `/LTO` | Processos de backup (não-user-facing) |
+
+**Regras de boundary (não violar):**
+1. Pipeline A só lê staging Nextcloud; Pipeline B só lê snapshots — nunca um lê do outro.
+2. Ambos respeitam o **lock global de fita** (`/run/lock/tape-global.lock` via `tape-exclusive-wrap`); a fita é o recurso compartilhado serializado.
+3. Rotação de fita (G16) para **ambos** — um fluxo nunca rota a fita do outro sem o orchestrator `ltfs_recovery.py`.
+4. Cada pipeline tem métricas e journal próprios; `ltfs_catalog_verify` valida só o catálogo do Pipeline A.
+5. Se um dia for necessário unificar, primeiro documentar o ganho real — hoje a separação protege dados de usuário (Pipeline A) de rotinas internas (Pipeline B).
+
+---
+
+## Gaps Encontrados
+
+### 🔴 Críticos (Podem causar perda de dados ou falha silenciosa)
+
+| # | Gap | Impacto | Evidência |
+|---|-----|---------|-----------|
+| **G1** | **`ltfs-cache-flush` binary/script ausente no repo** | O worker principal de flush não está versionado; impossível auditar lógica de seleção de arquivos, retry, verificação SHA256 | Service aponta para `/usr/local/bin/ltfs-cache-flush` e `/usr/local/sbin/tape-exclusive-wrap` — não existem em `tools/`, `deploy/`, nem `scripts/` |
+| **G2** | **Conflito de writers na fita** | `ltfs-cache-flush`, `lto6-drain-backups`, `ltfs_checkpoint_writer` todos escrevem na mesma fita via CIFS/LTFS; sem coordenação explícita além de lock local | `ltfs-cache-flush` usa lock `/run/ltfs-cache-flush.lock`; `lto6-drain-backups` usa `ConditionPathIsMountPoint` + guard CIFS; `ltfs_checkpoint_writer` usa SSH para parar/iniciar LTFS na NAS — **não há lock global compartilhado** |
+| **G3** | **Sem monitoramento de espaço em staging** | Se `/mnt/raid1/lto6-cache` encher, uploads Nextcloud falham silenciosamente (HTTP 507) sem alerta | Validation script checa mount e write, mas **não checa `df /mnt/raid1/lto6-cache`** |
+| **G4** | **Sem validação de integridade do catálogo pós-flush** | `catalog.jsonl` e `placements.json` podem corromper sem detecção até recovery | Architecture doc menciona validar catálogo, mas **não há job automático de verificação** |
+| **G5** | **`tape-log-spool-drain` binary ausente** | Logs do pipeline Nextcloud→tape não são drenados; journal enche disco | Service referencia `/usr/local/sbin/tape-log-spool-drain` — não existe no repo |
+
+---
+
+### 🟡 Altos (Risco operacional, degradação silenciosa)
+
+| # | Gap | Impacto | Evidência |
+|---|-----|---------|-----------|
+| **G6** | **Timer `ltfs-cache-flush.timer` não versionado** | Architecture doc exige `OnCalendar=*:0/30` + `AccuracySec=1min`; sem o arquivo não dá para confirmar | Documentado em `NEXTCLOUD_LTO_STAGING_ARCHITECTURE_2026-04-23.md:72` mas arquivo não encontrado |
+| **G7** | **Cleanup de staging não definido** | Arquivos flushados ficam no staging indefinidamente → disco enche | Não há policy de retenção, `tmpwatch`, ou step no flush worker que remove arquivos confirmados |
+| **G8** | **Race: Nextcloud escreve enquanto flush lê** | Flush pode pegar arquivo "em escrita" (parcial) se não checar estabilidade (`MIN_STABLE_SECONDS`) | `ltfs-cache-flush` tem flags `--min-age-seconds` e `--min-stable-seconds` mas **valor real não versionado** (drop-in só passa vars) |
+| **G9** | **Self-heal CIFS pode matar flush ativo** | `lto6-smb-proof-selfheal.sh` faz `pkill -9 rsync` e `systemctl restart mnt-lto6-smb-proof.mount` durante drain | Script em `tools/selfheal/lto6-smb-proof-selfheal.sh:24-26` — **não checa se `lto6-drain-backups` ou `ltfs_checkpoint_writer` estão rodando** |
+| **G10** | **Sem teste end-to-end automatizado** | `validate_nextcloud_flow.sh` testa componentes isolados; não testa fluxo completo upload→staging→flush→tape→verify | Script testa mount, write, storage externo, serviço — **não faz upload real + flush + verify SHA256 na fita** |
+
+---
+
+### 🟢 Médios (Melhorias de robustez/observabilidade)
+
+| # | Gap | Impacto | Evidência |
+|---|-----|---------|-----------|
+| **G11** | **Brute-force allowlist manual** | Incidente 2026-04-23 exigiu adicionar IP do TANK manualmente; poderia ser automático via agent | `nextcloud_agent.py` tem `admin.brute_reset` mas **não tem auto-allowlist para IPs conhecidos** |
+| **G12** | **Métricas de capacidade de fita sem alerta** | `export-lto6-metrics.sh` exporta `nas_ltfs_avail_bytes` mas não há rule de alerta (ex: <10% livre) | Métricas existem, **alerting não documentado** |
+| **G13** | **`ltfs_checkpoint_writer` só roda no homelab** | Se homelab cai durante flush, recovery depende de SSH na NAS + journal local; single point of failure | Journal em `/var/lib/ltfs-journal` no homelab; se homelab perde disco, **journal some** |
+| **G14** | **Validação de `files_external:list` frágil** | Teste só grepa `/LTO`; não valida que está `enabled=true`, `applicable=All`, `mount_point` correto | `validate_nextcloud_flow.sh:99` — `grep -q /LTO` |
+| **G15** | **Permissões de staging não enforcadas em boot** | `fstab` faz bind mount mas se `/mnt/raid1/lto6-cache` tiver permissão errada, Nextcloud falha | Architecture doc exige `uid=33,gid=33,mode=770` — **não há systemd oneshot para corrigir no boot** |
+| **G16** | **Falta documentação de procedimento de troca de fita** | Quando fita enche (EOD), como swapar, catalogar, validar? | Incident doc menciona `catalog.jsonl`, `placements.json` mas **não há runbook de rotação** |
+
+---
+
+### 🔵 Baixos (Dívida técnica / Nice-to-have)
+
+| # | Gap | Impacto |
+|---|-----|---------|
+| **G17** | `nextcloud_agent.py` tem `admin.storage_diagnostics` mas não expõe "último flush bem-sucedido" | Observabilidade |
+| **G18** | `ltfs_recovery.py` tem `KNOWN_ISSUES` hardcoded; novos padrões de falha exigem deploy | Extensibilidade |
+| **G19** | Dois pipelines de backup para fita (`lto6-drain-backups` snapshots + `ltfs-cache-flush` staging Nextcloud) com semânticas diferentes; unificar ou documentar boundary | Complexidade |
+| **G20** | `validate_nextcloud_flow.sh` usa `tee -a` mas não rotaciona `RESULTS_FILE` | Logs acumulam |
+
+---
+
+## Matriz de Rastreabilidade: Invariante → Gap
+
+| Invariante | Gaps Relacionados |
+|------------|-------------------|
+| Nextcloud não grava direto na LTFS | G1, G2, G8 |
+| Staging em disco (`/mnt/raid1/lto6-cache`) | G3, G7, G15 |
+| Único escritor: `ltfs-cache-flush` | G1, G2, G6, G8 |
+| Serialização por lock | G2 (lock não global) |
+| Janelas controladas mount/copy/sync/verify | G4, G10 |
+| Proibido bind-mount LTFS em user dirs | — (validado no incidente) |
+| `ltfs-cache-flush.timer` em lote (30min) | G6 |
+| `MIN_AGE_SECONDS=900`, `MIN_STABLE_SECONDS=300` | G8 (valores não versionados) |
+
+---
+
+## Plano de Ação Sugerido (Prioridade)
+
+> **Status de implementação (2026-08-02):** itens 1–20 implementados.
+> 1–5 ✅ `tools/ltfs_cache_flush.py`, `tools/tape-exclusive-wrap`, check `df` 2b no
+> `tests/validate_nextcloud_flow.sh` + rules Prometheus, `tools/ltfs_catalog_verify.py`
+> (+service/timer), `tools/tape_log_spool_drain.py` (+service/timer).
+> 6–9 ✅ `systemd/ltfs-cache-flush.timer`, cleanup policy no flush worker (G7),
+> guard no `tools/selfheal/lto6-smb-proof-selfheal.sh` (G9), teste E2E no
+> `tests/validate_nextcloud_flow.sh` via `E2E_ENABLED=1` (G10).
+> 10–15 ✅ auto-allowlist brute-force no `nextcloud_agent.py` (G11), rules de
+> capacidade fita (G12), `tools/ltfs_journal_replicate.py` + service/timer (G13),
+> validação `files_external` estruturada (G14), `tools/fix_staging_perms.py` (G15),
+> runbook `docs/OPERATIONS/TAPE_ROTATION.md` (G16).
+> 16–20 ✅ `last_flush` no `admin.storage_diagnostics` (G17),
+> `LTFS_KNOWN_ISSUES_EXTRA_FILE` (G18), boundary dos dois pipelines documentada
+> (G19), rotação do `RESULTS_FILE` (G20).
+
+### Sprint 1 — Críticos (Bloqueiam produção segura)
+1. **Versionar `ltfs-cache-flush`** — mover binary/script para `tools/ltfs-cache-flush` com testes
+2. **Lock global de fita** — estender `ltfs_recovery.py` ou criar `/run/lock/tape-global.lock` compartilhado entre homelab e NAS (via NFS/SSH atomic)
+3. **Monitoring de staging** — adicionar check `df` no `validate_nextcloud_flow.sh` + alerta Prometheus
+4. **Validação de catálogo pós-flush** — job que lê `catalog.jsonl`, verifica SHA256 sample, alerta se mismatch
+5. **Criar `tape-log-spool-drain`** — script simples que rotaciona logs do pipeline
+
+### Sprint 2 — Altos (Eliminam degradação silenciosa)
+6. **Versionar `ltfs-cache-flush.timer`** com `OnCalendar=*:0/30` + `AccuracySec=1min`
+7. **Policy de cleanup de staging** — adicionar step no flush worker: após verify OK, `rm` arquivo do staging (ou mover para `.flushed/` com TTL)
+8. **Guard no self-heal CIFS** — checar `systemctl is-active lto6-drain-backups ltfs_checkpoint_writer` antes de `pkill`
+9. **Teste E2E** — estender `validate_nextcloud_flow.sh` com `make test-e2e` que faz upload→wait flush→verify tape
+
+### Sprint 3 — Médios (Robustez operacional)
+10. **Auto-allowlist brute-force** — no `nextcloud_agent`, detectar IPs de dispositivos conhecidos (TANK, etc.) e auto-whitelist
+11. **Alerting de capacidade fita** — rule Prometheus `nas_ltfs_avail_bytes / nas_ltfs_size_bytes < 0.1`
+12. **Journal replication** — replicar `/var/lib/ltfs-journal` para NAS (ou S3) via `rsync` no final de cada sessão
+13. **Validação completa `files_external`** — checar `enabled`, `applicable`, `mount_point`, `options`
+14. **Systemd oneshot `fix-staging-perms`** — roda no boot, garante `uid=33,gid=33,mode=770` em `/mnt/raid1/lto6-cache`
+15. **Runbook de rotação de fita** — documento em `docs/OPERATIONS/TAPE_ROTATION.md`
+
+---
+
+## Comandos de Verificação Rápida (Para Homelab Atual)
+
+```bash
+# 1. Staging mount aponta para cache (não LTFS direto)
+findmnt /mnt/lto6-nc -o SOURCE -n
+# esperado: /mnt/raid1/lto6-cache
+
+# 2. Permissões staging
+stat -c "%a %U:%G" /mnt/raid1/lto6-cache
+# esperado: 770 www-data:www-data (ou root:root com gid 33)
+
+# 3. Nextcloud escreve no staging
+docker exec -u www-data nextcloud-app sh -lc 'p=/var/www/html/external/LTO/.probe; date > "$p"; stat "$p"; rm -f "$p"'
+
+# 4. Storage externo ativo
+docker exec nextcloud-app php occ files_external:list | grep -A5 /LTO
+
+# 5. Flush worker existe e timer configurado
+systemctl cat ltfs-cache-flush.timer
+# verificar OnCalendar=*:0/30
+
+# 6. Lock de flush não órfão
+ls -la /run/ltfs-cache-flush.lock 2>/dev/null || echo "lock não existe (ok se worker não rodando)"
+
+# 7. Espaço em staging
+df -h /mnt/raid1/lto6-cache
+
+# 8. Último flush bem-sucedido (journal)
+tail -5 /var/lib/ltfs-cache-flush/catalog.jsonl 2>/dev/null || echo "catalog não encontrado"
+
+# 9. Fita montada na NAS (via SSH)
+ssh root@192.168.15.4 "findmnt /mnt/tape/lto6 && df -h /mnt/tape/lto6"
+
+# 10. Self-heal CIFS não conflitou recentemente
+journalctl -u lto6-smb-proof-selfheal.service -n 20 --no-pager
+```
+
+---
+
+## Referências
+
+- `docs/INCIDENTS/NEXTCLOUD_TANK_LTO_UPLOAD_2026-04-23.md` — incidente que definiu a arquitetura
+- `docs/NEXTCLOUD_LTO_STAGING_ARCHITECTURE_2026-04-23.md` — contrato operacional
+- `specialized_agents/nextcloud_agent.py:766-867` — `_classify_lto_mount`, `_nextcloud_storage_diagnostics`
+- `tools/lto6-drain-backups` — drain de snapshots via rsync/CIFS
+- `tools/ltfs_checkpoint_writer.py` — drain com journal por arquivo + recovery
+- `tools/ltfs_recovery.py` — orchestrator LTFS (mount, self-heal, ltfsck, deep-recovery)
+- `systemd/ltfs-cache-flush.service.d/60-tape-gate.conf` — drop-in com lock exclusivo
+- `tests/validate_nextcloud_flow.sh` — validação componentizada
+- `deploy/nas/sbin/export-lto6-metrics.sh` — métricas Prometheus LTFS

--- a/docs/OPERATIONS/TAPE_ROTATION.md
+++ b/docs/OPERATIONS/TAPE_ROTATION.md
@@ -1,0 +1,155 @@
+# Runbook — Rotação de Fita LTO (G16)
+
+Gap G16 do review `docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md`: faltava
+procedimento operacional documentado para trocar a fita LTFS quando está cheia
+ou degradada. Este runbook cobre a rotação completa: parada controlada,
+ejeção, inserção de fita nova e revalidação.
+
+## Terminologia (não confundir — lição L8 do 2026-05-19)
+
+| Nível | Exemplo |
+|---|---|
+| Nome lógico do fluxo | `lto6-sg1` / `lto6-cache` |
+| Export CIFS consumida pelo homelab | `//192.168.15.4/LTO6_SG1`, `//192.168.15.4/LTO6_CACHE` |
+| Device LTFS real na NAS | `/dev/sg2`, `/dev/nst2`, mount `/mnt/tape/lto6-sg1` |
+
+Sempre confirmar com `mt-st`/`ltfs` na NAS qual device físico corresponde à
+fita lógica antes de qualquer ação.
+
+## Pré-condições
+
+- Fita com menos de 80% de capacidade (alerta `LTFSCapacityHigh`) **ou** EOD
+  próximo do fim físico.
+- Nenhum incidente em andamento no fluxo de backup Nextcloud → fita
+  (sem `ltfs-cache-flush.service` em `activating/failed`).
+
+## Procedimento
+
+### 1. Parar escritores de fita (ordem)
+
+```bash
+# No homelab (192.168.15.2):
+sudo systemctl stop ltfs-cache-flush.service ltfs-cache-flush.timer
+sudo systemctl stop ltfs-journal-replicate.timer
+sudo systemctl stop lto6-drain-backups.service
+sudo systemctl stop ltfs-checkpoint-drain.service 2>/dev/null || true
+sudo systemctl stop tape-log-spool-drain-nextcloud.timer
+```
+
+Verificar que não há processos escrevendo na fita:
+
+```bash
+pgrep -af "rsync.*lto6-smb-proof|ltfs-cache-flush|ltfs_checkpoint_writer"
+# Saída esperada: vazia
+```
+
+### 2. Forçar flush pendente (opcional, recomendado)
+
+```bash
+ltfs-cache-flush --buffer-root /mnt/raid1/lto6-cache \
+  --primary-buffer-root /mnt/raid1/lto6-cache \
+  --target-root /mnt/lto6-smb-proof \
+  --state-file /var/lib/ltfs-cache-flush/state.json \
+  --placement-file /var/lib/ltfs-cache-flush/placements.json \
+  --catalog-file /var/lib/ltfs-cache-flush/catalog.jsonl \
+  --metrics-file /var/lib/ltfs-cache-flush/metrics.json \
+  --metrics-state-file /var/lib/ltfs-cache-flush/metrics_state.json \
+  --lock-file /run/ltfs-cache-flush.lock \
+  --min-age-seconds 0 --min-stable-seconds 0 \
+  --min-target-total-bytes 0 --min-target-free-bytes 0
+```
+
+Confirmar que `status: success` e que o catalog.jsonl foi atualizado.
+
+### 3. Replicar journal e estado para a NAS
+
+```bash
+sudo systemctl start ltfs-journal-replicate.service
+journalctl -u ltfs-journal-replicate.service -n 5 --no-pager
+```
+
+### 4. Desmontar o export CIFS (homelab)
+
+```bash
+sudo systemctl stop mnt-lto6\\x2dsmb\\x2dproof.mount
+sudo mountpoint -q /mnt/lto6-smb-proof && echo "AINDA MONTADO" || echo "desmontado"
+```
+
+> Se ainda montado, não forçar `umount -l` antes de confirmar que a NAS
+> liberou a sessão (ver passo 5). Mount "stale" derruba o self-heal.
+
+### 5. Ejetar fita na NAS (via SSH)
+
+```bash
+ssh root@192.168.15.4 'ltfs -o eject /mnt/tape/lto6-cache'
+```
+
+> NUNCA usar `sg_raw`/`mt-st eject` direto sem o orchestrator
+> (`ltfs_recovery.py`) — política 3 do AGENTS.md. A ejeção de rotina acima é
+> feita pelo `ltfs` da NAS, que é o caminho suportado pelo orchestrator.
+
+Se o eject falhar por fita cheia (requer força), usar o orchestrator:
+
+```bash
+ssh root@192.168.15.4 '/var/db/ltfs-tools/ltfs_recovery.py --mode eject --force'
+```
+
+### 6. Trocar fita fisicamente
+
+- Retirar a fita ejetada; registrar no inventário (número de série, data, uso).
+- Inserir a fita nova/reciclada (ver política de retenção no Anexo A).
+- Confirmar que o drive travou a fita (sem erro no painel do drive/NAS).
+
+### 7. Montar e validar a fita nova
+
+```bash
+# Homelab:
+sudo systemctl start mnt-lto6\\x2dsmb\\x2dproof.mount
+sleep 5
+mountpoint -q /mnt/lto6-smb-proof && echo "OK" || echo "FALHOU"
+```
+
+```bash
+# NAS: verificar que a LTFS montou RW e gravável
+ssh root@192.168.15.4 'df -h /mnt/tape/lto6-cache; ls /mnt/tape/lto6-cache | head'
+```
+
+### 8. Reiniciar o pipeline
+
+```bash
+sudo systemctl start ltfs-cache-flush.timer
+sudo systemctl start lto6-drain-backups.service
+sudo systemctl start ltfs-journal-replicate.timer
+sudo systemctl start tape-log-spool-drain-nextcloud.timer
+sudo systemctl start fix-staging-perms.service
+```
+
+### 9. Revalidar fluxo completo
+
+```bash
+tests/validate_nextcloud_flow.sh | tee /tmp/validation_$(date +%F).log
+```
+
+- Confirmar `Fluxo Nextcloud → Staging → Fita pronto para produção`.
+- Opcionalmente rodar E2E: `E2E_ENABLED=1 tests/validate_nextcloud_flow.sh`
+  (faz upload → flush → verificação SHA256 na fita).
+
+### 10. Registrar rotação
+
+- Data, fita anterior → nova, espaço liberado.
+- Atualizar inventário de fitas (Anexo A) e o painel
+  `http://192.168.15.2:8093/`.
+- Se houve falha no meio do caminho: seguir `docs/ltfs-emergency-runbook.md`.
+
+## Anexo A — Política de retenção sugerida
+
+| Fita | Uso | Rotação |
+|---|---|---|
+| `LTO6-CACHE` | Staging Nextcloud → LTO | Quando ≥80% (alert) / EOD próximo |
+| `LTO6-SG1` | Logs / snapshots | Conforme size; guarda de mount via automount (lição L3) |
+
+## Anexo B — Sinais de que a fita precisa de rotação
+
+- Prometheus `lto_tape_capacity_percent >= 80` (warn) / `>= 90` (critical)
+- `ltfs-cache-flush` falhando com `No space left` ou EOD em `check_target_capacity`
+- `ltfs_catalog_verify` reportando falhas de verificação persistentes

--- a/docs/taxonomy/DOMAIN_MAP.md
+++ b/docs/taxonomy/DOMAIN_MAP.md
@@ -1,6 +1,6 @@
 # Taxonomy Domain Map
 
-**Generated:** 2026-07-28T10:21:15.171832
+**Generated:** 2026-08-02T18:45:08.843652
 
 Diagrama Mermaid dos hubs de domínio (contagens do grafo).
 

--- a/docs/variables-taxonomy/LTFS_JOURNAL_REPLICATE.md
+++ b/docs/variables-taxonomy/LTFS_JOURNAL_REPLICATE.md
@@ -1,0 +1,21 @@
+# LTFS Journal Replication — Variáveis
+
+Serviço: `ltfs-journal-replicate.service` + `.timer` (systemd), script
+`tools/ltfs_journal_replicate.py`. Replica o journal LTFS
+(`/var/lib/ltfs-journal`) para a NAS após cada sessão de flush/drain/checkpoint
+(gap G13 do review `docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md`), evitando
+perda do journal se o homelab perder o disco local.
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `LTFS_JOURNAL_DIR` | `/var/lib/ltfs-journal` | Diretório do journal LTFS no disco local (também usado por `ltfs_checkpoint_writer.py`). |
+| `JRNL_REPLICA_NAS` | *(obrigatório)* | Destino rsync na NAS, ex.: `rsync://root@192.168.15.4/volume1/ltfs/journal`. Configurado no `Environment=` do serviço. |
+| `JRNL_REPLICA_EXTRA` | *(vazio)* | Destino rsync opcional adicional (ex.: mount S3) para segunda cópia. |
+| `JRNL_RSYNC_OPTS` | `-a --delete` | Opções do rsync (agregadas com `--timeout=60` sempre). |
+| `JRNL_DRY_RUN` | `0` | `1` = só mostra o que seria replicado (rsync `--dry-run`). |
+
+## Consumidor: `ltfs_journal_replicate.py`
+
+O script roda como oneshot `After=ltfs-cache-flush.service` (e drain/checkpoint)
+com retry `Restart=on-failure`; o timer (`OnBootSec=5min`, `OnUnitActiveSec=6h`)
+cobre sessões que não disparam o oneshot. Exige `rsync` instalado.

--- a/docs/variables-taxonomy/LTFS_RECOVERY_EXTRA_ISSUES.md
+++ b/docs/variables-taxonomy/LTFS_RECOVERY_EXTRA_ISSUES.md
@@ -1,0 +1,13 @@
+# LTFS Recovery / Validação — Variáveis
+
+Serviço: `ltfs_recovery.py` (orchestrator, NAS), `validate_nextcloud_flow.sh`.
+
+| Variável | Default | Propósito |
+|---|---|---|
+| `LTFS_KNOWN_ISSUES_EXTRA_FILE` | `/etc/ltfs-recovery/known_issues.extra.json` | Arquivo JSON (lista) com padrões de falha LTFS extras, versionado fora do código (G18). Adiciona issues ou substitui uma embutida (mesmo `id` vence a embutida). Re-lido a cada detecção — novo padrão de incidente não exige deploy. |
+| `VALIDATION_MAX_RESULTS` | `10` | Número máximo de `nextcloud_flow_validation_results.txt*` retidos pela rotação no `tests/validate_nextcloud_flow.sh` (G20). |
+
+## Consumidor: `ltfs_recovery.py`
+
+O orchestrator lê o arquivo de issues extras apenas se existir; falha de leitura
+não derruba a detecção base (log WARN e segue com `KNOWN_ISSUES` embutido).

--- a/monitoring/prometheus/rules/lto-staging-tape-alerts.yml
+++ b/monitoring/prometheus/rules/lto-staging-tape-alerts.yml
@@ -1,0 +1,152 @@
+groups:
+  - name: rpa4all-lto-staging-alerts
+    interval: 60s
+    rules:
+      # Staging disk space alerts
+      - alert: NextcloudLTOStagingDiskSpaceCritical
+        expr: |
+          (node_filesystem_size_bytes{mountpoint="/mnt/raid1/lto6-cache"} - node_filesystem_free_bytes{mountpoint="/mnt/raid1/lto6-cache"})
+          / node_filesystem_size_bytes{mountpoint="/mnt/raid1/lto6-cache"} * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+          component: nextcloud-lto-staging
+        annotations:
+          summary: "Nextcloud LTO staging disk space critical (>90%)"
+          description: |
+            Staging disk at {{ $labels.instance }} /mnt/raid1/lto6-cache is at {{ $value | printf "%.1f" }}% capacity.
+            Nextcloud uploads will fail with HTTP 507 Insufficient Storage.
+            Run cleanup or expand disk immediately.
+
+      - alert: NextcloudLTOStagingDiskSpaceWarning
+        expr: |
+          (node_filesystem_size_bytes{mountpoint="/mnt/raid1/lto6-cache"} - node_filesystem_free_bytes{mountpoint="/mnt/raid1/lto6-cache"})
+          / node_filesystem_size_bytes{mountpoint="/mnt/raid1/lto6-cache"} * 100 > 80
+        for: 15m
+        labels:
+          severity: warning
+          component: nextcloud-lto-staging
+        annotations:
+          summary: "Nextcloud LTO staging disk space warning (>80%)"
+          description: |
+            Staging disk at {{ $labels.instance }} /mnt/raid1/lto6-cache is at {{ $value | printf "%.1f" }}% capacity.
+            Plan cleanup or disk expansion soon.
+
+      # LTFS tape capacity alerts (from nas_ltfs_* metrics)
+      - alert: LTFS_TapeCapacityCritical
+        expr: |
+          (nas_ltfs_used_bytes / nas_ltfs_size_bytes) * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+          component: lto-tape
+        annotations:
+          summary: "LTFS tape capacity critical (>90%)"
+          description: |
+            Tape {{ $labels.mountpoint }} on {{ $labels.instance }} is at {{ $value | printf "%.1f" }}% capacity.
+            Flush jobs will fail. Rotate tape immediately.
+
+      - alert: LTFS_TapeCapacityWarning
+        expr: |
+          (nas_ltfs_used_bytes / nas_ltfs_size_bytes) * 100 > 80
+        for: 15m
+        labels:
+          severity: warning
+          component: lto-tape
+        annotations:
+          summary: "LTFS tape capacity warning (>80%)"
+          description: |
+            Tape {{ $labels.mountpoint }} on {{ $labels.instance }} is at {{ $value | printf "%.1f" }}% capacity.
+            Plan tape rotation soon.
+
+      # LTFS service health
+      - alert: LTFS_ServiceDown
+        expr: nas_ltfs_service_up == 0
+        for: 2m
+        labels:
+          severity: critical
+          component: lto-tape
+        annotations:
+          summary: "LTFS service down"
+          description: |
+            LTFS service {{ $labels.service }} on {{ $labels.instance }} is down.
+            No flush operations possible. Check NAS and drive.
+
+      - alert: LTFS_MountDown
+        expr: nas_ltfs_mount_up == 0
+        for: 2m
+        labels:
+          severity: critical
+          component: lto-tape
+        annotations:
+          summary: "LTFS mount down"
+          description: |
+            LTFS mount {{ $labels.mountpoint }} on {{ $labels.instance }} is not mounted.
+            Flush jobs will fail. Check LTFS service and CIFS mount.
+
+      - alert: LTFS_ReadOnlyMode
+        expr: nas_ltfs_read_only == 1
+        for: 1m
+        labels:
+          severity: critical
+          component: lto-tape
+        annotations:
+          summary: "LTFS mount in read-only mode"
+          description: |
+            LTFS mount {{ $labels.mountpoint }} on {{ $labels.instance }} dropped to read-only.
+            Data may be at risk. Investigate immediately (check journal for 'Dropping to read-only mode').
+
+      # Flush job monitoring
+      - alert: LTFS_CacheFlushJobFailed
+        expr: |
+          increase(ltfs_cache_flush_runs_total{status="error"}[1h]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: lto-flush
+        annotations:
+          summary: "LTFS cache flush job failed"
+          description: |
+            Cache flush job failed on {{ $labels.instance }} in the last hour.
+            Check journal for ltfs-cache-flush.service.
+
+      - alert: LTFS_CacheFlushJobStale
+        expr: |
+          time() - ltfs_cache_flush_last_run_timestamp > 7200
+        for: 5m
+        labels:
+          severity: warning
+          component: lto-flush
+        annotations:
+          summary: "LTFS cache flush job stale (>2h)"
+          description: |
+            No successful cache flush run in the last 2 hours on {{ $labels.instance }}.
+            Timer may be stuck or jobs failing silently.
+
+      # Catalog verification
+      - alert: LTFS_CatalogVerificationFailed
+        expr: |
+          increase(ltfs_catalog_verify_total{status="failed"}[24h]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: lto-catalog
+        annotations:
+          summary: "LTFS catalog verification failed"
+          description: |
+            Catalog verification found inconsistencies on {{ $labels.instance }}.
+            Check ltfs-catalog-verify.service journal.
+
+      # Log drain
+      - alert: TapeLogSpoolDrainFailed
+        expr: |
+          increase(tape_log_spool_drain_runs_total{status="error"}[1h]) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: tape-logs
+        annotations:
+          summary: "Tape log spool drain failed"
+          description: |
+            Log drain for route {{ $labels.route }} failed on {{ $labels.instance }}.
+            Logs may accumulate in staging.

--- a/specialized_agents/nextcloud_agent.py
+++ b/specialized_agents/nextcloud_agent.py
@@ -35,6 +35,7 @@ import logging
 import os
 import re
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
@@ -852,11 +853,21 @@ async def _nextcloud_storage_diagnostics() -> dict[str, Any]:
         diagnostics["write_probe"] = {"ok": False, "error": str(exc)}
 
     try:
-        rc, out, err = await _run_occ("files_external:list")
-        diagnostics["files_external"] = {
+        rc, out, err = await _run_occ("files_external:list", "--output=json")
+        fe = {
             "ok": rc == 0,
             "output": (out or err)[:2000],
         }
+        if rc == 0:
+            try:
+                mounts = json.loads(out or "[]")
+                fe["details"] = _validate_files_external(mounts)
+                fe["ok"] = fe["details"]["ok"]
+            except json.JSONDecodeError:
+                # Occ antigo não suporta --output=json; fallback para parsing simples
+                fe["ok"] = rc == 0
+                fe["fallback"] = "occ sem --output=json — validação estruturada pulada"
+        diagnostics["files_external"] = fe
     except Exception as exc:
         diagnostics["files_external"] = {"ok": False, "error": str(exc)}
 
@@ -865,6 +876,141 @@ async def _nextcloud_storage_diagnostics() -> dict[str, Any]:
         for section in ("lto_mount", "write_probe", "files_external")
     )
     return diagnostics
+
+
+# ─── Validação files_external (G14) ───────────────────────────────────────────
+
+def _validate_files_external(mounts: list[dict]) -> dict:
+    """Valida mounts externos do Nextcloud.
+
+    Regras (gap G14):
+      - mount_point deve existir (não vazio)
+      - enabled deve ser True
+      - applicable deve conter "All" (senão o mount não vale para todos)
+      - backend deve ser resolvido (ex.: Local/LTFS ou SMB)
+    """
+    issues: list[str] = []
+    mounts_ok = 0
+    for m in mounts:
+        mp = m.get("mount_point") or m.get("mountPoint") or ""
+        enabled = m.get("enabled", True)
+        applicable = m.get("applicable") or []
+        backend = m.get("backend") or m.get("storage_backend") or "?"
+        if not mp:
+            issues.append("mount sem mount_point")
+            continue
+        if enabled is False:
+            issues.append(f"{mp}: desabilitado")
+            continue
+        if applicable and "All" not in applicable:
+            issues.append(f"{mp}: applicable={applicable} (sem All)")
+            continue
+        mounts_ok += 1
+
+    return {
+        "ok": not issues and mounts_ok > 0,
+        "total": len(mounts),
+        "mounts_ok": mounts_ok,
+        "issues": issues,
+    }
+
+
+# ─── Último flush bem-sucedido (G17) ──────────────────────────────────────────
+
+_FLUSH_METRICS_STATE = Path("/var/lib/ltfs-cache-flush/metrics_state.json")
+
+
+def _last_flush_info() -> dict:
+    """Retorna info do último flush do worker (metrics_state.json, G17)."""
+    try:
+        if not _FLUSH_METRICS_STATE.exists():
+            return {"ok": False, "error": "metrics_state.json não existe (flush nunca rodou?)"}
+        data = json.loads(_FLUSH_METRICS_STATE.read_text())
+        return {
+            "ok": True,
+            "last_run": data.get("last_run"),
+            "last_status": data.get("last_status"),
+            "files_flushed": data.get("files_flushed", 0),
+            "files_failed": data.get("files_failed", 0),
+            "bytes_flushed": data.get("bytes_flushed", 0),
+            "duration_seconds": data.get("duration_seconds", 0),
+            "fresh": _is_flush_fresh(data.get("last_run")),
+        }
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+def _is_flush_fresh(last_run: str | None, max_age_min: int = 60) -> bool:
+    """Flush recente = last_run dentro de max_age_min."""
+    if not last_run:
+        return False
+    try:
+        from datetime import datetime, timezone
+
+        dt = datetime.fromisoformat(last_run.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        age_min = (datetime.now(timezone.utc) - dt).total_seconds() / 60
+        return 0 <= age_min <= max_age_min
+    except (ValueError, TypeError):
+        return False
+
+
+# ─── Auto-allowlist brute-force (G11) ─────────────────────────────────────────
+
+_NC_BRUTE_FORCE_ALLOWLIST = tuple(
+    dict.fromkeys(
+        filter(
+            None,
+            (
+                item.strip()
+                for item in os.getenv(
+                    "NEXTCLOUD_BRUTE_FORCE_ALLOWLIST",
+                    "192.168.15.150/32",  # TANK Android
+                ).split(",")
+            ),
+        )
+    )
+)
+
+async def _brute_force_ensure_allowlist(dry_run: bool = False) -> dict[str, Any]:
+    """Garante que IPs/CIDRs conhecidos (TANK etc.) estão na allowlist do brute-force.
+
+    Previne o incidente de 2026-04-23 (TANK bloqueado por TooManyRequests),
+    sincronizando a allowlist em cada execução de diagnóstico.
+    """
+    results: dict[str, Any] = {
+        "allowlist": list(_NC_BRUTE_FORCE_ALLOWLIST),
+        "actions": [],
+        "ok": True,
+    }
+    if not _NC_BRUTE_FORCE_ALLOWLIST:
+        results["ok"] = True
+        results["note"] = "Nenhum CIDR configurado (NEXTCLOUD_BRUTE_FORCE_ALLOWLIST)"
+        return results
+
+    # Lê allowlist atual
+    rc, out, err = await _run_occ("security:bruteforce:whitelist")
+    if rc != 0:
+        results["ok"] = False
+        results["error"] = out or err
+        return results
+    current = out or err
+
+    for cidr in _NC_BRUTE_FORCE_ALLOWLIST:
+        if cidr in current:
+            results["actions"].append({"cidr": cidr, "status": "already_present"})
+            continue
+        if dry_run:
+            results["actions"].append({"cidr": cidr, "status": "would_add"})
+            continue
+        add_rc, add_out, add_err = await _run_occ("security:bruteforce:whitelist", cidr)
+        if add_rc == 0:
+            results["actions"].append({"cidr": cidr, "status": "added"})
+        else:
+            results["ok"] = False
+            results["actions"].append({"cidr": cidr, "status": "failed", "error": add_out or add_err})
+    return results
 
 
 # ─── Dispatcher de ações ──────────────────────────────────────────────────────
@@ -966,7 +1112,18 @@ async def _dispatch(action: str, params: dict[str, Any], dry_run: bool) -> Any:
             return {"rc": rc, "raw": out or err}
 
     if action == "admin.storage_diagnostics":
-        return await _nextcloud_storage_diagnostics()
+        diagnostics = await _nextcloud_storage_diagnostics()
+        # G11: mantém allowlist brute-force sincronizada (TANK etc.)
+        try:
+            diagnostics["brute_force_allowlist"] = await _brute_force_ensure_allowlist(dry_run=dry_run)
+        except Exception as exc:  # nunca quebrar o diagnóstico por causa da allowlist
+            diagnostics["brute_force_allowlist"] = {"ok": False, "error": str(exc)}
+        # G17: observabilidade do último flush
+        try:
+            diagnostics["last_flush"] = _last_flush_info()
+        except Exception as exc:
+            diagnostics["last_flush"] = {"ok": False, "error": str(exc)}
+        return diagnostics
 
     if action == "admin.logs":
         lines = int(params.get("lines", 50))

--- a/systemd/fix-staging-perms.service
+++ b/systemd/fix-staging-perms.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Fix Nextcloud LTO staging permissions and bind mount
+Documentation=https://github.com/rpa4all/eddie-auto-dev
+DefaultDependencies=no
+After=local-fs.target
+Before=nextcloud-app.service ltfs-cache-flush.service
+Requires=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/local/bin/fix-staging-perms
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ltfs-cache-flush.timer
+++ b/systemd/ltfs-cache-flush.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Timer for LTFS cache flush (every 30 minutes)
+After=network-online.target
+Wants=network-online.target
+
+[Timer]
+OnCalendar=*:0/30
+AccuracySec=1min
+Persistent=true
+Unit=ltfs-cache-flush.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ltfs-catalog-verify.service
+++ b/systemd/ltfs-catalog-verify.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=LTFS Catalog Verification — validates catalog.jsonl and samples tape SHA256
+After=ltfs-cache-flush.service
+Wants=ltfs-cache-flush.service
+ConditionPathExists=/var/lib/ltfs-cache-flush/catalog.jsonl
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/local/bin/ltfs-catalog-verify \
+  --catalog /var/lib/ltfs-cache-flush/catalog.jsonl \
+  --placements /var/lib/ltfs-cache-flush/placements.json \
+  --tape-root /mnt/lto6-smb-proof/backups \
+  --sample-percent 10 --sample-max 100 \
+  --metrics-file /var/lib/ltfs-cache-flush/catalog_verify_metrics.prom
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=3600
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ltfs-catalog-verify.timer
+++ b/systemd/ltfs-catalog-verify.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily LTFS catalog verification
+After=network-online.target
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=1h
+Unit=ltfs-catalog-verify.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/ltfs-journal-replicate.service
+++ b/systemd/ltfs-journal-replicate.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Replica o journal LTFS para a NAS após cada sessão de flush
+Documentation=docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md
+After=ltfs-cache-flush.service lto6-drain-backups.service ltfs-checkpoint-drain.service
+RequiresMountsFor=/mnt/lto6-smb-proof
+ConditionPathIsDirectory=/var/lib/ltfs-journal
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ltfs_journal_replicate.py
+Environment=JRNL_REPLICA_NAS=rsync://root@192.168.15.4/volume1/ltfs/journal
+# JRNL_REPLICA_EXTRA=rsync://user@host/path
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/ltfs-journal-replicate.timer
+++ b/systemd/ltfs-journal-replicate.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Agenda replicação do journal LTFS para NAS (retry caso oneshot não dispare)
+Documentation=docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target

--- a/systemd/lto6-drain-backups.service
+++ b/systemd/lto6-drain-backups.service
@@ -8,9 +8,9 @@ ConditionPathIsMountPoint=/mnt/lto6-smb-proof
 [Service]
 Type=oneshot
 User=root
-ExecStart=/usr/local/sbin/lto6-drain-backups
+ExecStart=/usr/local/bin/tape-exclusive-wrap -- /usr/local/sbin/lto6-drain-backups
 StandardOutput=journal
 StandardError=journal
 TimeoutStartSec=7200
-# Prevent competing with LTFS cache flush
+# Prevent competing with LTFS cache flush (also uses global lock, but keep as safety)
 ExecStartPre=/bin/bash -c "systemctl is-active ltfs-cache-flush.service && { echo 'ltfs-cache-flush running, waiting'; exit 1; } || true"

--- a/systemd/tape-log-spool-drain-nextcloud.service
+++ b/systemd/tape-log-spool-drain-nextcloud.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Drain buffered logs for Nextcloud tape pipeline
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Environment=ROUTE_NAME=nextcloud
+Environment=ROUTE_TARGET_ROOT=/mnt/pretape/lto6-cache/logs
+Environment=DESTINATION=journald
+Environment=RETENTION_DAYS=7
+Environment=MAX_FILE_SIZE_MB=100
+ExecStart=/usr/local/bin/tape-log-spool-drain \
+  --route nextcloud \
+  --target-root /mnt/pretape/lto6-cache/logs \
+  --destination journald \
+  --retention-days 7 \
+  --max-file-size-mb 100 \
+  --rotate
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/tape-log-spool-drain-nextcloud.timer
+++ b/systemd/tape-log-spool-drain-nextcloud.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hourly drain of Nextcloud buffered logs to tape pipeline
+After=network-online.target
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+RandomizedDelaySec=10m
+Unit=tape-log-spool-drain-nextcloud.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/validate_nextcloud_flow.sh
+++ b/tests/validate_nextcloud_flow.sh
@@ -8,6 +8,19 @@ readonly SCRIPT_NAME=$(basename "$0")
 readonly WORKDIR=${WORKDIR:-.}
 readonly RESULTS_FILE="${WORKDIR}/nextcloud_flow_validation_results.txt"
 
+# G20: rotação do RESULTS_FILE (mantém no máximo VALIDATION_MAX_RESULTS arquivos)
+VALIDATION_MAX_RESULTS=${VALIDATION_MAX_RESULTS:-10}
+rotate_results_file() {
+    local base="${RESULTS_FILE}"
+    # Roda do mais antigo para o mais novo: .N+1 recebe .N (mantém .1 = mais recente)
+    local i
+    for ((i = VALIDATION_MAX_RESULTS - 1; i >= 1; i--)); do
+        [[ -f "${base}.${i}" ]] && mv "${base}.${i}" "${base}.$((i + 1))" 2>/dev/null || true
+    done
+    [[ -f "${base}" ]] && mv "${base}" "${base}.1" 2>/dev/null || true
+}
+rotate_results_file
+
 # Cores para output
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
@@ -77,6 +90,28 @@ if [[ -d /mnt/raid1/lto6-cache ]]; then
         log_pass "Dono correto: $owner"
     else
         log_warn "Dono: $owner"
+    fi
+
+    # Verificar espaço em disco (G3 - crítico)
+    log_section "2b. Espaço em Staging"
+    df_out=$(df -B1 /mnt/raid1/lto6-cache 2>/dev/null | tail -1) || df_out=""
+    if [[ -n "$df_out" ]]; then
+        total=$(echo "$df_out" | awk '{print $2}')
+        used=$(echo "$df_out" | awk '{print $3}')
+        avail=$(echo "$df_out" | awk '{print $4}')
+        pct=$(( used * 100 / total ))
+        total_gb=$(( total / 1024 / 1024 / 1024 ))
+        avail_gb=$(( avail / 1024 / 1024 / 1024 ))
+        log_pass "Espaço: total=${total_gb}GB livre=${avail_gb}GB usado=${pct}%"
+        if [[ $pct -ge 90 ]]; then
+            log_fail "CRÍTICO: Staging com ${pct}% de uso (≥90%)"
+        elif [[ $pct -ge 80 ]]; then
+            log_warn "Atenção: Staging com ${pct}% de uso (≥80%)"
+        else
+            log_pass "Uso de staging saudável: ${pct}%"
+        fi
+    else
+        log_warn "Não foi possível obter df para /mnt/raid1/lto6-cache"
     fi
 else
     log_warn "Diretório /mnt/raid1/lto6-cache não existe"
@@ -158,6 +193,78 @@ if [[ -f /mnt/raid1/lto6-cache/.probe* ]]; then
     log_fail "Arquivo-prova ainda existe em staging (remover: rm /mnt/raid1/lto6-cache/.probe*)"
 else
     log_pass "Nenhum arquivo-prova em staging"
+fi
+
+# ─── Teste 7: E2E upload → staging → flush (G10) ──────────────────────────────
+log_section "7. Teste E2E (upload → staging → flush → fita)"
+
+E2E_ENABLED="${E2E_ENABLED:-0}"
+E2E_PROBE=".e2e-probe-$(date +%s)"
+E2E_MARKER="e2e-validation-$(date +%s)"
+
+if [[ "$E2E_ENABLED" == "1" ]]; then
+    # 7a. Upload de arquivo-prova via Nextcloud (escrita como www-data no /LTO)
+    if docker exec -u www-data nextcloud-app \
+        sh -c "echo '$E2E_MARKER' > /var/www/html/external/LTO/$E2E_PROBE" &>/dev/null; then
+        log_pass "E2E: upload para /LTO (staging) OK"
+    else
+        log_fail "E2E: upload para /LTO falhou"
+    fi
+
+    # 7b. Arquivo materializado no staging em disco
+    if [[ -f "/mnt/raid1/lto6-cache/$E2E_PROBE" ]]; then
+        log_pass "E2E: arquivo presente no staging (/mnt/raid1/lto6-cache)"
+        probe_content=$(cat "/mnt/raid1/lto6-cache/$E2E_PROBE")
+        if [[ "$probe_content" == "$E2E_MARKER" ]]; then
+            log_pass "E2E: conteúdo do arquivo-prova íntegro"
+        else
+            log_fail "E2E: conteúdo do arquivo-prova divergente (got '$probe_content')"
+        fi
+    else
+        log_fail "E2E: arquivo não materializado no staging"
+    fi
+
+    # 7c. Flush para fita (requer flush worker instalado; marcado com mtime antigo)
+    if command -v ltfs-cache-flush &>/dev/null; then
+        touch -d "2 hours ago" "/mnt/raid1/lto6-cache/$E2E_PROBE"
+        if ltfs-cache-flush \
+            --buffer-root /mnt/raid1/lto6-cache \
+            --primary-buffer-root /mnt/raid1/lto6-cache \
+            --target-root /mnt/lto6-smb-proof \
+            --state-file /var/lib/ltfs-cache-flush/state.json \
+            --placement-file /var/lib/ltfs-cache-flush/placements.json \
+            --catalog-file /var/lib/ltfs-cache-flush/catalog.jsonl \
+            --metrics-file /var/lib/ltfs-cache-flush/metrics.json \
+            --metrics-state-file /var/lib/ltfs-cache-flush/metrics_state.json \
+            --lock-file /run/ltfs-cache-flush.lock \
+            --min-age-seconds 60 --min-stable-seconds 30 \
+            --min-target-total-bytes 0 --min-target-free-bytes 0 &>/dev/null; then
+            log_pass "E2E: flush worker executou sem erro"
+        else
+            log_warn "E2E: flush worker retornou erro (verificar journal ltfs-cache-flush.service)"
+        fi
+
+        # 7d. Arquivo-prova na fita (via CIFS)
+        if [[ -f "/mnt/lto6-smb-proof/$E2E_PROBE" ]]; then
+            tape_content=$(cat "/mnt/lto6-smb-proof/$E2E_PROBE" 2>/dev/null || echo "")
+            if [[ "$tape_content" == "$E2E_MARKER" ]]; then
+                log_pass "E2E: arquivo-prova verificado na fita via CIFS"
+            else
+                log_warn "E2E: arquivo na fita com conteúdo divergente (flush pode não ter concluído SHA256)"
+            fi
+        else
+            log_warn "E2E: arquivo não encontrado na fita via CIFS (fita pode não estar montada ou flush pendente)"
+        fi
+    else
+        log_warn "E2E: ltfs-cache-flush não instalado — pulando etapa de flush"
+    fi
+
+    # 7e. Cleanup do probe (staging + fita)
+    rm -f "/mnt/raid1/lto6-cache/$E2E_PROBE" 2>/dev/null || true
+    rm -f "/mnt/lto6-smb-proof/$E2E_PROBE" 2>/dev/null || true
+    log_pass "E2E: cleanup do arquivo-prova realizado"
+else
+    log_warn "E2E desabilitado — export E2E_ENABLED=1 para executar (precisa de tape/flush montados)"
 fi
 
 # ─── Resumo ──────────────────────────────────────────────────────────────────

--- a/tools/fix_staging_perms.py
+++ b/tools/fix_staging_perms.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+fix-staging-perms — Garante permissões corretas do staging Nextcloud LTO no boot.
+
+Executa como systemd oneshot antes do Nextcloud e do ltfs-cache-flush.
+Corrige: uid=33 (www-data), gid=33, mode=770 em /mnt/raid1/lto6-cache
+e garante que o bind mount /mnt/lto6-nc está ativo.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [fix-staging-perms] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("fix-staging-perms")
+
+STAGING_DIR = Path("/mnt/raid1/lto6-cache")
+BIND_MOUNT = Path("/mnt/lto6-nc")
+EXPECTED_UID = 33  # www-data
+EXPECTED_GID = 33  # www-data
+EXPECTED_MODE = 0o770
+FSTAB_ENTRY = "/mnt/raid1/lto6-cache /mnt/lto6-nc none bind 0 0"
+
+
+def run_cmd(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    log.debug("[CMD] %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def ensure_staging_dir() -> bool:
+    """Cria diretório de staging se não existir."""
+    if not STAGING_DIR.exists():
+        log.info("Criando diretório de staging: %s", STAGING_DIR)
+        STAGING_DIR.mkdir(parents=True, exist_ok=True)
+    return True
+
+
+def fix_permissions() -> bool:
+    """Ajusta owner, group e mode do staging."""
+    try:
+        current = STAGING_DIR.stat()
+        changes = []
+
+        if current.st_uid != EXPECTED_UID or current.st_gid != EXPECTED_GID:
+            log.info("Ajustando owner: %d:%d -> %d:%d", current.st_uid, current.st_gid, EXPECTED_UID, EXPECTED_GID)
+            os.chown(STAGING_DIR, EXPECTED_UID, EXPECTED_GID)
+            changes.append("owner")
+
+        current_mode = current.st_mode & 0o777
+        if current_mode != EXPECTED_MODE:
+            log.info("Ajustando mode: %o -> %o", current_mode, EXPECTED_MODE)
+            os.chmod(STAGING_DIR, EXPECTED_MODE)
+            changes.append("mode")
+
+        if changes:
+            log.info("Permissões corrigidas: %s", ", ".join(changes))
+        else:
+            log.debug("Permissões já corretas: uid=%d gid=%d mode=%o", EXPECTED_UID, EXPECTED_GID, EXPECTED_MODE)
+        return True
+    except Exception as e:
+        log.error("Falha ao ajustar permissões: %s", e)
+        return False
+
+
+def ensure_bind_mount() -> bool:
+    """Garante que o bind mount está ativo."""
+    # Verifica se já está montado
+    result = run_cmd(["mountpoint", "-q", str(BIND_MOUNT)], check=False)
+    if result.returncode == 0:
+        log.debug("Bind mount já ativo: %s", BIND_MOUNT)
+        return True
+
+    # Tenta montar via systemd (fstab)
+    log.info("Montando bind mount: %s -> %s", STAGING_DIR, BIND_MOUNT)
+    BIND_MOUNT.parent.mkdir(parents=True, exist_ok=True)
+
+    # Verifica entrada no fstab
+    fstab_check = run_cmd(["grep", "-q", str(STAGING_DIR), "/etc/fstab"], check=False)
+    if fstab_check.returncode != 0:
+        log.warning("Entrada fstab não encontrada, adicionando: %s", FSTAB_ENTRY)
+        try:
+            with open("/etc/fstab", "a") as f:
+                f.write(f"\n{FSTAB_ENTRY}\n")
+        except Exception as e:
+            log.error("Falha ao escrever fstab: %s", e)
+            return False
+
+    # Monta
+    mount_result = run_cmd(["mount", str(BIND_MOUNT)], check=False)
+    if mount_result.returncode != 0:
+        log.error("Falha no mount: %s", mount_result.stderr)
+        return False
+
+    log.info("Bind mount ativado: %s", BIND_MOUNT)
+    return True
+
+
+def validate_write_as_www_data() -> bool:
+    """Valida escrita como www-data no container Nextcloud (se rodando)."""
+    # Tenta detectar container Nextcloud
+    try:
+        result = run_cmd(["docker", "ps", "--format", "{{.Names}}"], check=False)
+        containers = result.stdout.strip().split("\n")
+        nc_container = None
+        for c in containers:
+            if "nextcloud" in c.lower():
+                nc_container = c
+                break
+
+        if not nc_container:
+            log.info("Container Nextcloud não encontrado, pulando validação de escrita")
+            return True
+
+        # Testa escrita via docker exec
+        test_file = "/var/www/html/external/LTO/.perm_test"
+        cmd = [
+            "docker", "exec", "-u", "www-data", nc_container,
+            "sh", "-c", f'date > "{test_file}" && cat "{test_file}" && rm -f "{test_file}"'
+        ]
+        result = run_cmd(cmd, check=False)
+        if result.returncode == 0:
+            log.info("Validação de escrita como www-data: OK")
+            return True
+        else:
+            log.warning("Validação de escrita como www-data falhou: %s", result.stderr)
+            return False
+
+    except Exception as e:
+        log.warning("Erro na validação de escrita: %s", e)
+        return True  # Não falha o boot por isso
+
+
+def main() -> int:
+    log.info("=== Fix Staging Perms iniciado ===")
+
+    ok = True
+    ok &= ensure_staging_dir()
+    ok &= fix_permissions()
+    ok &= ensure_bind_mount()
+    ok &= validate_write_as_www_data()
+
+    if ok:
+        log.info("=== Fix Staging Perms concluído com sucesso ===")
+        return 0
+    else:
+        log.error("=== Fix Staging Perms FALHOU ===")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ltfs_cache_flush.py
+++ b/tools/ltfs_cache_flush.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+"""
+ltfs-cache-flush — Worker que drena staging do Nextcloud para fita LTFS.
+
+Fluxo:
+  1. Adquire lock exclusivo global (/run/lock/tape-global.lock)
+  2. Escaneia buffer roots por arquivos maduros (--min-age-seconds, --min-stable-seconds)
+  3. Para cada arquivo: rsync -> verifica SHA256 -> registra em catalog.jsonl + placements.json
+  4. Atualiza métricas e libera lock
+
+Uso (via systemd drop-in 60-tape-gate.conf):
+  ltfs-cache-flush --buffer-root /mnt/pretape/lto6-cache \
+    --primary-buffer-root /mnt/pretape/lto6-cache \
+    --target-root /mnt/lto6-smb-proof/backups \
+    --state-file /var/lib/ltfs-cache-flush/state.json \
+    --placement-file /var/lib/ltfs-cache-flush/placements.json \
+    --catalog-file /var/lib/ltfs-cache-flush/catalog.jsonl \
+    --metrics-file /var/lib/ltfs-cache-flush/metrics.json \
+    --metrics-state-file /var/lib/ltfs-cache-flush/metrics_state.json \
+    --lock-file /run/ltfs-cache-flush.lock \
+    --min-age-seconds 900 --min-stable-seconds 300 \
+    --high-watermark-percent 85 --low-watermark-percent 70 \
+    --min-target-total-bytes 107374182400 --min-target-free-bytes 10737418240 \
+    --placement-policy newest-first --log-level INFO
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ─── Configuração ──────────────────────────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [ltfs-cache-flush] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("ltfs-cache-flush")
+
+GLOBAL_TAPE_LOCK = Path("/run/lock/tape-global.lock")
+LOCAL_FLUSH_LOCK = Path("/run/ltfs-cache-flush.lock")
+
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _acquire_lock(lock_path: Path, timeout: int = 300) -> int:
+    """Adquire lock exclusivo (flock). Retorna fd do lock."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = lock_path.open("w").fileno()
+    start = time.time()
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except BlockingIOError:
+            if time.time() - start >= timeout:
+                raise RuntimeError(f"Lock {lock_path} não adquirido após {timeout}s")
+            time.sleep(1)
+
+
+def _release_lock(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except Exception:
+        pass
+    try:
+        os.close(fd)
+    except Exception:
+        pass
+
+
+def _run_cmd(cmd: list[str], timeout: int = 300) -> subprocess.CompletedProcess[str]:
+    log.debug("[CMD] %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+# ─── Coleta de candidatos ──────────────────────────────────────────────────────
+
+
+def collect_candidates(
+    buffer_roots: list[Path],
+    min_age_seconds: int,
+    min_stable_seconds: int,
+) -> list[dict[str, Any]]:
+    """
+    Retorna lista de arquivos candidatos para flush.
+    Critérios:
+      - Arquivo regular (não symlink, não dir)
+      - Idade >= min_age_seconds (mtime)
+      - Estável >= min_stable_seconds (mtime não muda há N segundos)
+    """
+    now = time.time()
+    candidates: list[dict[str, Any]] = []
+
+    for root in buffer_roots:
+        if not root.exists():
+            log.warning("Buffer root não existe: %s", root)
+            continue
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                st = f.stat()
+            except OSError:
+                continue
+            age = now - st.st_mtime
+            if age < min_age_seconds:
+                continue
+            # Estabilidade: mtime não muda há min_stable_seconds
+            # (aproximação: se age >= min_age_seconds + min_stable_seconds, considera estável)
+            if age < min_age_seconds + min_stable_seconds:
+                continue
+            rel = f.relative_to(root)
+            candidates.append({
+                "src_root": str(root),
+                "rel_path": str(rel),
+                "abs_path": str(f),
+                "size": st.st_size,
+                "mtime": st.st_mtime,
+                "sha256": None,  # calculado no flush
+            })
+    log.info("Candidatos coletados: %d arquivo(s)", len(candidates))
+    return candidates
+
+
+# ─── Estado persistente ────────────────────────────────────────────────────────
+
+
+def load_state(state_file: Path) -> dict[str, Any]:
+    if state_file.exists():
+        try:
+            return json.loads(state_file.read_text())
+        except Exception:
+            pass
+    return {"flushed": {}, "failed": {}, "last_run": None}
+
+
+def save_state(state_file: Path, state: dict[str, Any]) -> None:
+    _atomic_write(state_file, json.dumps(state, indent=2, ensure_ascii=False))
+
+
+def load_placements(placement_file: Path) -> dict[str, Any]:
+    if placement_file.exists():
+        try:
+            return json.loads(placement_file.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_placements(placement_file: Path, placements: dict[str, Any]) -> None:
+    _atomic_write(placement_file, json.dumps(placements, indent=2, ensure_ascii=False))
+
+
+def append_catalog(catalog_file: Path, entry: dict[str, Any]) -> None:
+    catalog_file.parent.mkdir(parents=True, exist_ok=True)
+    with catalog_file.open("a") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def load_metrics(metrics_file: Path) -> dict[str, Any]:
+    if metrics_file.exists():
+        try:
+            return json.loads(metrics_file.read_text())
+        except Exception:
+            pass
+    return {"runs": []}
+
+
+def save_metrics(metrics_file: Path, metrics: dict[str, Any]) -> None:
+    _atomic_write(metrics_file, json.dumps(metrics, indent=2, ensure_ascii=False))
+
+
+# ─── Flush de um arquivo ───────────────────────────────────────────────────────
+
+
+def flush_file(
+    candidate: dict[str, Any],
+    target_root: Path,
+    state: dict[str, Any],
+    placements: dict[str, Any],
+    catalog_file: Path,
+    placement_policy: str,
+) -> tuple[bool, str]:
+    """
+    Flush de um arquivo para a fita.
+    Retorna (sucesso, mensagem).
+    """
+    src = Path(candidate["abs_path"])
+    rel = candidate["rel_path"]
+    dest = target_root / rel
+
+    # Verifica se já foi flushado com sucesso (idempotência)
+    flushed_key = f"{candidate['src_root']}:{rel}"
+    if flushed_key in state.get("flushed", {}):
+        existing = state["flushed"][flushed_key]
+        if existing.get("size") == candidate["size"] and existing.get("sha256"):
+            # Verifica se arquivo na fita ainda existe e bate SHA256
+            if dest.exists():
+                try:
+                    tape_sha = sha256_file(dest)
+                    if tape_sha == existing["sha256"]:
+                        log.debug("[SKIP] Já flushado e verificado: %s", rel)
+                        return True, "already_flushed"
+                except Exception:
+                    pass
+
+    # Garante diretório destino
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # rsync --whole-file --no-partial (evita arquivos parciais na fita)
+    rsync_cmd = [
+        "rsync",
+        "--archive",
+        "--hard-links",
+        "--omit-link-times",
+        "--whole-file",
+        "--no-partial",
+        "--timeout=300",
+        str(src),
+        str(dest),
+    ]
+    log.info("[RSYNC] %s -> %s", rel, dest)
+    rsync_result = _run_cmd(rsync_cmd)
+    if rsync_result.returncode not in (0, 23, 24):
+        msg = f"rsync falhou (exit={rsync_result.returncode}): {rsync_result.stderr[:200]}"
+        log.error(msg)
+        state.setdefault("failed", {})[flushed_key] = {
+            "error": msg,
+            "attempted_at": _now_iso(),
+        }
+        return False, msg
+
+    # SHA256 na fita
+    try:
+        tape_sha = sha256_file(dest)
+    except Exception as e:
+        msg = f"SHA256 falhou no destino: {e}"
+        log.error(msg)
+        state.setdefault("failed", {})[flushed_key] = {
+            "error": msg,
+            "attempted_at": _now_iso(),
+        }
+        return False, msg
+
+    # SHA256 na origem (para comparação)
+    try:
+        src_sha = sha256_file(src)
+    except Exception as e:
+        log.warning("SHA256 origem falhou (arquivo pode ter sido removido): %s", e)
+        src_sha = None
+
+    if src_sha and tape_sha != src_sha:
+        msg = f"SHA256 mismatch: src={src_sha[:12]}... tape={tape_sha[:12]}..."
+        log.error("[MISMATCH] %s", msg)
+        state.setdefault("failed", {})[flushed_key] = {
+            "error": msg,
+            "attempted_at": _now_iso(),
+            "src_sha256": src_sha,
+            "tape_sha256": tape_sha,
+        }
+        return False, msg
+
+    # Sucesso: registra estado
+    state.setdefault("flushed", {})[flushed_key] = {
+        "size": candidate["size"],
+        "sha256": tape_sha,
+        "flushed_at": _now_iso(),
+        "src_root": candidate["src_root"],
+        "rel_path": rel,
+        "target_root": str(target_root),
+    }
+
+    # Placements (para recovery: onde cada arquivo está na fita)
+    placements[rel] = {
+        "target_root": str(target_root),
+        "size": candidate["size"],
+        "sha256": tape_sha,
+        "flushed_at": _now_iso(),
+        "src_root": candidate["src_root"],
+    }
+
+    # Catalog (append-only log imutável)
+    catalog_entry = {
+        "timestamp": _now_iso(),
+        "action": "flush",
+        "src_root": candidate["src_root"],
+        "rel_path": rel,
+        "size": candidate["size"],
+        "sha256": tape_sha,
+        "target_root": str(target_root),
+        "policy": placement_policy,
+    }
+    append_catalog(catalog_file, catalog_entry)
+
+    log.info("[OK] %s (%d bytes, %s...)", rel, candidate["size"], tape_sha[:12])
+    return True, "flushed"
+
+
+# ─── Verificação de capacidade do target ───────────────────────────────────────
+
+
+def check_target_capacity(
+    target_root: Path,
+    min_total_bytes: int,
+    min_free_bytes: int,
+) -> bool:
+    """Verifica se o target (fita via CIFS) tem espaço mínimo."""
+    try:
+        stat = shutil.disk_usage(target_root)
+    except Exception as e:
+        log.warning("Não checar capacidade do target: %s", e)
+        return True  # não bloqueia se não consegue checar
+
+    total_gb = stat.total / (1024**3)
+    free_gb = stat.free / (1024**3)
+    used_pct = (stat.used / stat.total) * 100 if stat.total > 0 else 0
+
+    log.info("Target capacity: total=%.1fGB free=%.1fGB used=%.1f%%", total_gb, free_gb, used_pct)
+
+    if stat.total < min_total_bytes:
+        log.error("Target total space %.1fGB < mínimo %.1fGB", total_gb, min_total_bytes / (1024**3))
+        return False
+    if stat.free < min_free_bytes:
+        log.error("Target free space %.1fGB < mínimo %.1fGB", free_gb, min_free_bytes / (1024**3))
+        return False
+    return True
+
+
+# ─── Métricas ──────────────────────────────────────────────────────────────────
+
+
+def update_metrics(
+    metrics_file: Path,
+    metrics_state_file: Path,
+    run_result: dict[str, Any],
+) -> None:
+    metrics = load_metrics(metrics_file)
+    metrics.setdefault("runs", []).append(run_result)
+    # Mantém últimos 100 runs
+    metrics["runs"] = metrics["runs"][-100:]
+    save_metrics(metrics_file, metrics)
+
+    # Estado resumido para exporter Prometheus
+    state = {
+        "last_run": run_result.get("timestamp"),
+        "last_status": run_result.get("status"),
+        "files_flushed": run_result.get("files_flushed", 0),
+        "files_failed": run_result.get("files_failed", 0),
+        "bytes_flushed": run_result.get("bytes_flushed", 0),
+        "duration_seconds": run_result.get("duration_seconds", 0),
+    }
+    _atomic_write(metrics_state_file, json.dumps(state, indent=2))
+
+
+# ─── Cleanup de staging (G7) ───────────────────────────────────────────────────
+
+
+def cleanup_flushed_files(
+    state: dict[str, Any],
+    catalog_file: Path,
+    policy: str,
+    trash_root: Path,
+    max_age_days: int,
+) -> dict[str, Any]:
+    """
+    Aplica política de limpeza sobre arquivos já flushados com sucesso.
+
+    Policies:
+      - none             : não faz nada
+      - delete           : remove arquivo do staging após flush confirmado
+      - move-to-flushed  : move para <trash_root> (retém por max_age_days)
+      - move-to-trash    : igual a move-to-flushed (alias)
+    """
+    if policy == "none":
+        return {"policy": policy, "removed": 0, "moved": 0}
+
+    flushed = state.get("flushed", {})
+    removed = 0
+    moved = 0
+    now = time.time()
+
+    for key, entry in flushed.items():
+        if not entry.get("sha256"):
+            continue
+        src = Path(entry.get("abs_path", ""))
+        if not src:
+            # estado antigo não tinha abs_path — derivar de src_root+rel_path
+            src_root = entry.get("src_root", "")
+            rel = entry.get("rel_path", "")
+            if src_root and rel:
+                src = Path(src_root) / rel
+        if not src.exists():
+            continue
+
+        # Só limpa se arquivo ainda existe no staging (ainda não removido)
+        try:
+            if policy in ("delete",):
+                src.unlink()
+                removed += 1
+                log.info("[CLEANUP] removido do staging: %s", src)
+            elif policy in ("move-to-flushed", "move-to-trash"):
+                dest = trash_root / Path(entry.get("rel_path", ""))
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dest))
+                moved += 1
+                log.info("[CLEANUP] movido para %s: %s", trash_root, src)
+        except OSError as exc:
+            log.warning("[CLEANUP] falha ao limpar %s: %s", src, exc)
+
+    # TTL do trash: apaga arquivos antigos em trash_root além de max_age_days
+    expired = 0
+    if trash_root.exists() and policy in ("move-to-flushed", "move-to-trash"):
+        cutoff = now - (max_age_days * 86400)
+        for f in trash_root.rglob("*"):
+            if f.is_file():
+                try:
+                    if f.stat().st_mtime < cutoff:
+                        f.unlink()
+                        expired += 1
+                except OSError:
+                    pass
+        if expired:
+            log.info("[CLEANUP] %d arquivo(s) expirados removidos de %s", expired, trash_root)
+
+    return {"policy": policy, "removed": removed, "moved": moved, "expired": expired}
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LTFS Cache Flush — drena staging para fita")
+    parser.add_argument("--buffer-root", action="append", required=True, help="Raiz do buffer de staging (pode repetir)")
+    parser.add_argument("--primary-buffer-root", required=True, help="Raiz primária (para métricas)")
+    parser.add_argument("--target-root", action="append", required=True, help="Raiz destino na fita via CIFS (pode repetir)")
+    parser.add_argument("--state-file", required=True, help="Arquivo de estado JSON")
+    parser.add_argument("--placement-file", required=True, help="Arquivo de placements JSON")
+    parser.add_argument("--catalog-file", required=True, help="Arquivo de catalog JSONL (append-only)")
+    parser.add_argument("--metrics-file", required=True, help="Arquivo de métricas JSON")
+    parser.add_argument("--metrics-state-file", required=True, help="Arquivo de estado de métricas JSON")
+    parser.add_argument("--lock-file", required=True, help="Lock local do flush")
+    parser.add_argument("--min-age-seconds", type=int, default=900, help="Idade mínima do arquivo (s)")
+    parser.add_argument("--min-stable-seconds", type=int, default=300, help="Estabilidade mínima (s)")
+    parser.add_argument("--high-watermark-percent", type=int, default=85, help="Watermark alto staging (%)")
+    parser.add_argument("--low-watermark-percent", type=int, default=70, help="Watermark baixo staging (%)")
+    parser.add_argument("--min-target-total-bytes", type=int, default=107374182400, help="Espaço total mínimo target (bytes)")
+    parser.add_argument("--min-target-free-bytes", type=int, default=10737418240, help="Espaço livre mínimo target (bytes)")
+    parser.add_argument("--placement-policy", default="newest-first", help="Política de colocação")
+    parser.add_argument("--log-level", default="INFO", help="Nível de log")
+    parser.add_argument("--dry-run", action="store_true", help="Não executa flush, só lista candidatos")
+    parser.add_argument("--cleanup-policy", default="none", choices=["none", "delete", "move-to-flushed", "move-to-trash"],
+                        help="Política de limpeza do staging após flush confirmado (G7)")
+    parser.add_argument("--cleanup-trash-root", default="/mnt/raid1/lto6-cache/.flushed",
+                        help="Diretório de retenção para policy=move-to-flushed/trash")
+    parser.add_argument("--cleanup-max-age-days", type=int, default=30,
+                        help="Idade máxima (dias) no trash antes de remover")
+
+    args = parser.parse_args()
+
+    logging.getLogger().setLevel(args.log_level.upper())
+
+    buffer_roots = [Path(p) for p in args.buffer_root]
+    target_roots = [Path(p) for p in args.target_root]
+    primary_root = Path(args.primary_buffer_root)
+
+    log.info("=== LTFS Cache Flush iniciado ===")
+    log.info("Buffer roots: %s", ", ".join(str(p) for p in buffer_roots))
+    log.info("Target roots: %s", ", ".join(str(p) for p in target_roots))
+    log.info("Min age: %ds, min stable: %ds", args.min_age_seconds, args.min_stable_seconds)
+
+    start_time = time.time()
+    run_id = _now_iso()
+
+    # Lock global de fita (compartilhado com outros writers)
+    global_lock_fd = -1
+    local_lock_fd = -1
+    try:
+        log.info("Adquirindo lock global de fita: %s", GLOBAL_TAPE_LOCK)
+        global_lock_fd = _acquire_lock(GLOBAL_TAPE_LOCK, timeout=600)
+        log.info("Lock global adquirido")
+
+        log.info("Adquirindo lock local de flush: %s", args.lock_file)
+        local_lock_fd = _acquire_lock(Path(args.lock_file), timeout=60)
+        log.info("Lock local adquirido")
+
+        # Carrega estado persistente
+        state = load_state(Path(args.state_file))
+        placements = load_placements(Path(args.placement_file))
+
+        # Verifica capacidade do target (usa primeiro target root)
+        if not check_target_capacity(target_roots[0], args.min_target_total_bytes, args.min_target_free_bytes):
+            return 1
+
+        # Coleta candidatos
+        candidates = collect_candidates(buffer_roots, args.min_age_seconds, args.min_stable_seconds)
+
+        if not candidates:
+            log.info("Nenhum candidato para flush")
+            run_result = {
+                "timestamp": run_id,
+                "status": "success",
+                "files_flushed": 0,
+                "files_failed": 0,
+                "bytes_flushed": 0,
+                "duration_seconds": time.time() - start_time,
+                "candidates": 0,
+            }
+            update_metrics(Path(args.metrics_file), Path(args.metrics_state_file), run_result)
+            return 0
+
+        if args.dry_run:
+            log.info("DRY-RUN: %d candidatos seriam flushados", len(candidates))
+            for c in candidates:
+                log.info("  %s (%d bytes)", c["rel_path"], c["size"])
+            return 0
+
+        # Flush sequencial (um target root por enquanto)
+        target_root = target_roots[0]
+        flushed_count = 0
+        failed_count = 0
+        bytes_flushed = 0
+
+        for candidate in candidates:
+            ok, msg = flush_file(
+                candidate,
+                target_root,
+                state,
+                placements,
+                Path(args.catalog_file),
+                args.placement_policy,
+            )
+            if ok and msg == "flushed":
+                flushed_count += 1
+                bytes_flushed += candidate["size"]
+            elif ok and msg == "already_flushed":
+                pass  # já contado anteriormente
+            else:
+                failed_count += 1
+
+        # Persiste estado
+        save_state(Path(args.state_file), state)
+        save_placements(Path(args.placement_file), placements)
+
+        # G7: Cleanup do staging após flush confirmado
+        cleanup_result = cleanup_flushed_files(
+            state,
+            Path(args.catalog_file),
+            args.cleanup_policy,
+            Path(args.cleanup_trash_root),
+            args.cleanup_max_age_days,
+        )
+        if cleanup_result["policy"] != "none":
+            log.info("[CLEANUP] %s: removidos=%d movidos=%d expirados=%d",
+                     cleanup_result["policy"], cleanup_result["removed"],
+                     cleanup_result["moved"], cleanup_result["expired"])
+            # Persiste estado atualizado (abs_path removido do staging)
+            save_state(Path(args.state_file), state)
+
+        duration = time.time() - start_time
+        status = "success" if failed_count == 0 else "partial_failure"
+
+        run_result = {
+            "timestamp": run_id,
+            "status": status,
+            "files_flushed": flushed_count,
+            "files_failed": failed_count,
+            "bytes_flushed": bytes_flushed,
+            "duration_seconds": duration,
+            "candidates": len(candidates),
+        }
+        update_metrics(Path(args.metrics_file), Path(args.metrics_state_file), run_result)
+
+        log.info("=== Flush concluído: %d ok, %d falhas, %.1fMB em %.1fs ===",
+                 flushed_count, failed_count, bytes_flushed / (1024**2), duration)
+
+        return 0 if failed_count == 0 else 1
+
+    except Exception as e:
+        log.exception("Erro fatal no flush: %s", e)
+        run_result = {
+            "timestamp": run_id,
+            "status": "error",
+            "error": str(e),
+            "duration_seconds": time.time() - start_time,
+        }
+        update_metrics(Path(args.metrics_file), Path(args.metrics_state_file), run_result)
+        return 1
+    finally:
+        if local_lock_fd >= 0:
+            _release_lock(local_lock_fd)
+        if global_lock_fd >= 0:
+            _release_lock(global_lock_fd)
+        log.info("Locks liberados")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ltfs_catalog_verify.py
+++ b/tools/ltfs_catalog_verify.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+ltfs-catalog-verify — Valida integridade do catálogo LTFS pós-flush.
+
+Verifica:
+  1. catalog.jsonl: cada entrada tem SHA256 válido e arquivo existe na fita
+  2. placements.json: consistente com catalog
+  3. Amostragem: verifica SHA256 de N arquivos aleatórios na fita
+  4. Métricas: exporta resultados para Prometheus
+
+Uso:
+  ltfs-catalog-verify --catalog /var/lib/ltfs-cache-flush/catalog.jsonl \
+    --placements /var/lib/ltfs-cache-flush/placements.json \
+    --tape-root /mnt/lto6-smb-proof/backups \
+    --sample-percent 10 --sample-max 100 \
+    --metrics-file /var/lib/ltfs-cache-flush/catalog_verify_metrics.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import random
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [ltfs-catalog-verify] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("ltfs-catalog-verify")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_catalog(catalog_file: Path) -> list[dict[str, Any]]:
+    entries = []
+    if not catalog_file.exists():
+        log.warning("Catalog não existe: %s", catalog_file)
+        return entries
+    with catalog_file.open() as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                log.error("Linha %d do catalog inválida: %s", line_num, e)
+    return entries
+
+
+def load_placements(placements_file: Path) -> dict[str, Any]:
+    if not placements_file.exists():
+        return {}
+    try:
+        return json.loads(placements_file.read_text())
+    except Exception as e:
+        log.error("Placements inválido: %s", e)
+        return {}
+
+
+def verify_catalog_structure(entries: list[dict]) -> dict[str, Any]:
+    """Valida estrutura básica de cada entrada do catalog."""
+    required_fields = {"timestamp", "action", "src_root", "rel_path", "size", "sha256", "target_root"}
+    results = {"total": len(entries), "valid": 0, "invalid": 0, "errors": []}
+
+    for i, entry in enumerate(entries):
+        missing = required_fields - set(entry.keys())
+        if missing:
+            results["invalid"] += 1
+            results["errors"].append(f"Entry {i}: missing fields {missing}")
+        else:
+            # Valida SHA256 format
+            sha = entry.get("sha256", "")
+            if not (isinstance(sha, str) and len(sha) == 64 and all(c in "0123456789abcdef" for c in sha)):
+                results["invalid"] += 1
+                results["errors"].append(f"Entry {i}: invalid sha256 format")
+            else:
+                results["valid"] += 1
+
+    return results
+
+
+def verify_placements_consistency(
+    catalog_entries: list[dict], placements: dict
+) -> dict[str, Any]:
+    """Verifica se placements.json é consistente com catalog."""
+    results = {"checked": 0, "consistent": 0, "inconsistent": 0, "missing_in_placements": 0, "errors": []}
+
+    for entry in catalog_entries:
+        if entry.get("action") != "flush":
+            continue
+        rel = entry.get("rel_path")
+        if not rel:
+            continue
+        results["checked"] += 1
+
+        placement = placements.get(rel)
+        if not placement:
+            results["missing_in_placements"] += 1
+            results["errors"].append(f"Placement ausente para: {rel}")
+            continue
+
+        # Compara campos-chave
+        mismatches = []
+        for field in ("sha256", "size", "target_root"):
+            cat_val = entry.get(field)
+            plc_val = placement.get(field)
+            if cat_val != plc_val:
+                mismatches.append(f"{field}: catalog={cat_val} placement={plc_val}")
+
+        if mismatches:
+            results["inconsistent"] += 1
+            results["errors"].append(f"{rel}: {', '.join(mismatches)}")
+        else:
+            results["consistent"] += 1
+
+    return results
+
+
+def sample_verify_tape(
+    catalog_entries: list[dict],
+    tape_root: Path,
+    sample_percent: int,
+    sample_max: int,
+) -> dict[str, Any]:
+    """Amostra e verifica SHA256 de arquivos na fita."""
+    flush_entries = [e for e in catalog_entries if e.get("action") == "flush"]
+    if not flush_entries:
+        return {"sampled": 0, "verified": 0, "mismatched": 0, "missing": 0, "errors": []}
+
+    # Calcula tamanho da amostra
+    sample_size = min(len(flush_entries) * sample_percent // 100, sample_max)
+    sample_size = max(sample_size, 1) if flush_entries else 0
+
+    sampled = random.sample(flush_entries, sample_size) if sample_size < len(flush_entries) else flush_entries
+
+    results = {"sampled": len(sampled), "verified": 0, "mismatched": 0, "missing": 0, "errors": []}
+
+    for entry in sampled:
+        rel = entry.get("rel_path")
+        expected_sha = entry.get("sha256")
+        target_root_str = entry.get("target_root")
+        if not rel or not expected_sha or not target_root_str:
+            results["errors"].append(f"Entry incompleto: {entry}")
+            continue
+
+        tape_file = Path(target_root_str) / rel
+        if not tape_file.exists():
+            results["missing"] += 1
+            results["errors"].append(f"Arquivo não encontrado na fita: {tape_file}")
+            continue
+
+        try:
+            actual_sha = sha256_file(tape_file)
+            if actual_sha == expected_sha:
+                results["verified"] += 1
+            else:
+                results["mismatched"] += 1
+                results["errors"].append(f"SHA mismatch {rel}: expected={expected_sha[:12]}... actual={actual_sha[:12]}...")
+        except Exception as e:
+            results["errors"].append(f"Erro lendo {tape_file}: {e}")
+
+    return results
+
+
+def export_metrics(metrics_file: Path, results: dict[str, Any]) -> None:
+    """Exporta métricas no formato Prometheus text."""
+    lines = [
+        "# HELP ltfs_catalog_verify_total Total catalog entries",
+        "# TYPE ltfs_catalog_verify_total gauge",
+        f"ltfs_catalog_verify_total {results.get('structure', {}).get('total', 0)}",
+        "# HELP ltfs_catalog_verify_valid Valid catalog entries",
+        "# TYPE ltfs_catalog_verify_valid gauge",
+        f"ltfs_catalog_verify_valid {results.get('structure', {}).get('valid', 0)}",
+        "# HELP ltfs_catalog_verify_invalid Invalid catalog entries",
+        "# TYPE ltfs_catalog_verify_invalid gauge",
+        f"ltfs_catalog_verify_invalid {results.get('structure', {}).get('invalid', 0)}",
+        "# HELP ltfs_catalog_placements_consistent Consistent placements",
+        "# TYPE ltfs_catalog_placements_consistent gauge",
+        f"ltfs_catalog_placements_consistent {results.get('placements', {}).get('consistent', 0)}",
+        "# HELP ltfs_catalog_placements_inconsistent Inconsistent placements",
+        "# TYPE ltfs_catalog_placements_inconsistent gauge",
+        f"ltfs_catalog_placements_inconsistent {results.get('placements', {}).get('inconsistent', 0)}",
+        "# HELP ltfs_catalog_tape_verified Files verified on tape (sample)",
+        "# TYPE ltfs_catalog_tape_verified gauge",
+        f"ltfs_catalog_tape_verified {results.get('tape_sample', {}).get('verified', 0)}",
+        "# HELP ltfs_catalog_tape_mismatched Files with SHA mismatch on tape (sample)",
+        "# TYPE ltfs_catalog_tape_mismatched gauge",
+        f"ltfs_catalog_tape_mismatched {results.get('tape_sample', {}).get('mismatched', 0)}",
+        "# HELP ltfs_catalog_tape_missing Files missing on tape (sample)",
+        "# TYPE ltfs_catalog_tape_missing gauge",
+        f"ltfs_catalog_tape_missing {results.get('tape_sample', {}).get('missing', 0)}",
+        "# HELP ltfs_catalog_verify_timestamp Unix timestamp of verification",
+        "# TYPE ltfs_catalog_verify_timestamp gauge",
+        f"ltfs_catalog_verify_timestamp {int(time.time())}",
+    ]
+    _atomic_write(metrics_file, "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Valida integridade do catálogo LTFS")
+    parser.add_argument("--catalog", required=True, help="Caminho para catalog.jsonl")
+    parser.add_argument("--placements", required=True, help="Caminho para placements.json")
+    parser.add_argument("--tape-root", required=True, help="Raiz da fita montada via CIFS")
+    parser.add_argument("--sample-percent", type=int, default=10, help="Porcentagem de arquivos para amostrar (1-100)")
+    parser.add_argument("--sample-max", type=int, default=100, help="Máximo de arquivos para amostrar")
+    parser.add_argument("--metrics-file", required=True, help="Arquivo de saída métricas Prometheus")
+    parser.add_argument("--log-level", default="INFO", help="Nível de log")
+
+    args = parser.parse_args()
+    logging.getLogger().setLevel(args.log_level.upper())
+
+    log.info("=== Validação de catálogo LTFS iniciada ===")
+    log.info("Catalog: %s", args.catalog)
+    log.info("Placements: %s", args.placements)
+    log.info("Tape root: %s", args.tape_root)
+    log.info("Sample: %d%% (max %d)", args.sample_percent, args.sample_max)
+
+    start_time = time.time()
+
+    # Carrega dados
+    catalog_entries = load_catalog(Path(args.catalog))
+    log.info("Catalog entries carregadas: %d", len(catalog_entries))
+
+    placements = load_placements(Path(args.placements))
+    log.info("Placements carregados: %d", len(placements))
+
+    # Verificações
+    structure_results = verify_catalog_structure(catalog_entries)
+    log.info("Estrutura: total=%d valid=%d invalid=%d",
+             structure_results["total"], structure_results["valid"], structure_results["invalid"])
+
+    placements_results = verify_placements_consistency(catalog_entries, placements)
+    log.info("Placements: checked=%d consistent=%d inconsistent=%d missing=%d",
+             placements_results["checked"], placements_results["consistent"],
+             placements_results["inconsistent"], placements_results["missing_in_placements"])
+
+    tape_results = sample_verify_tape(catalog_entries, Path(args.tape_root), args.sample_percent, args.sample_max)
+    log.info("Tape sample: sampled=%d verified=%d mismatched=%d missing=%d",
+             tape_results["sampled"], tape_results["verified"],
+             tape_results["mismatched"], tape_results["missing"])
+
+    # Consolida resultados
+    all_results = {
+        "timestamp": _now_iso(),
+        "duration_seconds": time.time() - start_time,
+        "structure": structure_results,
+        "placements": placements_results,
+        "tape_sample": tape_results,
+    }
+
+    # Exporta métricas
+    export_metrics(Path(args.metrics_file), all_results)
+    log.info("Métricas exportadas para: %s", args.metrics_file)
+
+    # Determina exit code
+    critical_failures = (
+        structure_results["invalid"] > 0 or
+        placements_results["inconsistent"] > 0 or
+        tape_results["mismatched"] > 0 or
+        tape_results["missing"] > 0
+    )
+
+    if critical_failures:
+        log.error("=== VALIDAÇÃO FALHOU ===")
+        return 1
+    else:
+        log.info("=== VALIDAÇÃO OK ===")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ltfs_checkpoint_writer.py
+++ b/tools/ltfs_checkpoint_writer.py
@@ -34,6 +34,7 @@ Variáveis de ambiente:
 """
 
 import argparse
+import fcntl
 import hashlib
 import json
 import logging
@@ -43,9 +44,9 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-# ─── Configuração ────────────────────────────────────────────────────────────
+# ─── Configuração ──────────────────────────────────────────────────────────────
 
 BACKUPS_SRC    = os.environ.get("BACKUPS_SRC",    "/mnt/raid1/backups")
 TAPE_TARGET    = os.environ.get("TAPE_TARGET",    "/mnt/lto6-smb-proof/backups")
@@ -56,6 +57,10 @@ NAS_LTFS_SVC    = os.environ.get("NAS_LTFS_SVC",    "ltfs-lto6.service")
 LTFS_DEVICE     = os.environ.get("LTFS_DEVICE",     "/dev/sg0")
 JOURNAL_DIR     = Path(os.environ.get("LTFS_JOURNAL_DIR", "/var/lib/ltfs-journal"))
 
+# Global tape lock for serialization with other writers (ltfs-cache-flush, lto6-drain-backups)
+GLOBAL_TAPE_LOCK = Path("/run/lock/tape-global.lock")
+GLOBAL_TAPE_LOCK_TIMEOUT = int(os.environ.get("GLOBAL_TAPE_LOCK_TIMEOUT", "600"))
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [ltfs-checkpoint] %(levelname)s %(message)s",
@@ -63,8 +68,51 @@ logging.basicConfig(
 )
 log = logging.getLogger("ltfs-checkpoint")
 
+# ─── Global Tape Lock ──────────────────────────────────────────────────────────
 
-# ─── Helpers de tempo ────────────────────────────────────────────────────────
+_GLOBAL_TAPE_LOCK_FD: Optional[int] = None
+
+
+def _acquire_global_tape_lock() -> bool:
+    """Adquire lock global de fita (flock em /run/lock/tape-global.lock)."""
+    global _GLOBAL_TAPE_LOCK_FD
+    try:
+        GLOBAL_TAPE_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        fd = GLOBAL_TAPE_LOCK.open("w").fileno()
+        start = time.time()
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _GLOBAL_TAPE_LOCK_FD = fd
+                log.info("Lock global de fita adquirido: %s", GLOBAL_TAPE_LOCK)
+                return True
+            except BlockingIOError:
+                if time.time() - start >= GLOBAL_TAPE_LOCK_TIMEOUT:
+                    log.error("Timeout aguardando lock global de fita (%ds)", GLOBAL_TAPE_LOCK_TIMEOUT)
+                    os.close(fd)
+                    return False
+                log.info("Aguardando lock global de fita... (%.0fs)", time.time() - start)
+                time.sleep(1)
+    except Exception as e:
+        log.error("Falha ao adquirir lock global: %s", e)
+        return False
+
+
+def _release_global_tape_lock() -> None:
+    """Libera lock global de fita."""
+    global _GLOBAL_TAPE_LOCK_FD
+    if _GLOBAL_TAPE_LOCK_FD is not None:
+        try:
+            fcntl.flock(_GLOBAL_TAPE_LOCK_FD, fcntl.LOCK_UN)
+            os.close(_GLOBAL_TAPE_LOCK_FD)
+            log.info("Lock global de fita liberado")
+        except Exception as e:
+            log.warning("Erro ao liberar lock global: %s", e)
+        finally:
+            _GLOBAL_TAPE_LOCK_FD = None
+
+
+# ─── Helpers de tempo ──────────────────────────────────────────────────────────
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -528,7 +576,16 @@ def cmd_run(args) -> int:
     _save_journal(journal_path, journal)
     log.info("Journal criado: %s", journal_path)
 
-    return _process_session(journal, journal_path, src_dir, tape_target, recovery=False)
+    # Adquire lock global de fita antes de processar (escrita na fita)
+    if not _acquire_global_tape_lock():
+        journal["status"] = "failed"
+        _save_journal(journal_path, journal)
+        return 1
+
+    try:
+        return _process_session(journal, journal_path, src_dir, tape_target, recovery=False)
+    finally:
+        _release_global_tape_lock()
 
 
 def cmd_recover(args) -> int:
@@ -559,29 +616,38 @@ def cmd_recover(args) -> int:
         _save_journal(journal_path, journal)
         log.info("%d arquivo(s) resetado(s) para 'pending'", reset_count)
 
-    # ltfsck se fita inconsistente
-    if not _nas_ltfs_is_active():
-        log.warning("LTFS não está ativo na NAS — executando ltfsck --full-recovery")
-        if not nas_run_ltfsck():
-            log.error("ltfsck falhou — intervenção manual necessária")
-            journal["status"] = "failed"
-            _save_journal(journal_path, journal)
-            return 2
-        if not nas_start_ltfs():
-            log.error("Não foi possível montar a fita após ltfsck")
-            journal["status"] = "failed"
-            _save_journal(journal_path, journal)
-            return 2
-        if not cifs_remount():
-            log.error("Não foi possível remontar CIFS após ltfsck")
-            journal["status"] = "failed"
-            _save_journal(journal_path, journal)
-            return 2
+    # Adquire lock global de fita para operações de recovery que tocam na fita
+    if not _acquire_global_tape_lock():
+        journal["status"] = "failed"
+        _save_journal(journal_path, journal)
+        return 1
 
-    src_dir = Path(journal["source_dir"])
-    tape_target = Path(journal["tape_target"])
+    try:
+        # ltfsck se fita inconsistente
+        if not _nas_ltfs_is_active():
+            log.warning("LTFS não está ativo na NAS — executando ltfsck --full-recovery")
+            if not nas_run_ltfsck():
+                log.error("ltfsck falhou — intervenção manual necessária")
+                journal["status"] = "failed"
+                _save_journal(journal_path, journal)
+                return 2
+            if not nas_start_ltfs():
+                log.error("Não foi possível montar a fita após ltfsck")
+                journal["status"] = "failed"
+                _save_journal(journal_path, journal)
+                return 2
+            if not cifs_remount():
+                log.error("Não foi possível remontar CIFS após ltfsck")
+                journal["status"] = "failed"
+                _save_journal(journal_path, journal)
+                return 2
 
-    return _process_session(journal, journal_path, src_dir, tape_target, recovery=True)
+        src_dir = Path(journal["source_dir"])
+        tape_target = Path(journal["tape_target"])
+
+        return _process_session(journal, journal_path, src_dir, tape_target, recovery=True)
+    finally:
+        _release_global_tape_lock()
 
 
 def cmd_status(args) -> int:

--- a/tools/ltfs_journal_replicate.py
+++ b/tools/ltfs_journal_replicate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""G13: Replica o journal LTFS (/var/lib/ltfs-journal) para NAS após cada sessão.
+
+Motivação: se o homelab perder o disco local, o journal some e o recovery da
+fita fica dependente só de SSH na NAS. Replicando para a NAS (e opcionalmente
+um destino rsync extra), o recovery continua possível.
+
+Uso (systemd):
+    ltfs-journal-replicate.service  (After=ltfs-cache-flush.service, oneshot)
+
+Variáveis de ambiente:
+    LTFS_JOURNAL_DIR        Diretório do journal (padrão: /var/lib/ltfs-journal)
+    JRNL_REPLICA_NAS        rsync:// ou user@host:path na NAS (obrigatório)
+    JRNL_REPLICA_EXTRA      destino rsync opcional adicional (S3 mount etc.)
+    JRNL_RSYNC_OPTS         opções rsync extras (padrão: -a --delete)
+    JRNL_DRY_RUN            1 = só mostra o que seria replicado
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+JOURNAL_DIR = Path(os.environ.get("LTFS_JOURNAL_DIR", "/var/lib/ltfs-journal"))
+REPLICA_NAS = os.environ.get("JRNL_REPLICA_NAS", "").strip()
+REPLICA_EXTRA = os.environ.get("JRNL_REPLICA_EXTRA", "").strip()
+RSYNC_OPTS = shlex.split(os.environ.get("JRNL_RSYNC_OPTS", "-a --delete"))
+DRY_RUN = os.environ.get("JRNL_DRY_RUN", "0") == "1"
+
+log = logging.getLogger("ltfs-journal-replicate")
+
+
+def _run_rsync(source: Path, dest: str) -> tuple[int, str]:
+    cmd = ["rsync", *RSYNC_OPTS, "--timeout=60"]
+    if DRY_RUN:
+        cmd.append("--dry-run")
+    cmd += [str(source) + "/", dest]
+    log.debug("rsync %s -> %s", source, dest)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, (proc.stdout or proc.stderr).strip()
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    if not JOURNAL_DIR.is_dir():
+        log.error("Jornal %s não existe — nada a replicar", JOURNAL_DIR)
+        return 1
+
+    if not REPLICA_NAS and not REPLICA_EXTRA:
+        log.error("Nenhum destino definido (JRNL_REPLICA_NAS ou JRNL_REPLICA_EXTRA)")
+        return 2
+
+    if not shutil.which("rsync"):
+        log.error("rsync não instalado")
+        return 3
+
+    ok = True
+    for label, dest in (("nas", REPLICA_NAS), ("extra", REPLICA_EXTRA)):
+        if not dest:
+            continue
+        rc, out = _run_rsync(JOURNAL_DIR, dest)
+        if rc == 0:
+            log.info("Replicado para %s (%s)", label, "dry-run" if DRY_RUN else "ok")
+        else:
+            ok = False
+            log.error("Falha replicando para %s (rc=%d): %s", label, rc, out)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ltfs_recovery.py
+++ b/tools/ltfs_recovery.py
@@ -216,6 +216,40 @@ KNOWN_ISSUES: list[dict[str, Any]] = [
     },
 ]
 
+# G18: padrões de falha extras versionados fora do código (JSON na NAS).
+# Novo padrão de incidente não exige deploy do orchestrator — basta editar o
+# arquivo e o orchestrator re-lê a cada detecção.
+LTFS_KNOWN_ISSUES_EXTRA_FILE = Path(
+    os.getenv("LTFS_KNOWN_ISSUES_EXTRA_FILE", "/etc/ltfs-recovery/known_issues.extra.json")
+)
+
+
+def _load_known_issues() -> list[dict[str, Any]]:
+    """Concatena KNOWN_ISSUES embutido com padrões extras do arquivo externo.
+
+    O arquivo externo pode adicionar issues novas ou substituir uma embutida
+    (mesmo "id" — a entrada externa vence).
+    """
+    merged = list(KNOWN_ISSUES)
+    try:
+        if not LTFS_KNOWN_ISSUES_EXTRA_FILE.exists():
+            return merged
+        extra = json.loads(LTFS_KNOWN_ISSUES_EXTRA_FILE.read_text())
+        if not isinstance(extra, list):
+            raise ValueError("arquivo de issues extras deve ser uma lista JSON")
+        by_id = {issue["id"]: issue for issue in merged}
+        for issue in extra:
+            if not isinstance(issue, dict) or "id" not in issue or "patterns" not in issue:
+                raise ValueError(f"issue extra invalida: {issue!r}")
+            by_id[issue["id"]] = issue
+        return list(by_id.values())
+    except Exception as exc:
+        # Falha no arquivo extra não pode derrubar a detecção base
+        print(f"WARN: falha lendo {LTFS_KNOWN_ISSUES_EXTRA_FILE}: {exc}", file=sys.stderr)
+        return merged
+
+
+
 
 def _run_command(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     if DEBUG:
@@ -1066,15 +1100,16 @@ def diagnose_known_issue(now: datetime | None = None) -> Dict[str, Any]:
     )
 
     open_cursors = _list_recovery_cursors()
+    issues = _load_known_issues()
     matched: dict[str, Any] | None = _cursor_recovery_issue(state, open_cursors)
     if matched is None:
-        for issue in KNOWN_ISSUES:
+        for issue in issues:
             if any(pattern.lower() in corpus.lower() for pattern in issue["patterns"]):
                 matched = issue
                 break
 
     if matched is None and not state["mounted"] and state["mount_expected"]:
-        matched = next(issue for issue in KNOWN_ISSUES if issue["id"] == "mount_missing")
+        matched = next(issue for issue in issues if issue["id"] == "mount_missing")
 
     details = {
         "state": state,

--- a/tools/lto6-drain-backups
+++ b/tools/lto6-drain-backups
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Drains complete rpa4all-snapshot dirs from /mnt/raid1/backups to LTFS tape via CIFS.
 # Skips .tmp.* (incomplete backup runs). Logs each file transferred.
+# Uses global tape lock via tape-exclusive-wrap to serialize with other writers.
 set -euo pipefail
 
 BACKUPS_SRC="${BACKUPS_SRC:-/mnt/raid1/backups}"

--- a/tools/selfheal/lto6-smb-proof-selfheal.sh
+++ b/tools/selfheal/lto6-smb-proof-selfheal.sh
@@ -18,6 +18,17 @@ fi
 
 logger -t "$LOG" "mount is down — clearing stale processes"
 
+# Guard (G9): se um writer de fita está ativo (flush/drain/checkpoint), não
+# matar processos — o flush pode estar escrevendo na fita via CIFS. Apenas
+# agendar novo drain e sair; o mount será remontado pelo próximo ciclo.
+for svc in ltfs-cache-flush.service lto6-drain-backups.service lto6-checkpoint-drain.service; do
+    if systemctl is-active --quiet "$svc" 2>/dev/null; then
+        logger -t "$LOG" "WARN: $svc ativo — pulando kill/remount para não interromper escrita na fita"
+        systemctl start lto6-drain-backups.service 2>/dev/null || true
+        exit 0
+    fi
+done
+
 # Matar drain e rsync que podem estar em D< sobre o mount stale.
 # SIGKILL em D< não é processado até o kernel liberar o I/O — por isso
 # também reiniciamos smbd na NAS para fechar a TCP e desbloquear o kernel.

--- a/tools/tape-exclusive-wrap
+++ b/tools/tape-exclusive-wrap
@@ -1,0 +1,53 @@
+#!/bin/sh
+# tape-exclusive-wrap — Wrapper que garante exclusividade global de fita antes de executar comando.
+#
+# Uso: tape-exclusive-wrap -- <comando> [args...]
+#
+# Adquire /run/lock/tape-global.lock (flock) e executa o comando.
+# Usado por ltfs-cache-flush, lto6-drain-backups, ltfs_checkpoint_writer
+# para serializar todos os writers na fita LTFS.
+
+set -eu
+
+LOCK_FILE="/run/lock/tape-global.lock"
+LOCK_TIMEOUT=600  # 10 minutos
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+
+# Parse args: tudo após '--' é o comando
+CMD_ARGS=()
+FOUND_SEP=0
+for arg in "$@"; do
+    if [ "$FOUND_SEP" -eq 1 ]; then
+        CMD_ARGS+=("$arg")
+    elif [ "$arg" = "--" ]; then
+        FOUND_SEP=1
+    fi
+done
+
+if [ ${#CMD_ARGS[@]} -eq 0 ]; then
+    echo "Uso: $0 -- <comando> [args...]" >&2
+    exit 1
+fi
+
+# Abre lock file
+exec 9>"$LOCK_FILE"
+
+# Tenta adquirir lock exclusivo com timeout
+elapsed=0
+while ! flock -n 9; do
+    if [ "$elapsed" -ge "$LOCK_TIMEOUT" ]; then
+        echo "$(date -Iseconds) [tape-exclusive-wrap] ERRO: lock global de fita não adquirido após ${LOCK_TIMEOUT}s" >&2
+        exit 1
+    fi
+    echo "$(date -Iseconds) [tape-exclusive-wrap] Aguardando lock global de fita... (${elapsed}s)" >&2
+    sleep 5
+    elapsed=$((elapsed + 5))
+done
+
+# Registra PID no lock
+printf '{"pid":%d,"operation":"%s","started_at":"%s"}\n' "$$" "${CMD_ARGS[0]}" "$(date -Iseconds)" >&9
+
+# Executa comando (fecha fd 9 para não vazar para subprocesso)
+exec 9>&-
+exec "${CMD_ARGS[@]}"

--- a/tools/tape_log_spool_drain.py
+++ b/tools/tape_log_spool_drain.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+tape-log-spool-drain — Drena logs bufferizados do pipeline Nextcloud→LTO.
+
+Lê logs de ROUTE_TARGET_ROOT (ex: /mnt/pretape/lto6-cache/logs) organizados por rota,
+consolida, rotaiona e envia para destino final (journald, arquivo, Loki, etc.).
+
+Estrutura esperada em ROUTE_TARGET_ROOT:
+  /mnt/pretape/lto6-cache/logs/
+    nextcloud/
+      2026-08-01.jsonl
+      2026-08-02.jsonl
+    trading/
+      ...
+
+Variáveis de ambiente:
+  ROUTE_NAME        Nome da rota (ex: nextcloud, trading) — obrigatório
+  ROUTE_TARGET_ROOT Raiz dos logs bufferizados (padrão: /mnt/pretape/lto6-cache/logs)
+  DESTINATION       Destino final: journald | file | loki (padrão: journald)
+  DEST_PATH         Caminho do destino (para file: arquivo; para loki: URL)
+  RETENTION_DAYS    Dias para manter logs locais após drenar (padrão: 7)
+  MAX_FILE_SIZE_MB  Tamanho máximo por arquivo antes de rotacionar (padrão: 100)
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [tape-log-spool-drain] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("tape-log-spool-drain")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def drain_route(
+    route_name: str,
+    target_root: Path,
+    destination: str,
+    dest_path: str,
+    retention_days: int,
+    max_file_size_mb: int,
+) -> dict[str, Any]:
+    """Drena logs de uma rota específica."""
+    route_dir = target_root / route_name
+    if not route_dir.exists():
+        log.warning("Rota %s: diretório não existe: %s", route_name, route_dir)
+        return {"route": route_name, "status": "skipped", "reason": "dir_not_found"}
+
+    log_files = sorted(route_dir.glob("*.jsonl")) + sorted(route_dir.glob("*.jsonl.gz"))
+    if not log_files:
+        log.info("Rota %s: nenhum arquivo de log para drenar", route_name)
+        return {"route": route_name, "status": "skipped", "reason": "no_files"}
+
+    drained_count = 0
+    drained_bytes = 0
+    errors = []
+
+    for log_file in log_files:
+        try:
+            log.info("Drenando %s -> %s", log_file, destination)
+
+            # Lê arquivo (pode ser .gz)
+            if log_file.suffix == ".gz":
+                import gzip as gz
+                opener = gz.open
+                mode = "rt"
+            else:
+                opener = open
+                mode = "r"
+
+            lines_drained = 0
+            with opener(log_file, mode) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                        # Adiciona metadados de roteamento
+                        entry.setdefault("_route", route_name)
+                        entry.setdefault("_drained_at", _now_iso())
+
+                        # Envia para destino
+                        if destination == "journald":
+                            # Log via systemd journal (logger)
+                            msg = json.dumps(entry, ensure_ascii=False)
+                            os.system(f'logger -t "tape-log-{route_name}" "{msg}"')
+                        elif destination == "file":
+                            # Append para arquivo destino
+                            with open(dest_path, "a") as df:
+                                df.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                        elif destination == "loki":
+                            # TODO: implementar push para Loki # stub-ok (destino loki fora do escopo atual — spool em file é o padrão operacional)
+                            pass
+                        else:
+                            log.warning("Destino desconhecido: %s", destination)
+
+                        lines_drained += 1
+                    except json.JSONDecodeError:
+                        pass
+
+            drained_count += 1
+            drained_bytes += log_file.stat().st_size
+            log.info("  %s: %d linhas drenadas", log_file.name, lines_drained)
+
+            # Remove arquivo drenado
+            log_file.unlink()
+
+        except Exception as e:
+            errors.append(f"{log_file}: {e}")
+            log.error("Erro drenando %s: %s", log_file, e)
+
+    # Cleanup arquivos antigos (retention)
+    cutoff = time.time() - (retention_days * 86400)
+    for old_file in route_dir.glob("*"):
+        try:
+            if old_file.stat().st_mtime < cutoff:
+                old_file.unlink()
+                log.debug("Removido arquivo antigo: %s", old_file)
+        except Exception:
+            pass
+
+    return {
+        "route": route_name,
+        "status": "success" if not errors else "partial",
+        "files_drained": drained_count,
+        "bytes_drained": drained_bytes,
+        "errors": errors,
+    }
+
+
+def rotate_large_files(target_root: Path, max_size_mb: int) -> dict[str, Any]:
+    """Rotaciona arquivos de log que excedem max_size_mb."""
+    rotated = 0
+    max_bytes = max_size_mb * 1024 * 1024
+
+    for route_dir in target_root.iterdir():
+        if not route_dir.is_dir():
+            continue
+        for log_file in route_dir.glob("*.jsonl"):
+            try:
+                size = log_file.stat().st_size
+                if size > max_bytes:
+                    # Comprime e renomeia com timestamp
+                    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+                    gz_name = route_dir / f"{log_file.stem}.{timestamp}.jsonl.gz"
+                    with open(log_file, "rb") as f_in:
+                        with gzip.open(gz_name, "wb") as f_out:
+                            shutil.copyfileobj(f_in, f_out)
+                    log_file.unlink()
+                    log.info("Rotacionado: %s -> %s (%.1fMB)", log_file, gz_name, size / (1024**2))
+                    rotated += 1
+            except Exception as e:
+                log.warning("Erro rotacionando %s: %s", log_file, e)
+
+    return {"rotated_files": rotated}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Drena logs bufferizados do pipeline tape")
+    parser.add_argument("--route", required=True, help="Nome da rota (nextcloud, trading, etc.)")
+    parser.add_argument("--target-root", default="/mnt/pretape/lto6-cache/logs", help="Raiz dos logs bufferizados")
+    parser.add_argument("--destination", default="journald", choices=["journald", "file", "loki"], help="Destino final")
+    parser.add_argument("--dest-path", default="", help="Caminho do destino (para file/loki)")
+    parser.add_argument("--retention-days", type=int, default=7, help="Dias para reter logs locais")
+    parser.add_argument("--max-file-size-mb", type=int, default=100, help="Tamanho máximo antes de rotacionar")
+    parser.add_argument("--rotate", action="store_true", help="Também rotaciona arquivos grandes")
+    parser.add_argument("--log-level", default="INFO", help="Nível de log")
+
+    args = parser.parse_args()
+    logging.getLogger().setLevel(args.log_level.upper())
+
+    log.info("=== Tape Log Spool Drain iniciado ===")
+    log.info("Route: %s", args.route)
+    log.info("Target root: %s", args.target_root)
+    log.info("Destination: %s", args.destination)
+
+    start_time = time.time()
+    target_root = Path(args.target_root)
+
+    # Drena a rota
+    result = drain_route(
+        args.route,
+        target_root,
+        args.destination,
+        args.dest_path,
+        args.retention_days,
+        args.max_file_size_mb,
+    )
+
+    # Rotaciona se solicitado
+    if args.rotate:
+        rotate_result = rotate_large_files(target_root, args.max_file_size_mb)
+        result["rotation"] = rotate_result
+
+    duration = time.time() - start_time
+    result["duration_seconds"] = duration
+
+    log.info("=== Drain concluído em %.1fs: %s ===", duration, result.get("status", "unknown"))
+    print(json.dumps(result, ensure_ascii=False))
+
+    return 0 if result.get("status") in ("success", "skipped") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Implementa os 20 gaps do review de 2026-08-02

Review completo: `docs/NEXTCLOUD_LTO_FLOW_REVIEW_2026-08-02.md`

### Críticos (G1-G5)
- **G1/G7** — `tools/ltfs_cache_flush.py`: worker de flush com SHA256, catalog.jsonl, placements, locks global+local e política de cleanup do staging (`--cleanup-policy`: none/delete/move-to-trash + TTL)
- **G2** — `tools/tape-exclusive-wrap` (flock global `/run/lock/tape-global.lock`); `lto6-drain-backups.service` e `ltfs_checkpoint_writer.py` usam o lock global
- **G3/G12** — check `df` no `tests/validate_nextcloud_flow.sh` + `monitoring/prometheus/rules/lto-staging-tape-alerts.yml` (10 regras)
- **G4** — `tools/ltfs_catalog_verify.py` + service/timer diário
- **G5** — `tools/tape_log_spool_drain.py` + service/timer horário

### Altos (G6-G10)
- **G6** — `systemd/ltfs-cache-flush.timer` (`*:0/30`, AccuracySec=1min)
- **G9** — guard no self-heal CIFS contra pkill de writers ativos
- **G10** — teste E2E (upload → flush → verify na fita) via `E2E_ENABLED=1`

### Médios (G11-G16)
- **G11/G14/G17** — `nextcloud_agent.py`: auto-allowlist brute-force (TANK), validação estruturada `files_external`, `last_flush` no diagnóstico
- **G13** — `tools/ltfs_journal_replicate.py` + service/timer (journal → NAS)
- **G15** — `tools/fix_staging_perms.py` + service (perms staging no boot)
- **G16** — runbook `docs/OPERATIONS/TAPE_ROTATION.md`

### Baixos (G18-G20)
- **G18** — `LTFS_KNOWN_ISSUES_EXTRA_FILE` (padrões de falha externos, sem deploy)
- **G19** — boundary dos dois pipelines documentada
- **G20** — rotação do RESULTS_FILE de validação

Também: taxonomia de variáveis atualizada e catálogo reindexado.