### PR TITLE
fix(trading): reconcilia fill real do BUY e elimina dust acumulado

### DIFF
--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -5358,6 +5358,10 @@ class BitcoinTradingAgent(
                         "ts": time.time(),
                         "target_sell": 0.0,         # filled after tp_target is computed below
                         "trailing_high": price,     # per-slot trailing high start
+                        # order_id identifica o slot para a reconciliação de fill e
+                        # para o dedup de readopção (_restore_persistent_
+                        # reconciliation_candidate lê entry["order_id"]).
+                        "order_id": order_id,
                     })
                     self._sync_position_tracking()
                     # Resetar rastreamento de vale após BUY executado (nova referência de fundo)
@@ -5421,6 +5425,16 @@ class BitcoinTradingAgent(
                         self.state.entries[-1]["trade_id"] = trade_id
                     # FIX #1: Reset trailing high on new position
                     self.state.trailing_high = price
+
+                    # Corrige size/price com o fill real antes de qualquer venda
+                    # usar entries[].size — evita o dust de cada ciclo.
+                    if not self.state.dry_run and order_id:
+                        threading.Thread(
+                            target=self._reconcile_buy_fill,
+                            args=(order_id, trade_id, price, size),
+                            daemon=True,
+                            name=f"buy-fill-reconcile-{trade_id}",
+                        ).start()
 
                     # Reconciliação pós-compra: detecta slots fantasma acumulados
                     # antes desta compra (race condition com outro agente)
@@ -5562,6 +5576,114 @@ class BitcoinTradingAgent(
 
     # _check_per_slot_exits → migrado para PositionManagerMixin
     # _execute_slot_sell → migrado para PositionManagerMixin
+
+    def _reconcile_buy_fill(
+        self,
+        order_id: str,
+        trade_id: int,
+        estimated_price: float,
+        estimated_size: float,
+    ) -> None:
+        """Busca o fill real do BUY e corrige size/price no DB e em state.entries.
+
+        O size gravado no BUY é estimado (``funds / ticker``) e fica menor que o
+        dealSize real por dois motivos: a fee é cobrada em USDT (o BTC é
+        creditado bruto) e ``ticker`` não é o preço de execução. Como o SELL
+        vende ``entries[].size``, cada ciclo deixava dust na exchange — origem
+        dos falsos positivos de reconciliação.
+
+        Corrigir apenas o DB não basta: sem atualizar ``entries[].size`` o SELL
+        continuaria vendendo o valor estimado. Ambos são corrigidos aqui.
+
+        Roda em background thread após BUY real (nunca em dry_run).
+        """
+        time.sleep(3)
+        try:
+            fill = get_fills_for_order(order_id, self.symbol)
+            if not fill:
+                logger.warning(
+                    "⚠️ [buy-fill-reconcile] Fills não encontrados para order=%s "
+                    "(trade_id=%s) — mantendo estimativa",
+                    order_id, trade_id,
+                )
+                return
+
+            actual_size = float(fill["fill_size"])
+            actual_price = float(fill["fill_price"])
+            actual_funds = float(fill.get("fill_funds") or 0) or None
+            if actual_size <= 0 or actual_price <= 0:
+                return
+
+            size_delta = actual_size - estimated_size
+
+            # entries[] é mutado por outras threads (vendas, reconciliação de
+            # posição). Sem o lock, o read-modify-write abaixo é um TOCTOU —
+            # mesmo raciocínio de _reconcile_position_with_exchange.
+            with self._trade_lock:
+                entries = list(getattr(self.state, "entries", []) or [])
+                target_idx = None
+                for idx, entry in enumerate(entries):
+                    if entry.get("trade_id") == trade_id or (
+                        order_id and entry.get("order_id") == order_id
+                    ):
+                        target_idx = idx
+                        break
+
+                if target_idx is None:
+                    # Slot já vendido/removido antes do fill aparecer na API.
+                    # Corrigir o DB ainda é correto (registro histórico), mas
+                    # não há entry para ajustar.
+                    logger.info(
+                        "ℹ️ [buy-fill-reconcile] Slot do trade_id=%s não está mais "
+                        "em entries — corrigindo apenas o DB",
+                        trade_id,
+                    )
+                else:
+                    entries[target_idx]["size"] = actual_size
+                    entries[target_idx]["price"] = actual_price
+                    self.state.entries = entries
+
+                    total_size = sum(float(e.get("size", 0) or 0) for e in entries)
+                    total_cost = sum(
+                        float(e.get("size", 0) or 0) * float(e.get("price", 0) or 0)
+                        for e in entries
+                    )
+                    self.state.position = total_size
+                    self.state.entry_price = (
+                        total_cost / total_size if total_size > 0 else 0.0
+                    )
+                    self._sync_position_tracking()
+
+            updated = self.db.update_trade_fill(
+                trade_id, actual_size, actual_price, funds=actual_funds,
+            )
+            self.db.merge_trade_metadata(trade_id, {
+                "fill_reconciled": True,
+                "fill_price":      actual_price,
+                "fill_size":       actual_size,
+                "fill_fee":        fill.get("fill_fee"),
+                "fee_currency":    fill.get("fee_currency"),
+                "fee_rate":        fill.get("fee_rate"),
+                "liquidity":       fill.get("liquidity"),
+                "estimated_size":  estimated_size,
+                "estimated_price": estimated_price,
+                "size_correction": round(size_delta, 8),
+                "price_slippage":  round(actual_price - estimated_price, 4),
+            })
+
+            logger.info(
+                "🔍 [buy-fill-reconcile] order=%s fills=%s "
+                "size=%.8f (est=%.8f corr=%+.8f) "
+                "price=$%.4f (est=$%.4f slip=$%+.4f) db_updated=%s",
+                order_id, fill.get("fills_count"),
+                actual_size, estimated_size, size_delta,
+                actual_price, estimated_price, actual_price - estimated_price,
+                updated,
+            )
+        except Exception as exc:
+            logger.warning(
+                "⚠️ [buy-fill-reconcile] Falhou para order=%s: %s", order_id, exc,
+            )
 
     def _reconcile_sell_fill(
         self,

--- a/btc_trading_agent/training_db.py
+++ b/btc_trading_agent/training_db.py
@@ -570,6 +570,52 @@ class TrainingDatabase:
                 UPDATE {SCHEMA}.trades SET pnl = %s, pnl_pct = %s WHERE id = %s
             """, (pnl, pnl_pct, trade_id))
 
+    def update_trade_fill(
+        self,
+        trade_id: int,
+        size: float,
+        price: float,
+        *,
+        funds: Optional[float] = None,
+    ) -> bool:
+        """Corrige size/price de um trade com o fill real da exchange.
+
+        O size gravado no momento da ordem é uma estimativa
+        (``funds / ticker``): o dealSize real só é conhecido consultando os
+        fills. Sem essa correção o DB fica com size menor que o saldo real e o
+        SELL — que vende ``entries[].size`` — deixa dust a cada ciclo.
+
+        Restrito a trades live e não fechados: um trade já fechado teve o PnL
+        calculado sobre o size antigo, e reescrever o size sem recalcular o PnL
+        deixaria os dois inconsistentes.
+
+        Returns:
+            True se a linha foi atualizada.
+        """
+        if size <= 0 or price <= 0:
+            return False
+
+        sets = ["size = %s", "price = %s"]
+        params: List[Any] = [size, price]
+        if funds is not None and funds > 0:
+            sets.append("funds = %s")
+            params.append(funds)
+        params.append(trade_id)
+
+        with self._get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                f"""
+                UPDATE {SCHEMA}.trades
+                SET {', '.join(sets)}
+                WHERE id = %s
+                  AND dry_run = FALSE
+                  AND status != 'closed'
+                """,
+                tuple(params),
+            )
+            return cur.rowcount == 1
+
     def merge_trade_metadata(self, trade_id: int, metadata: Dict[str, Any]) -> None:
         """Mescla chaves de metadata em um trade existente."""
         if not metadata:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-03T11:23:23.908897+00:00",
-  "repo_root": "/workspace/eddie-auto-dev",
+  "generated_at": "2026-08-04T04:02:39.583028+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-03T11:23:23.908897+00:00`
+- Generated at: `2026-08-04T04:02:39.583028+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `210`

--- a/tests/test_buy_fill_reconcile.py
+++ b/tests/test_buy_fill_reconcile.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Regressões para _reconcile_buy_fill — correção do size estimado do BUY.
+
+O size do BUY é gravado como estimativa (``funds / ticker``) e fica menor que o
+dealSize real, porque a fee é cobrada em USDT (BTC creditado bruto) e o ticker
+não é o preço de execução. Como o SELL vende ``entries[].size``, cada ciclo
+deixava dust na exchange — origem dos falsos positivos de reconciliação.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+import os
+import sys
+import threading
+import types
+
+import unittest.mock as _mock
+
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "btc_trading_agent"))
+sys.modules.setdefault("httpx", types.SimpleNamespace())
+
+_numpy_mock = _mock.MagicMock()
+_numpy_mock.isscalar = lambda x: isinstance(x, (int, float, complex, bool))
+_numpy_mock.bool_ = bool
+sys.modules.setdefault("numpy", _numpy_mock)
+
+_psycopg2_mock = types.ModuleType("psycopg2")
+_psycopg2_mock.extras = types.SimpleNamespace(RealDictCursor=object)
+_psycopg2_mock.pool = types.SimpleNamespace(
+    ThreadedConnectionPool=object,
+    SimpleConnectionPool=object,
+)
+sys.modules.setdefault("psycopg2", _psycopg2_mock)
+sys.modules.setdefault("psycopg2.extras", _psycopg2_mock.extras)
+sys.modules.setdefault("psycopg2.pool", _psycopg2_mock.pool)
+
+# Don't mock training_db module globally - it breaks other test files
+# We'll mock TrainingDatabase on the agent instance instead
+sys.modules.setdefault("market_rag", types.SimpleNamespace(MarketRAG=object))
+sys.modules.setdefault(
+    "kucoin_api",
+    types.SimpleNamespace(
+        get_price=None,
+        get_price_fast=None,
+        get_orderbook=None,
+        get_candles=None,
+        get_recent_trades=None,
+        get_balances=None,
+        get_balance=None,
+        place_market_order=None,
+        analyze_orderbook=None,
+        analyze_trade_flow=None,
+        inner_transfer=None,
+        _has_keys=lambda: False,
+        get_fills_for_order=lambda *a, **kw: {},
+        _resolve_telegram_bot_token=lambda: "",
+        _resolve_telegram_chat_id=lambda: "",
+        _send_telegram_alert=lambda *a, **kw: None,
+    ),
+)
+sys.modules.setdefault(
+    "fast_model",
+    types.SimpleNamespace(FastTradingModel=object, MarketState=object, Signal=object),
+)
+
+import trading_agent as ta_mod
+from trading_agent import BitcoinTradingAgent
+
+
+# ── Dados reais capturados da API KuCoin (subconta BTCConservative) ──────────
+# Trade #3833: ticker $63.400,95 / fill real $63.443,50, dealSize 0.00023643.
+# O size estimado grava 0.00023635 — 8 satoshis a menos.
+REAL_TICKER = 63_400.95
+REAL_FILL_PRICE = 63_443.5
+REAL_DEAL_SIZE = 0.00023643
+EST_SIZE = 15.0 / REAL_TICKER * (1 - 0.001)  # fórmula atual: 0.00023635...
+ORDER_ID = "6a7132756b3c7c0007927616"
+TRADE_ID = 3833
+
+
+def _fill(size=REAL_DEAL_SIZE, price=REAL_FILL_PRICE, funds=15.0):
+    return {
+        "fill_price": price,
+        "fill_size": size,
+        "fill_funds": funds,
+        "fill_fee": 0.00999989,
+        "fee_currency": "USDT",
+        "fee_rate": 0.001,
+        "liquidity": "taker",
+        "fills_count": 1,
+    }
+
+
+def _agent(entries=None, *, position=None) -> BitcoinTradingAgent:
+    agent = BitcoinTradingAgent.__new__(BitcoinTradingAgent)
+    agent.symbol = "BTC-USDT"
+    agent._trade_lock = threading.Lock()
+    entries = list(entries if entries is not None else [_entry()])
+    total = sum(e["size"] for e in entries)
+    agent.state = SimpleNamespace(
+        dry_run=False,
+        profile="conservative",
+        position=position if position is not None else total,
+        entry_price=REAL_TICKER,
+        entries=entries,
+        position_count=len(entries),
+        raw_entry_count=len(entries),
+        logical_position_slots=len(entries),
+    )
+    agent.db = _mock.MagicMock()
+    agent.db.update_trade_fill.return_value = True
+    return agent
+
+
+def _entry(size=EST_SIZE, price=REAL_TICKER, trade_id=TRADE_ID, order_id=ORDER_ID):
+    return {
+        "price": price,
+        "size": size,
+        "ts": 1_784_000_000.0,
+        "target_sell": 0.0,
+        "trailing_high": price,
+        "trade_id": trade_id,
+        "order_id": order_id,
+    }
+
+
+def _run(agent, fill_value, *, est_size=EST_SIZE, est_price=REAL_TICKER):
+    """Executa _reconcile_buy_fill sem o sleep(3) de espera do fill."""
+    with (
+        _mock.patch.object(ta_mod, "get_fills_for_order", return_value=fill_value),
+        _mock.patch.object(ta_mod.time, "sleep"),
+    ):
+        agent._reconcile_buy_fill(ORDER_ID, TRADE_ID, est_price, est_size)
+
+
+# ── Correção do size ────────────────────────────────────────────────────────
+
+def test_entry_size_corrected_to_real_deal_size() -> None:
+    """entries[].size passa a valer o dealSize real — sem isso o SELL deixa dust."""
+    agent = _agent()
+    assert agent.state.entries[0]["size"] == EST_SIZE  # pré-condição
+
+    _run(agent, _fill())
+
+    assert agent.state.entries[0]["size"] == REAL_DEAL_SIZE
+    assert agent.state.entries[0]["price"] == REAL_FILL_PRICE
+
+
+def test_dust_eliminated_end_to_end() -> None:
+    """O que o SELL venderia passa a casar com o que a exchange creditou."""
+    agent = _agent()
+    dust_antes = REAL_DEAL_SIZE - agent.state.entries[0]["size"]
+    assert dust_antes > 0  # a estimativa subestima
+
+    _run(agent, _fill())
+
+    assert REAL_DEAL_SIZE - agent.state.entries[0]["size"] == 0
+
+
+def test_db_updated_with_fill_and_metadata() -> None:
+    agent = _agent()
+
+    _run(agent, _fill())
+
+    agent.db.update_trade_fill.assert_called_once()
+    args, kwargs = agent.db.update_trade_fill.call_args
+    assert args[0] == TRADE_ID
+    assert args[1] == REAL_DEAL_SIZE
+    assert args[2] == REAL_FILL_PRICE
+    assert kwargs["funds"] == 15.0
+
+    meta = agent.db.merge_trade_metadata.call_args[0][1]
+    assert meta["fill_reconciled"] is True
+    assert meta["fill_size"] == REAL_DEAL_SIZE
+    assert meta["estimated_size"] == EST_SIZE
+    assert meta["size_correction"] > 0
+    assert meta["fee_currency"] == "USDT"
+
+
+def test_position_and_avg_price_recomputed() -> None:
+    """Posição e preço médio refletem o fill, não a estimativa."""
+    other = _entry(size=0.0002, price=60_000.0, trade_id=999, order_id="other")
+    agent = _agent(entries=[other, _entry()])
+
+    _run(agent, _fill())
+
+    expected_total = 0.0002 + REAL_DEAL_SIZE
+    assert agent.state.position == expected_total
+    expected_avg = (
+        0.0002 * 60_000.0 + REAL_DEAL_SIZE * REAL_FILL_PRICE
+    ) / expected_total
+    assert agent.state.entry_price == expected_avg
+    assert other["size"] == 0.0002  # slot alheio intocado
+
+
+def test_matches_slot_by_order_id_when_trade_id_absent() -> None:
+    entry = _entry()
+    del entry["trade_id"]
+    agent = _agent(entries=[entry])
+
+    _run(agent, _fill())
+
+    assert agent.state.entries[0]["size"] == REAL_DEAL_SIZE
+
+
+# ── Robustez ────────────────────────────────────────────────────────────────
+
+def test_no_fill_keeps_estimate_and_skips_db() -> None:
+    """Fill indisponível: mantém a estimativa em vez de corromper o estado."""
+    agent = _agent()
+
+    _run(agent, {})
+
+    assert agent.state.entries[0]["size"] == EST_SIZE
+    agent.db.update_trade_fill.assert_not_called()
+    agent.db.merge_trade_metadata.assert_not_called()
+
+
+def test_zero_size_fill_is_ignored() -> None:
+    agent = _agent()
+
+    _run(agent, _fill(size=0.0))
+
+    assert agent.state.entries[0]["size"] == EST_SIZE
+    agent.db.update_trade_fill.assert_not_called()
+
+
+def test_slot_already_sold_still_corrects_db() -> None:
+    """Slot vendido antes do fill aparecer: DB é corrigido, sem KeyError."""
+    agent = _agent(entries=[], position=0.0)
+
+    _run(agent, _fill())
+
+    agent.db.update_trade_fill.assert_called_once()
+    assert agent.state.entries == []
+
+
+def test_db_failure_does_not_raise() -> None:
+    agent = _agent()
+    agent.db.update_trade_fill.side_effect = RuntimeError("db down")
+
+    _run(agent, _fill())  # não deve propagar
+
+    # entries já foi corrigido antes da escrita no DB
+    assert agent.state.entries[0]["size"] == REAL_DEAL_SIZE
+
+
+def test_holds_trade_lock_while_mutating_entries() -> None:
+    """A mutação de entries acontece sob _trade_lock (evita TOCTOU)."""
+    agent = _agent()
+    observed = []
+
+    real_lock = agent._trade_lock
+
+    class _SpyLock:
+        def __enter__(self):
+            observed.append("acquired")
+            return real_lock.__enter__()
+
+        def __exit__(self, *a):
+            observed.append("released")
+            return real_lock.__exit__(*a)
+
+    agent._trade_lock = _SpyLock()
+
+    _run(agent, _fill())
+
+    assert observed == ["acquired", "released"]

--- a/tests/test_update_trade_fill.py
+++ b/tests/test_update_trade_fill.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regressões para TrainingDatabase.update_trade_fill.
+
+Corrige size/price de um trade com o fill real da exchange. Só deve alcançar
+trades live e não fechados: um trade fechado teve o PnL calculado sobre o size
+antigo, e reescrevê-lo sem recalcular o PnL deixaria os dois inconsistentes.
+"""
+
+from pathlib import Path
+import os
+import sys
+import types
+
+import unittest.mock as _mock
+
+import pytest
+
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "btc_trading_agent"))
+
+_psycopg2_mock = types.ModuleType("psycopg2")
+_psycopg2_mock.extras = types.SimpleNamespace(RealDictCursor=object)
+_psycopg2_mock.pool = types.SimpleNamespace(
+    ThreadedConnectionPool=object,
+    SimpleConnectionPool=object,
+)
+_psycopg2_mock.Error = Exception
+sys.modules.setdefault("psycopg2", _psycopg2_mock)
+sys.modules.setdefault("psycopg2.extras", _psycopg2_mock.extras)
+sys.modules.setdefault("psycopg2.pool", _psycopg2_mock.pool)
+
+_numpy_mock = _mock.MagicMock()
+_numpy_mock.isscalar = lambda x: isinstance(x, (int, float, complex, bool))
+_numpy_mock.bool_ = bool
+sys.modules.setdefault("numpy", _numpy_mock)
+
+import training_db as tdb_mod
+from training_db import TrainingDatabase
+
+
+REAL_SIZE = 0.00023643
+REAL_PRICE = 63_443.5
+
+
+def _db(rowcount=1):
+    """TrainingDatabase com _get_conn stubado, expondo o cursor para asserts."""
+    db = TrainingDatabase.__new__(TrainingDatabase)
+
+    cur = _mock.MagicMock()
+    cur.rowcount = rowcount
+    conn = _mock.MagicMock()
+    conn.__enter__ = _mock.MagicMock(return_value=conn)
+    conn.__exit__ = _mock.MagicMock(return_value=False)
+    conn.cursor.return_value = cur
+
+    db._get_conn = _mock.MagicMock(return_value=conn)
+    return db, cur
+
+
+def _sql(cur) -> str:
+    return " ".join(cur.execute.call_args[0][0].split())
+
+
+def test_updates_size_and_price() -> None:
+    db, cur = _db()
+
+    assert db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE) is True
+
+    sql = _sql(cur)
+    assert "SET size = %s, price = %s" in sql
+    params = cur.execute.call_args[0][1]
+    assert params == (REAL_SIZE, REAL_PRICE, 3833)
+
+
+def test_includes_funds_when_provided() -> None:
+    db, cur = _db()
+
+    db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE, funds=15.0)
+
+    assert "funds = %s" in _sql(cur)
+    assert cur.execute.call_args[0][1] == (REAL_SIZE, REAL_PRICE, 15.0, 3833)
+
+
+def test_omits_funds_when_absent_or_zero() -> None:
+    for funds in (None, 0, 0.0):
+        db, cur = _db()
+        db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE, funds=funds)
+        assert "funds" not in _sql(cur)
+
+
+def test_guards_scope_to_live_and_open_trades() -> None:
+    """Nunca reescreve dry_run nem trade fechado (PnL já calculado)."""
+    db, cur = _db()
+
+    db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE)
+
+    sql = _sql(cur)
+    assert "dry_run = FALSE" in sql
+    assert "status != 'closed'" in sql
+
+
+def test_returns_false_when_no_row_matched() -> None:
+    """rowcount=0 → trade fechado/dry_run/inexistente."""
+    db, cur = _db(rowcount=0)
+
+    assert db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE) is False
+
+
+@pytest.mark.parametrize(
+    "size,price",
+    [(0, REAL_PRICE), (-1, REAL_PRICE), (REAL_SIZE, 0), (REAL_SIZE, -1)],
+)
+def test_rejects_non_positive_values_without_touching_db(size, price) -> None:
+    db, _cur = _db()
+
+    assert db.update_trade_fill(3833, size, price) is False
+    db._get_conn.assert_not_called()
+
+
+def test_targets_trades_table_in_schema() -> None:
+    db, cur = _db()
+
+    db.update_trade_fill(3833, REAL_SIZE, REAL_PRICE)
+
+    assert f"UPDATE {tdb_mod.SCHEMA}.trades" in _sql(cur)


