### PR TITLE
docs(ollama): registra upgrade v0.32.5 em produção, LFM2.5-VL-450M destravado

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-03T11:23:23.908897+00:00",
+  "generated_at": "2026-08-03T11:53:48.315667+00:00",
   "repo_root": "/workspace/eddie-auto-dev",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T11:23:23.908897+00:00`
+- Generated at: `2026-08-03T11:53:48.315667+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `210`

--- a/docs/ARCHITECTURE_LFM25_MULTIMODAL_STATUS.md
+++ b/docs/ARCHITECTURE_LFM25_MULTIMODAL_STATUS.md
@@ -187,4 +187,38 @@ error starting llama-server: llama-server binary not found
 
 **Próxima tentativa:** Baixar release oficial completa do GitHub (tarball completo, não build local).
 
-**Próxima revisão:** após upgrade Ollama bem-sucedido e teste do VL-450M (meta: 2026-08-05)
+## ✅ Upgrade Ollama v0.32.5 — Concluído 2026-08-03
+
+**Causa raiz do incidente anterior:** não era a versão em si — era um binário canário/local incompleto usado nos primeiros testes. O asset oficial `ollama-linux-amd64.tar.zst` da release `v0.32.5` no GitHub é válido e completo (1.42GB, `sha256` consistente, inclui `bin/ollama` + `lib/ollama/*.so`, com CUDA `cuda_v12`/`cuda_v13` e Vulkan). URLs assinadas do GitHub (`release-assets.githubusercontent.com`) expiram em ~1h — downloads muito lentos podem falhar por expiração da URL, não por asset inexistente.
+
+**Descoberta importante:** desde ~v0.31, o Ollama usa layout de biblioteca dividida (`bin/ollama` dinamicamente ligado a `lib/ollama/*.so`), igual ao que já existia em produção em `/usr/local/lib/ollama/`. Não é mais um binário estático único — **substituir só `/usr/local/bin/ollama` sem sincronizar `/usr/local/lib/ollama/` quebra o serviço**.
+
+**Processo de validação usado (nenhuma etapa pulada):**
+1. Validado via GitHub API que o asset `ollama-linux-amd64.tar.zst` da v0.32.5 existe e tem `content-length` correto
+2. Download completo no servidor (1.422.353.729 bytes, batendo exato com o header) — versões anteriores tinham sido interrompidas por timeout/URL expirada
+3. Extraído e validado: binários são ELF válidos, `llama-server` presente (o incidente anterior tinha binário canário sem esse arquivo)
+4. **Testado isolado** (porta 11439, `systemd-run`/processo à parte, sem tocar produção) — `LFM2.5-VL-450M` carregou e gerou texto corretamente (erro `output_norm` ausente da v0.17.6 confirmado resolvido)
+5. **Aplicado em produção com cautela em 2 etapas:**
+   - Backup completo de `/usr/local/bin/ollama` + `/usr/local/lib/ollama/` (4.3GB) antes de qualquer mudança
+   - Binário trocado via `mv` atômico (evita erro `Text file busy` ao trocar arquivo em uso por processo já rodando)
+   - **GPU1 primeiro** (não-crítico): reiniciado, validado `lfm2.5-fast:gpu1` (produção) intacto, depois `LFM2.5-VL-450M` testado com CUDA real — funcionando
+   - **GPU0 por último** (trading-analyst ao vivo): checada exposição de trading antes (posição pequena ~$47, 0 trades em 7d, modo shadow) — reiniciado, `trading-analyst` recarregou em VRAM (~25s de load) e respondeu corretamente
+
+**Status final (2026-08-03 08:52 -03):**
+
+| Serviço | Versão | Status |
+|---------|--------|--------|
+| ollama (GPU0, RTX 3060) | v0.32.5 | ✅ `trading-analyst` residente, respondendo |
+| ollama-gpu1 (GTX 1050) | v0.32.5 | ✅ `lfm2.5-fast:gpu1` residente + `LFM2.5-VL-450M` testado |
+| ollama-gpu-coordinator | — | ✅ saudável, 3 endpoints ativos |
+
+**Backup para rollback (se necessário):**
+```bash
+sudo cp /usr/local/bin/ollama.backup.pre_v0325_20260803_084135 /usr/local/bin/ollama
+sudo rsync -a --delete /usr/local/lib/ollama.backup.pre_v0325_20260803_084135/ /usr/local/lib/ollama/
+sudo systemctl restart ollama ollama-gpu1
+```
+
+**Pendência:** `LFM2.5-VL-450M` ainda não está integrado como substituto do Moondream no fluxo de análise de imagem do Telegram — só foi validado tecnicamente. Isso é trabalho futuro separado.
+
+**Próxima revisão:** integrar VL-450M no pipeline de imagens do Telegram substituindo Moondream.

