### PR TITLE
feat: STT faster-whisper + visão padronizada (vision-moondream) + fix memory MCP via ssh

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,11 @@
 {
   "mcpServers": {
     "homelab": {
-      "command": "/workspace/eddie-auto-dev/.venv/bin/python",
+      "command": "ssh",
       "args": [
-        "/workspace/eddie-auto-dev/scripts/homelab_mcp_server.py"
-      ],
-      "env": {
-        "HOMELAB_URL": "http://192.168.15.2:8503",
-        "SECRETS_AGENT_URL": "http://192.168.15.2:8088",
-        "API_BASE_URL": "http://192.168.15.2:3000"
-      }
+        "homelab",
+        "set -a; . /etc/default/eddie-common; set +a; exec /home/homelab/mcp/venv/bin/python /home/homelab/myClaude/scripts/homelab_mcp_server.py"
+      ]
     },
     "telegram": {
       "command": "ssh",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-03T03:33:04.557358+00:00",
+  "generated_at": "2026-08-03T12:51:25.288108+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-08-03T11:23:23.908897+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-08-03T03:33:04.557358+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 210,
+    "repo_services": 211,
     "trading_instances": 12,
     "critical_services": 85,
     "domains": {
       "identity": 4,
       "monitoring": 19,
       "network": 23,
-      "operations": 114,
+      "operations": 115,
       "storage": 39,
       "trading": 11
     }
@@ -29,7 +29,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "subconta (BTCAgressive)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "activate_script": null
     },
     {
@@ -42,7 +42,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "subconta (BTCConservative)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "activate_script": null
     },
     {
@@ -970,6 +970,14 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "faster-whisper-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/faster-whisper-api.service",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },
@@ -2908,7 +2916,7 @@
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading agent BTC-USDT perfil aggressive (live) \u2014 subconta (BTCAgressive).",
+      "description": "Trading agent BTC-USDT perfil aggressive (live) \u2014 master TRADE (kucoin/homelab).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "aggressive",
@@ -2917,7 +2925,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "subconta (BTCAgressive)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "systemd_instance": "BTC_USDT_aggressive",
       "prometheus_job": "crypto-exporter-btc_usdt_aggressive",
       "activate_script": null,
@@ -2927,7 +2935,7 @@
     {
       "name": "crypto-exporter@BTC_USDT_aggressive.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading exporter BTC-USDT perfil aggressive (live) \u2014 subconta (BTCAgressive).",
+      "description": "Trading exporter BTC-USDT perfil aggressive (live) \u2014 master TRADE (kucoin/homelab).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "aggressive",
@@ -2936,7 +2944,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "subconta (BTCAgressive)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "systemd_instance": "BTC_USDT_aggressive",
       "prometheus_job": "crypto-exporter-btc_usdt_aggressive",
       "activate_script": null,
@@ -2946,7 +2954,7 @@
     {
       "name": "crypto-agent@BTC_USDT_conservative.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading agent BTC-USDT perfil conservative (live) \u2014 subconta (BTCConservative).",
+      "description": "Trading agent BTC-USDT perfil conservative (live) \u2014 master TRADE (kucoin/homelab).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "conservative",
@@ -2955,7 +2963,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "subconta (BTCConservative)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "systemd_instance": "BTC_USDT_conservative",
       "prometheus_job": "crypto-exporter-btc_usdt_conservative",
       "activate_script": null,
@@ -2965,7 +2973,7 @@
     {
       "name": "crypto-exporter@BTC_USDT_conservative.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading exporter BTC-USDT perfil conservative (live) \u2014 subconta (BTCConservative).",
+      "description": "Trading exporter BTC-USDT perfil conservative (live) \u2014 master TRADE (kucoin/homelab).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "conservative",
@@ -2974,7 +2982,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "subconta (BTCConservative)",
+      "kucoin_account": "master TRADE (kucoin/homelab)",
       "systemd_instance": "BTC_USDT_conservative",
       "prometheus_job": "crypto-exporter-btc_usdt_conservative",
       "activate_script": null,

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-03T12:51:25.288108+00:00",
+  "generated_at": "2026-08-03T12:53:11.754236+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-plucky-rabbit",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
@@ -29,7 +29,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCAgressive)",
       "activate_script": null
     },
     {
@@ -42,7 +42,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCConservative)",
       "activate_script": null
     },
     {
@@ -2916,7 +2916,7 @@
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading agent BTC-USDT perfil aggressive (live) \u2014 master TRADE (kucoin/homelab).",
+      "description": "Trading agent BTC-USDT perfil aggressive (live) \u2014 subconta (BTCAgressive).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "aggressive",
@@ -2925,7 +2925,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCAgressive)",
       "systemd_instance": "BTC_USDT_aggressive",
       "prometheus_job": "crypto-exporter-btc_usdt_aggressive",
       "activate_script": null,
@@ -2935,7 +2935,7 @@
     {
       "name": "crypto-exporter@BTC_USDT_aggressive.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading exporter BTC-USDT perfil aggressive (live) \u2014 master TRADE (kucoin/homelab).",
+      "description": "Trading exporter BTC-USDT perfil aggressive (live) \u2014 subconta (BTCAgressive).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "aggressive",
@@ -2944,7 +2944,7 @@
       "live_mode": true,
       "metrics_port": 9095,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCAgressive)",
       "systemd_instance": "BTC_USDT_aggressive",
       "prometheus_job": "crypto-exporter-btc_usdt_aggressive",
       "activate_script": null,
@@ -2954,7 +2954,7 @@
     {
       "name": "crypto-agent@BTC_USDT_conservative.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading agent BTC-USDT perfil conservative (live) \u2014 master TRADE (kucoin/homelab).",
+      "description": "Trading agent BTC-USDT perfil conservative (live) \u2014 subconta (BTCConservative).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "conservative",
@@ -2963,7 +2963,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCConservative)",
       "systemd_instance": "BTC_USDT_conservative",
       "prometheus_job": "crypto-exporter-btc_usdt_conservative",
       "activate_script": null,
@@ -2973,7 +2973,7 @@
     {
       "name": "crypto-exporter@BTC_USDT_conservative.service",
       "source": "scripts/cmdb/generate_cmdb_baseline.py",
-      "description": "Trading exporter BTC-USDT perfil conservative (live) \u2014 master TRADE (kucoin/homelab).",
+      "description": "Trading exporter BTC-USDT perfil conservative (live) \u2014 subconta (BTCConservative).",
       "domain": "trading",
       "symbol": "BTC-USDT",
       "profile": "conservative",
@@ -2982,7 +2982,7 @@
       "live_mode": true,
       "metrics_port": 9094,
       "api_port": null,
-      "kucoin_account": "master TRADE (kucoin/homelab)",
+      "kucoin_account": "subconta (BTCConservative)",
       "systemd_instance": "BTC_USDT_conservative",
       "prometheus_job": "crypto-exporter-btc_usdt_conservative",
       "activate_script": null,

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T12:51:25.288108+00:00`
+- Generated at: `2026-08-03T12:53:11.754236+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`
@@ -19,8 +19,8 @@
 
 ## Trading profile instances (`12`)
 
-- `BTC_USDT_aggressive` → `BTC-USDT` / `aggressive` (live, metrics `:9095`) — `master TRADE (kucoin/homelab)`
-- `BTC_USDT_conservative` → `BTC-USDT` / `conservative` (live, metrics `:9094`) — `master TRADE (kucoin/homelab)`
+- `BTC_USDT_aggressive` → `BTC-USDT` / `aggressive` (live, metrics `:9095`) — `subconta (BTCAgressive)`
+- `BTC_USDT_conservative` → `BTC-USDT` / `conservative` (live, metrics `:9094`) — `subconta (BTCConservative)`
 - `BTC_USDT_shadow` → `BTC-USDT` / `shadow` (live, metrics `:9099`) — `subconta (BTCAgressive)`
 - `DOGE_USDT_aggressive` → `DOGE-USDT` / `aggressive` (live, metrics `:9114`) — `master TRADE (kucoin/homelab) — mesma conta do SOL`
 - `DOGE_USDT_conservative` → `DOGE-USDT` / `conservative` (live, metrics `:9113`) — `master TRADE (kucoin/homelab) — mesma conta do SOL`
@@ -155,7 +155,7 @@
 - target_device: `homelab`
 
 ### `crypto-agent@BTC_USDT_aggressive.service`
-- Descrição: Trading agent BTC-USDT perfil aggressive (live) — master TRADE (kucoin/homelab).
+- Descrição: Trading agent BTC-USDT perfil aggressive (live) — subconta (BTCAgressive).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -165,14 +165,14 @@
 - live_mode: `True`
 - metrics_port: `9095`
 - api_port: `None`
-- kucoin_account: `master TRADE (kucoin/homelab)`
+- kucoin_account: `subconta (BTCAgressive)`
 - systemd_instance: `BTC_USDT_aggressive`
 - prometheus_job: `crypto-exporter-btc_usdt_aggressive`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-exporter@BTC_USDT_aggressive.service`
-- Descrição: Trading exporter BTC-USDT perfil aggressive (live) — master TRADE (kucoin/homelab).
+- Descrição: Trading exporter BTC-USDT perfil aggressive (live) — subconta (BTCAgressive).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -182,14 +182,14 @@
 - live_mode: `True`
 - metrics_port: `9095`
 - api_port: `None`
-- kucoin_account: `master TRADE (kucoin/homelab)`
+- kucoin_account: `subconta (BTCAgressive)`
 - systemd_instance: `BTC_USDT_aggressive`
 - prometheus_job: `crypto-exporter-btc_usdt_aggressive`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-agent@BTC_USDT_conservative.service`
-- Descrição: Trading agent BTC-USDT perfil conservative (live) — master TRADE (kucoin/homelab).
+- Descrição: Trading agent BTC-USDT perfil conservative (live) — subconta (BTCConservative).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -199,14 +199,14 @@
 - live_mode: `True`
 - metrics_port: `9094`
 - api_port: `None`
-- kucoin_account: `master TRADE (kucoin/homelab)`
+- kucoin_account: `subconta (BTCConservative)`
 - systemd_instance: `BTC_USDT_conservative`
 - prometheus_job: `crypto-exporter-btc_usdt_conservative`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-exporter@BTC_USDT_conservative.service`
-- Descrição: Trading exporter BTC-USDT perfil conservative (live) — master TRADE (kucoin/homelab).
+- Descrição: Trading exporter BTC-USDT perfil conservative (live) — subconta (BTCConservative).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -216,7 +216,7 @@
 - live_mode: `True`
 - metrics_port: `9094`
 - api_port: `None`
-- kucoin_account: `master TRADE (kucoin/homelab)`
+- kucoin_account: `subconta (BTCConservative)`
 - systemd_instance: `BTC_USDT_conservative`
 - prometheus_job: `crypto-exporter-btc_usdt_conservative`
 - activate_script: `None`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T11:23:23.908897+00:00`
+- Generated at: `2026-08-03T03:33:04.557358+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `210`
+- Repo services discovered: `211`
 - Critical services flagged for MVP: `85`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,14 +13,14 @@
 - `identity`: 4
 - `monitoring`: 19
 - `network`: 23
-- `operations`: 114
+- `operations`: 115
 - `storage`: 39
 - `trading`: 11
 
 ## Trading profile instances (`12`)
 
-- `BTC_USDT_aggressive` → `BTC-USDT` / `aggressive` (live, metrics `:9095`) — `subconta (BTCAgressive)`
-- `BTC_USDT_conservative` → `BTC-USDT` / `conservative` (live, metrics `:9094`) — `subconta (BTCConservative)`
+- `BTC_USDT_aggressive` → `BTC-USDT` / `aggressive` (live, metrics `:9095`) — `master TRADE (kucoin/homelab)`
+- `BTC_USDT_conservative` → `BTC-USDT` / `conservative` (live, metrics `:9094`) — `master TRADE (kucoin/homelab)`
 - `BTC_USDT_shadow` → `BTC-USDT` / `shadow` (live, metrics `:9099`) — `subconta (BTCAgressive)`
 - `DOGE_USDT_aggressive` → `DOGE-USDT` / `aggressive` (live, metrics `:9114`) — `master TRADE (kucoin/homelab) — mesma conta do SOL`
 - `DOGE_USDT_conservative` → `DOGE-USDT` / `conservative` (live, metrics `:9113`) — `master TRADE (kucoin/homelab) — mesma conta do SOL`
@@ -155,7 +155,7 @@
 - target_device: `homelab`
 
 ### `crypto-agent@BTC_USDT_aggressive.service`
-- Descrição: Trading agent BTC-USDT perfil aggressive (live) — subconta (BTCAgressive).
+- Descrição: Trading agent BTC-USDT perfil aggressive (live) — master TRADE (kucoin/homelab).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -165,14 +165,14 @@
 - live_mode: `True`
 - metrics_port: `9095`
 - api_port: `None`
-- kucoin_account: `subconta (BTCAgressive)`
+- kucoin_account: `master TRADE (kucoin/homelab)`
 - systemd_instance: `BTC_USDT_aggressive`
 - prometheus_job: `crypto-exporter-btc_usdt_aggressive`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-exporter@BTC_USDT_aggressive.service`
-- Descrição: Trading exporter BTC-USDT perfil aggressive (live) — subconta (BTCAgressive).
+- Descrição: Trading exporter BTC-USDT perfil aggressive (live) — master TRADE (kucoin/homelab).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -182,14 +182,14 @@
 - live_mode: `True`
 - metrics_port: `9095`
 - api_port: `None`
-- kucoin_account: `subconta (BTCAgressive)`
+- kucoin_account: `master TRADE (kucoin/homelab)`
 - systemd_instance: `BTC_USDT_aggressive`
 - prometheus_job: `crypto-exporter-btc_usdt_aggressive`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-agent@BTC_USDT_conservative.service`
-- Descrição: Trading agent BTC-USDT perfil conservative (live) — subconta (BTCConservative).
+- Descrição: Trading agent BTC-USDT perfil conservative (live) — master TRADE (kucoin/homelab).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -199,14 +199,14 @@
 - live_mode: `True`
 - metrics_port: `9094`
 - api_port: `None`
-- kucoin_account: `subconta (BTCConservative)`
+- kucoin_account: `master TRADE (kucoin/homelab)`
 - systemd_instance: `BTC_USDT_conservative`
 - prometheus_job: `crypto-exporter-btc_usdt_conservative`
 - activate_script: `None`
 - auto_generated: `True`
 
 ### `crypto-exporter@BTC_USDT_conservative.service`
-- Descrição: Trading exporter BTC-USDT perfil conservative (live) — subconta (BTCConservative).
+- Descrição: Trading exporter BTC-USDT perfil conservative (live) — master TRADE (kucoin/homelab).
 - source: `scripts/cmdb/generate_cmdb_baseline.py`
 - domain: `trading`
 - symbol: `BTC-USDT`
@@ -216,7 +216,7 @@
 - live_mode: `True`
 - metrics_port: `9094`
 - api_port: `None`
-- kucoin_account: `subconta (BTCConservative)`
+- kucoin_account: `master TRADE (kucoin/homelab)`
 - systemd_instance: `BTC_USDT_conservative`
 - prometheus_job: `crypto-exporter-btc_usdt_conservative`
 - activate_script: `None`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T03:33:04.557358+00:00`
+- Generated at: `2026-08-03T12:51:25.288108+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`

--- a/scripts/faster_whisper_api.py
+++ b/scripts/faster_whisper_api.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""API de transcrição de áudio via faster-whisper (STT local).
+
+Política do homelab: whisper/aux só na VRAM livre — nunca despejar trading.
+Por padrão roda em CPU (zero interferência na GPU0); `WHISPER_DEVICE=cuda`
+liga o backend CUDA quando houver folga comprovada de VRAM.
+
+Endpoints:
+    GET  /health       → {status, model, device, compute_type, language}
+    POST /transcribe   → multipart (file, language?, task?, word_timestamps?)
+                         {text, language, language_probability, duration, segments}
+
+Usage:
+    uvicorn faster_whisper_api:app --host 0.0.0.0 --port 8087
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="Faster Whisper API", version="1.0.0")
+
+MODEL_NAME = os.environ.get("WHISPER_MODEL", "small")
+DEVICE = os.environ.get("WHISPER_DEVICE", "cpu")
+COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "int8")
+CACHE_DIR = os.environ.get("WHISPER_CACHE_DIR", "/home/homelab/models/whisper")
+
+_model = None
+_model_lock = None
+
+
+def _get_model():
+    global _model, _model_lock
+    if _model is None:
+        import threading
+
+        _model_lock = threading.Lock()
+        with _model_lock:
+            if _model is None:
+                from faster_whisper import WhisperModel
+
+                os.makedirs(CACHE_DIR, exist_ok=True)
+                _model = WhisperModel(
+                    MODEL_NAME,
+                    device=DEVICE,
+                    compute_type=COMPUTE_TYPE,
+                    download_root=CACHE_DIR,
+                )
+    return _model
+
+
+def _run_transcription(file_path: str, language: str | None, task: str,
+                       word_timestamps: bool) -> dict:
+    model = _get_model()
+    t0 = time.monotonic()
+    segments, info = model.transcribe(
+        file_path,
+        language=language or None,
+        task=task,
+        word_timestamps=word_timestamps,
+    )
+    seg_list = []
+    text_parts = []
+    for seg in segments:
+        seg_list.append({
+            "start": round(seg.start, 2),
+            "end": round(seg.end, 2),
+            "text": seg.text.strip(),
+        })
+        text_parts.append(seg.text.strip())
+    elapsed = round(time.monotonic() - t0, 2)
+    return {
+        "text": " ".join(p for p in text_parts if p).strip(),
+        "language": info.language,
+        "language_probability": round(float(info.language_probability), 3),
+        "duration": round(info.duration, 2),
+        "segments": seg_list,
+        "elapsed_s": elapsed,
+        "model": MODEL_NAME,
+        "device": DEVICE,
+        "compute_type": COMPUTE_TYPE,
+    }
+
+
+@app.get("/health")
+def health():
+    return JSONResponse({
+        "status": "ok",
+        "model": MODEL_NAME,
+        "device": DEVICE,
+        "compute_type": COMPUTE_TYPE,
+        "cache_dir": CACHE_DIR,
+    })
+
+
+@app.post("/transcribe")
+async def transcribe(
+    file: UploadFile = File(...),
+    language: str | None = Form(None),
+    task: str = Form("transcribe"),
+    word_timestamps: bool = Form(False),
+):
+    if task not in ("transcribe", "translate"):
+        raise HTTPException(400, "task deve ser 'transcribe' ou 'translate'")
+    suffix = os.path.splitext(file.filename or "")[1] or ".wav"
+    if suffix.lower() not in {".wav", ".mp3", ".ogg", ".m4a", ".flac", ".webm", ".opus", ".mp4"}:
+        suffix = ".wav"
+    fd, tmp_path = tempfile.mkstemp(suffix=suffix, prefix="whisper_")
+    try:
+        with os.fdopen(fd, "wb") as out:
+            out.write(await file.read())
+        try:
+            result = _run_transcription(tmp_path, language, task, word_timestamps)
+        except Exception as exc:
+            raise HTTPException(500, f"transcrição falhou: {exc}") from exc
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+    return JSONResponse(result)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("WHISPER_PORT", "8087"))
+    uvicorn.run(app, host=os.environ.get("WHISPER_HOST", "0.0.0.0"), port=port)

--- a/systemd/faster-whisper-api.service
+++ b/systemd/faster-whisper-api.service
@@ -1,0 +1,36 @@
+# faster-whisper-api.service — STT local (transcrição de áudio)
+# Política: whisper/aux nunca despejam trading — roda em CPU por padrão
+# (WHISPER_DEVICE=cuda só com folga de VRAM comprovada na GPU0).
+#
+# Instalação:
+#   sudo cp systemd/faster-whisper-api.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable --now faster-whisper-api
+
+[Unit]
+Description=Faster Whisper API — transcrição de áudio local (porta 8087)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+
+User=homelab
+Group=homelab
+
+Environment=WHISPER_MODEL=small
+Environment=WHISPER_DEVICE=cpu
+Environment=WHISPER_COMPUTE_TYPE=int8
+Environment=WHISPER_CACHE_DIR=/home/homelab/models/whisper
+Environment=WHISPER_HOST=0.0.0.0
+Environment=WHISPER_PORT=8087
+
+ExecStart=/home/homelab/myClaude/venv/bin/python /home/homelab/eddie-auto-dev/scripts/faster_whisper_api.py
+
+# CPU/IO sem competir com trading (GPU0) nem com o coordinator
+CPUWeight=50
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/ollama_gpu_coordinator.py
+++ b/tools/ollama_gpu_coordinator.py
@@ -161,6 +161,9 @@ _VRAM_ESTIMATES: list[tuple[str, int]] = [
     # modelos nomeados
     ("trading-analyst", 6500), ("gemma3", 1000), ("smollm", 600),
     ("moondream", 1700), ("lfm2.5-vl", 500), ("lfm2", 1100), ("lfm", 1100),
+    # aliases canônicos de visão (vision-*)
+    ("vision", 1700), ("vision-moondream", 1700), ("vision-vl", 500),
+    ("vision-gemma3", 1000),
     ("phi4-mini", 2500), ("phi3", 2200), ("llama3.2", 900),
     # GPU1 GGUF quant (Q4_0 / IQ3) — pesos ~0.7–0.9GB + KV
     ("lfm2.5", 900), ("smollm2", 900), ("smollm", 800),

--- a/tools/telegram_mcp_server.py
+++ b/tools/telegram_mcp_server.py
@@ -41,6 +41,7 @@ TG_FILE    = f"https://api.telegram.org/file/bot{TG_TOKEN}"
 OLLAMA_BASE    = os.environ.get("OLLAMA_BASE", "http://192.168.15.2:11434")
 TEXT_MODEL     = os.environ.get("TEXT_MODEL", "phi4-mini:latest")
 VISION_MODEL   = os.environ.get("VISION_MODEL", "moondream:latest")
+STT_URL        = os.environ.get("STT_URL", "http://127.0.0.1:8087/transcribe")
 MEDIA_DIR      = Path(os.environ.get("MEDIA_DIR", "/tmp/tg_media"))
 MEDIA_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -93,6 +94,23 @@ async def ollama_chat(client: httpx.AsyncClient, model: str, prompt: str,
 def _vision_available(client: httpx.AsyncClient) -> bool:
     # verificado dinamicamente no primeiro uso
     return True
+
+
+async def stt_transcribe(client: httpx.AsyncClient, audio_path: Path) -> str:
+    """Transcreve áudio via faster-whisper API (STT local)."""
+    try:
+        with open(audio_path, "rb") as f:
+            data = f.read()
+        r = await client.post(
+            STT_URL,
+            files={"file": (audio_path.name, data)},
+            timeout=httpx.Timeout(300.0, connect=10.0),
+        )
+        if r.status_code != 200:
+            return f"[stt error: HTTP {r.status_code}]"
+        return (r.json().get("text") or "").strip()
+    except Exception as e:
+        return f"[stt error: {e}]"
 
 
 def _parse_message(msg: dict) -> dict:
@@ -227,7 +245,21 @@ async def _analyze_message(client: httpx.AsyncClient, parsed: dict,
         path = await tg_download(client, parsed["file_id"])
         if path:
             parsed["local_path"] = str(path)
-            parsed["ai_analysis"] = f"[áudio {parsed.get('duration', '?')}s — transcrição requer whisper]"
+            transcript = await stt_transcribe(client, path)
+            if transcript.startswith("[stt error"):
+                parsed["ai_analysis"] = (
+                    f"[áudio {parsed.get('duration', '?')}s — transcrição indisponível: {transcript}]"
+                )
+            else:
+                parsed["ai_analysis"] = (
+                    f"[áudio {parsed.get('duration', '?')}s — transcrição]: {transcript}"
+                )
+                parsed["transcript"] = transcript
+                intent_prompt = (
+                    f"Transcrição de mensagem de voz: '{transcript[:400]}'\n"
+                    "Em uma frase: qual é a intenção/pedido do usuário?"
+                )
+                parsed["intent"] = await ollama_chat(client, TEXT_MODEL, intent_prompt)
 
     return parsed
 


### PR DESCRIPTION
## STT / Visão
- `scripts/faster_whisper_api.py` + `systemd/faster-whisper-api.service`: API local de transcrição (:8087, modelo small CPU int8) — política: nunca despejar trading na GPU0.
- `tools/ollama_gpu_coordinator.py`: estimativas VRAM para aliases `vision-*` no registry.
- `tools/telegram_mcp_server.py`: voz/áudio transcritos via STT_URL (fallback seguro).

## MCP memory fix
- `.mcp.json`: homelab MCP server agora roda **no homelab via ssh** (padrão do entry telegram), usando venv `/home/homelab/mcp/venv` (chromadb 1.5.9) e o script de produção `/home/homelab/myClaude/scripts/`.
- Antes, sessões da workstation tentavam criar `/home/homelab/myClaude/chroma_db` localmente (EACCES) — `memory_store` quebrado.
- API key via `~/.config/homelab/secrets.env` (0600) no homelab — `.mcp.json` (público) permanece sem credenciais.

## Notas
- LFM2.5-VL GGUF (tensor `output_norm` faltando) e gemma3:1b (texto-only) descartados; `vision-moondream:nas` validado 2x.
- Validado: initialize + `memory_store` → `{"ok": true, "memory_id": ...}` na memória compartilhada real.