### PR TITLE
fix(ci): lê SECRETS_AGENT_API_KEY do EnvironmentFile no deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             git reset --hard origin/main
 
             echo "🔎 Resolvendo DATABASE_URL via Secrets Agent (como o runtime)..."
-            SECRETS_AGENT_API_KEY="$(sudo systemctl show crypto-agent@BTC_USDT_aggressive.service -p Environment --value 2>/dev/null | tr ' ' '\n' | sed -n 's/^SECRETS_AGENT_API_KEY=//p' | tail -n1)"
+            SECRETS_AGENT_API_KEY="$(sudo grep '^SECRETS_AGENT_API_KEY=' /etc/crypto-agent/secrets-api.env 2>/dev/null | cut -d= -f2-)"
             if [ -n "${SECRETS_AGENT_API_KEY}" ]; then
               TRADING_DATABASE_URL="$(SECRETS_AGENT_API_KEY="${SECRETS_AGENT_API_KEY}" python3 -c 'from btc_trading_agent.secrets_helper import get_database_url; print(get_database_url(), end="")' 2>/dev/null || true)"
             fi

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-04T05:02:05.689087+00:00",
+  "generated_at": "2026-08-05T00:15:03.213200+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-04T05:02:05.689087+00:00`
+- Generated at: `2026-08-05T00:15:03.213200+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`


### PR DESCRIPTION
## Problema

O deploy do CI Pipeline falhava com `❌ DATABASE_URL do trading não encontrado` mesmo após o #306.

Causa: o drop-in do serviço usa

```
EnvironmentFile=/etc/crypto-agent/secrets-api.env
```

ou seja, `SECRETS_AGENT_API_KEY` **não aparece** em `systemctl show -p Environment` (vem de um EnvironmentFile). O script extraía a chave do `Environment` → vazia → `get_database_url()` não conseguia chamar o Secrets Agent → fallback `.env` também vazio → exit 1.

## Correção

Ler a chave direto do arquivo:

```bash
SECRETS_AGENT_API_KEY="$(sudo grep '^SECRETS_AGENT_API_KEY=' /etc/crypto-agent/secrets-api.env | cut -d= -f2-)"
```

Validado manualmente no servidor: com a chave do arquivo, `get_database_url()` resolve `postgresql://...:5433/btc_trading`.