### PR TITLE
ci: roda testes Python em todo PR para main (requisito p/ checks obrigatórios)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,13 +5,6 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]
-    paths:
-      - 'btc_trading_agent/**'
-      - 'clear_trading_agent/**'
-      - 'site/index.html'
-      - 'tests/**'
-      - 'tests/unit/**'
-      - '.github/workflows/python-ci.yml'
 
 jobs:
   python-tests:

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-04T04:22:01.351881+00:00",
+  "generated_at": "2026-08-04T04:33:25.983789+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-04T04:33:25.983789+00:00",
+  "generated_at": "2026-08-04T04:41:27.693658+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-04T04:22:01.351881+00:00`
+- Generated at: `2026-08-04T04:33:25.983789+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `210`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-04T04:33:25.983789+00:00`
+- Generated at: `2026-08-04T04:41:27.693658+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `210`


### PR DESCRIPTION
## Contexto
O usuário quer que **todos os testes sejam obrigatórios** no branch protection do `main`. 

Pré-requisito: o `python-ci.yml` tinha `paths` filter (`btc_trading_agent/**`, `tests/**`...). Com checks obrigatórios, um PR que não tocasse esses paths ficaria preso eternamente em "Expected — Waiting for status to be reported" (o check nunca dispara). 

## Mudança
Remove o `paths` filter do trigger `pull_request` — agora "Python Tests" e "Clear Agent Tests" rodam em **todo** PR para `main`.

## Verificação
- Este próprio PR valida o comportamento: os dois jobs devem rodar aqui.
- O requirements.txt restaurado (PR #304, já mergeado) garante as deps.