### PR DESCRIPTION
## Contexto
O BUY gravava `size` **estimado** (`amount_usdt / price * (1 - fee)`), não o fill real. Dois erros compostos: a fee sai em USDT (BTC é creditado bruto) e `price` era o ticker, não o preço de execução. Cada ciclo deixava ~24 satoshis de dust que o DB nunca contabilizava — material de falsos positivos de reconciliação.

## Mudanças
- **`btc_trading_agent/trading_agent.py`**: `_reconcile_buy_fill()` busca o fill real via `get_fills_for_order()` e corrige DB + `state.entries[]` sob `_trade_lock`, espelhando o caminho do SELL que já reconciliado.
- **`btc_trading_agent/training_db.py`**: `update_trade_fill()` grava size/price/funds reais (só trades live/open).
- **`tests/test_buy_fill_reconcile.py`** (10) e **`tests/test_update_trade_fill.py`** (9): cobertura de correção, remoção de dust, matching por order_id e robustez.
- `order_id` agora é gravado no entry do BUY (antes ausente, quebrava dedup na readoção).

## Verificação
- 19 novos + 91 regressão (dryrun, position_manager, metadata) — verdes.
- Validação prévia na API KuCoin: #3619 + #3833 explicam os 0.00046283 BTC da subconta; resíduo 71 satoshis.

Closes o diagnóstico do falso positivo de reconciliação (alerta 0.00022648 BTC).