--- a/scripts/upgrade-ollama.sh
+++ b/scripts/upgrade-ollama.sh
@@ -1,132 +1,123 @@
 #!/bin/bash
 set -euo pipefail
 
-# Upgrade Ollama 0.17.6 → latest stable
+# Upgrade Ollama 0.17.6 → versão estável mais recente
 # Objetivo: destravar suporte a LFM2.5-VL-450M (tensor 'output_norm' faltando em 0.17.6)
-# Incidente 2026-08-02: binário canary incompleto (sem llama-server)
-# Solução: usar tarball oficial do GitHub releases + validar binários
+#
+# Histórico:
+# - Incidente 2026-08-02: binário canário incompleto (sem llama-server)
+# - Sucesso 2026-08-03: tarball oficial do GitHub, layout bin+lib validado, deploy em 2 etapas (GPU1 → GPU0)
+#
+# Desde ~v0.31, o Ollama usa layout de biblioteca dividida:
+#   bin/ollama (dinamicamente ligado) + lib/ollama/*.so (CUDA/Vulkan/CPU backends)
+# Substituir só o binário sem sincronizar lib/ollama quebra o serviço.
 
-echo "📦 Download e upgrade do Ollama..."
-
-# Usa latest stable do GitHub (não canary!)
-# Asset correto: ollama-linux-amd64.tar.zst (inclui llama-server + CUDA)
-VERSION_TAG="v0.32.5"
+VERSION_TAG="${1:-v0.32.5}"
 URL="https://github.com/ollama/ollama/releases/download/${VERSION_TAG}/ollama-linux-amd64.tar.zst"
 TMP_DIR="/tmp/ollama-upgrade-$$"
-BACKUP_DIR="/usr/local/bin/ollama.backup.$(date +%Y%m%d_%H%M%S)"
+TS="$(date +%Y%m%d_%H%M%S)"
+BIN_BACKUP="/usr/local/bin/ollama.backup.pre_${VERSION_TAG//./}_${TS}"
+LIB_BACKUP="/usr/local/lib/ollama.backup.pre_${VERSION_TAG//./}_${TS}"
 
-cleanup() {
-    rm -rf "$TMP_DIR"
-}
+cleanup() { rm -rf "$TMP_DIR"; }
 trap cleanup EXIT
 
-# 1. Download tarball oficial (.zst = zstd compressed)
-echo "→ Download da release oficial (${VERSION_TAG})..."
+echo "📦 Upgrade Ollama → ${VERSION_TAG}"
+
+# 1. Download tarball oficial (.tar.zst)
+echo "→ Download da release oficial..."
 mkdir -p "$TMP_DIR"
-
-# Usa curl com retry e timeout maior (download ~1.3GB pode demorar)
-if ! curl -L --connect-timeout 30 --max-time 3600 -o "${TMP_DIR}/ollama.tar.zst" "$URL"; then
-    echo "❌ Download falhou após timeout"
+if ! curl -fL --connect-timeout 30 --max-time 900 --retry 3 -o "${TMP_DIR}/ollama.tar.zst" "$URL"; then
+    echo "❌ Download falhou"
     exit 1
 fi
 
-# Verifica tamanho mínimo (deve ser >100MB para incluir todos os binários)
 FILE_SIZE=$(stat -c%s "${TMP_DIR}/ollama.tar.zst" 2>/dev/null || echo 0)
-if [[ $FILE_SIZE -lt 100000000 ]]; then
-    echo "❌ Arquivo baixado muito pequeno (${FILE_SIZE} bytes) — provavelmente página de erro"
-    cat "${TMP_DIR}/ollama.tar.zst" | head -3
+if [[ $FILE_SIZE -lt 500000000 ]]; then
+    echo "❌ Arquivo baixado muito pequeno (${FILE_SIZE} bytes) — provavelmente página de erro ou URL assinada expirada (validade ~1h)"
+    head -c 500 "${TMP_DIR}/ollama.tar.zst"
     exit 1
 fi
-echo "   Tamanho: $(echo "scale=2; $FILE_SIZE/1024/1024" | bc)MB ✅"
+echo "   Tamanho: $((FILE_SIZE / 1024 / 1024))MB ✅"
 
-# 2. Extrai (.zst = zstd)
-echo "→ Extraindo (zstd)..."
-if ! command -v unzstd &>/dev/null && ! command -v zstd &>/dev/null; then
-    echo "⚠️  zstd não encontrado, tentando com tar --use-compress-program..."
-    tar --use-compress-program=zstd -xf "${TMP_DIR}/ollama.tar.zst" -C "$TMP_DIR"
-else
-    unzstd -dk -o "${TMP_DIR}/ollama.tar" "${TMP_DIR}/ollama.tar.zst" 2>/dev/null || \
-    zstd -d -k -o "${TMP_DIR}/ollama.tar" "${TMP_DIR}/ollama.tar.zst"
-    tar -xf "${TMP_DIR}/ollama.tar" -C "$TMP_DIR"
-    rm "${TMP_DIR}/ollama.tar"
-fi
+# 2. Extrai (produz ./bin/ollama e ./lib/ollama/*)
+echo "→ Extraindo..."
+tar --use-compress-program=unzstd -xf "${TMP_DIR}/ollama.tar.zst" -C "$TMP_DIR"
 
-# 3. Valida presença de binários críticos
-echo "→ Validando integridade dos binários..."
-if [[ ! -f "${TMP_DIR}/ollama" ]]; then
-    echo "❌ Binário 'ollama' não encontrado no tarball"
+if [[ ! -f "${TMP_DIR}/bin/ollama" ]]; then
+    echo "❌ bin/ollama não encontrado no tarball"
     exit 1
 fi
-
-# Verifica se é ELF válido (não HTML/error page)
-if ! file "${TMP_DIR}/ollama" | grep -q "ELF"; then
-    echo "❌ Binário não é um executável válido (é uma página de erro?)"
-    cat "${TMP_DIR}/ollama" | head -5
+if [[ ! -f "${TMP_DIR}/lib/ollama/llama-server" ]]; then
+    echo "❌ lib/ollama/llama-server ausente — binário incompleto (mesmo problema do incidente 2026-08-02)"
     exit 1
 fi
+if ! file "${TMP_DIR}/bin/ollama" | grep -q "ELF"; then
+    echo "❌ bin/ollama não é um executável válido"
+    exit 1
+fi
+chmod +x "${TMP_DIR}/bin/ollama"
 
-chmod +x "${TMP_DIR}/ollama"
-
-# 4. Verifica versão baixada
-DOWNLOADED_VERSION=$("${TMP_DIR}/ollama" --version 2>&1 | grep -oP '\d+\.\d+\.\d+' || echo "desconhecida")
+DOWNLOADED_VERSION=$("${TMP_DIR}/bin/ollama" --version 2>&1 | grep -oP 'client version is \K[\d.]+' || echo "desconhecida")
 echo "   Versão baixada: ${DOWNLOADED_VERSION}"
 
-# 5. Backup da versão atual
-CURRENT_VERSION=$(/usr/local/bin/ollama --version 2>&1 | grep -oP '\d+\.\d+\.\d+' || echo "desconhecida")
-echo "   Versão atual: ${CURRENT_VERSION}"
-echo "→ Criando backup..."
-sudo cp /usr/local/bin/ollama "$BACKUP_DIR"
-sudo chown root:root "$BACKUP_DIR"
+# 3. Backup binário + lib atuais
+echo "→ Backup: ${BIN_BACKUP}, ${LIB_BACKUP}"
+sudo cp -a /usr/local/bin/ollama "$BIN_BACKUP"
+sudo cp -a /usr/local/lib/ollama "$LIB_BACKUP"
 
-# 6. Para serviço e substitui binário
-echo "→ Parando Ollama..."
-sudo pkill -9 ollama || true
-sleep 2
+rollback() {
+    echo "⚠️  Revertendo para backup..."
+    sudo cp "$BIN_BACKUP" /usr/local/bin/ollama
+    sudo rsync -a --delete "${LIB_BACKUP}/" /usr/local/lib/ollama/
+    sudo systemctl restart ollama-gpu1 2>/dev/null || true
+    sudo systemctl restart ollama 2>/dev/null || true
+    echo "Rollback concluído."
+}
 
-echo "→ Substituindo binário..."
-sudo cp "${TMP_DIR}/ollama" /usr/local/bin/ollama
-sudo chmod 755 /usr/local/bin/ollama
+# 4. Troca binário (via mv atômico — evita 'Text file busy' com serviço rodando) + lib
+echo "→ Substituindo binário e libs..."
+sudo cp "${TMP_DIR}/bin/ollama" /usr/local/bin/ollama.new
+sudo chmod 755 /usr/local/bin/ollama.new
+sudo chown root:root /usr/local/bin/ollama.new
+sudo mv /usr/local/bin/ollama.new /usr/local/bin/ollama
+sudo rsync -a --delete "${TMP_DIR}/lib/ollama/" /usr/local/lib/ollama/
+sudo chown -R root:root /usr/local/lib/ollama
 
-# 7. Inicia serviço
-echo "→ Iniciando Ollama..."
-sudo systemctl start ollama
-sleep 8
+# 5. GPU1 primeiro (não-crítico) — depois GPU0 (trading, por último e com cautela)
+for svc in ollama-gpu1 ollama; do
+    echo "→ Reiniciando ${svc}..."
+    sudo systemctl restart "$svc"
+    sleep 10
 
-# 8. Verifica saúde
-echo "→ Verificando saúde..."
-if curl -s --max-time 10 http://127.0.0.1:11434/api/tags > /dev/null; then
-    echo "✅ Ollama respondendo"
-else
-    echo "❌ Ollama não respondeu — revertendo..."
-    sudo pkill -9 ollama || true
-    sudo cp "$BACKUP_DIR" /usr/local/bin/ollama
-    sudo systemctl start ollama
-    exit 1
-fi
+    port=11434
+    [[ "$svc" == "ollama-gpu1" ]] && port=11435
 
-# 9. Testa geração real (não só API tags)
-echo "→ Testando geração com modelo existente..."
-TEST_OUTPUT=$(timeout 60 curl -s -X POST http://127.0.0.1:11434/api/generate \
-    -H "Content-Type: application/json" \
-    -d '{"model":"gemma3:1b","prompt":"test","stream":false}' 2>&1)
+    ok=""
+    for i in $(seq 1 12); do
+        if curl -sf --max-time 3 "http://127.0.0.1:${port}/api/version" > /dev/null; then
+            ok=1
+            break
+        fi
+        sleep 5
+    done
 
-if echo "$TEST_OUTPUT" | grep -q '"done":true'; then
-    echo "✅ Geração funcionando"
-else
-    echo "⚠️  Geração falhou (pode ser problema de modelo, não do binário):"
-    echo "$TEST_OUTPUT" | head -c 200
-fi
+    if [[ -z "$ok" ]]; then
+        echo "❌ ${svc} não respondeu em ${port} após restart"
+        rollback
+        exit 1
+    fi
+    echo "✅ ${svc} respondendo em ${port} ($(curl -s http://127.0.0.1:${port}/api/version))"
+done
 
 echo ""
-echo "📊 Resumo:"
-echo "   Versão anterior: ${CURRENT_VERSION}"
-echo "   Versão instalada: ${DOWNLOADED_VERSION}"
-echo "   Backup: ${BACKUP_DIR}"
+echo "📊 Resumo: ${DOWNLOADED_VERSION} instalado em ambos os serviços GPU0/GPU1"
+echo "   Backup binário: ${BIN_BACKUP}"
+echo "   Backup libs:    ${LIB_BACKUP}"
 echo ""
-echo "📋 Para testar LFM2.5-VL-450M:"
-echo "   ollama run hf.co/LiquidAI/LFM2.5-VL-450M-GGUF:Q4_K_M:gpu1 'descreva esta imagem' <img.jpg"
-echo ""
-echo "⚠️  Se houver problemas, rollback manual:"
-echo "   sudo cp ${BACKUP_DIR} /usr/local/bin/ollama && sudo systemctl restart ollama"
+echo "⚠️  Rollback manual se necessário:"
+echo "   sudo cp ${BIN_BACKUP} /usr/local/bin/ollama"
+echo "   sudo rsync -a --delete ${LIB_BACKUP}/ /usr/local/lib/ollama/"
+echo "   sudo systemctl restart ollama-gpu1 ollama"
 echo ""
 echo "✅ Upgrade concluído!"


### PR DESCRIPTION
## Summary
- Upgrade Ollama v0.17.6 → v0.32.5 aplicado com sucesso em produção (GPU0/trading-analyst + GPU1) após validação isolada
- Confirmado: erro `output_norm` ausente que bloqueava LFM2.5-VL-450M está resolvido
- `scripts/upgrade-ollama.sh` corrigido para o layout `bin/`+`lib/ollama/*.so` (desde ~v0.31) e para os serviços reais do cluster (GPU1 primeiro, GPU0/trading por último, com backup+rollback)
- Documentação completa do processo de validação em `docs/ARCHITECTURE_LFM25_MULTIMODAL_STATUS.md`

## Test plan
- [x] Binário validado via GitHub API (asset existe, content-length correto)
- [x] Testado isolado em porta separada (11439) sem tocar produção — VL-450M carregou e gerou texto
- [x] GPU1 (não-crítico) atualizado primeiro, `lfm2.5-fast:gpu1` de produção confirmado intacto
- [x] VL-450M testado com CUDA real em produção (GPU1)
- [x] Exposição de trading checada antes de reiniciar GPU0 (posição pequena, 0 trades em 7d)
- [x] GPU0 atualizado, `trading-analyst` recarregou e respondeu corretamente
- [x] Coordenador (`ollama-gpu-coordinator`) confirmado saudável com os 3 endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)