### PR TITLE
fix(trading): garante reconciliação de fill em cada BUY live

### DIFF
--- a/btc_trading_agent/trading_agent.py
+++ b/btc_trading_agent/trading_agent.py
@@ -5318,9 +5318,13 @@ class BitcoinTradingAgent(
                     trade_metadata = None
 
                     if self.state.dry_run:
-                        # Simulação (desconta fee como no trade real)
-                        size = amount_usdt / price * (1 - TRADING_FEE_PCT)
-                        logger.info(f"🔵 [DRY] BUY #{self.state.position_count+1} {size:.6f} BTC @ ${price:,.2f} (${amount_usdt:.2f}, fee={TRADING_FEE_PCT*100:.1f}%)")
+                        # Fee da KuCoin é cobrada em USDT — o BTC creditado é bruto
+                        # (funds/price). Não subtrair TRADING_FEE_PCT do size.
+                        size = amount_usdt / price
+                        logger.info(
+                            f"🔵 [DRY] BUY #{self.state.position_count+1} {size:.6f} BTC "
+                            f"@ ${price:,.2f} (${amount_usdt:.2f}, fee={TRADING_FEE_PCT*100:.1f}% USDT)"
+                        )
                     else:
                         # Trade real
                         result = place_market_order(self.symbol, "buy", funds=amount_usdt)
@@ -5340,8 +5344,9 @@ class BitcoinTradingAgent(
                             if subaccount:
                                 trade_metadata["kucoin_subaccount"] = subaccount
                         
-                        # Atualizar posição (aproximado)
-                        size = amount_usdt / price * (1 - TRADING_FEE_PCT)
+                        # Estimativa provisória até _reconcile_buy_fill corrigir com
+                        # o dealSize real. Fee em USDT → size ≈ funds/ticker (bruto).
+                        size = amount_usdt / price
                         logger.info(f"🟢 BUY #{self.state.position_count+1} {size:.6f} BTC @ ${price:,.2f}")
                     
                     # Multi-posição: acumular com preço médio ponderado
@@ -5426,25 +5431,28 @@ class BitcoinTradingAgent(
                     # FIX #1: Reset trailing high on new position
                     self.state.trailing_high = price
 
-                    # Corrige size/price com o fill real antes de qualquer venda
-                    # usar entries[].size — evita o dust de cada ciclo.
-                    if not self.state.dry_run and order_id:
-                        threading.Thread(
-                            target=self._reconcile_buy_fill,
-                            args=(order_id, trade_id, price, size),
-                            daemon=True,
-                            name=f"buy-fill-reconcile-{trade_id}",
-                        ).start()
-
-                    # Reconciliação pós-compra: detecta slots fantasma acumulados
-                    # antes desta compra (race condition com outro agente)
+                    # Cada BUY live DEVE reconciliar o fill real (dealSize/price)
+                    # e só depois comparar saldo DB×exchange. Sem order_id ainda
+                    # roda a reconciliação de posição (depósitos/slots fantasma).
                     if not self.state.dry_run:
-                        threading.Thread(
-                            target=self._reconcile_position_with_exchange,
-                            args=(price,),
-                            daemon=True,
-                            name="reconcile-post-buy",
-                        ).start()
+                        if order_id:
+                            threading.Thread(
+                                target=self._reconcile_buy_fill,
+                                args=(order_id, trade_id, price, size),
+                                daemon=True,
+                                name=f"buy-fill-reconcile-{trade_id}",
+                            ).start()
+                        else:
+                            logger.warning(
+                                "⚠️ BUY sem order_id — fill reconcile impossível; "
+                                "rodando só reconciliação de posição"
+                            )
+                            threading.Thread(
+                                target=self._reconcile_position_with_exchange,
+                                args=(price,),
+                                daemon=True,
+                                name="reconcile-post-buy",
+                            ).start()
 
                 elif signal.action == "SELL":
                     # Use _calculate_trade_size for fee check (force bypasses)
@@ -5586,14 +5594,18 @@ class BitcoinTradingAgent(
     ) -> None:
         """Busca o fill real do BUY e corrige size/price no DB e em state.entries.
 
-        O size gravado no BUY é estimado (``funds / ticker``) e fica menor que o
-        dealSize real por dois motivos: a fee é cobrada em USDT (o BTC é
-        creditado bruto) e ``ticker`` não é o preço de execução. Como o SELL
-        vende ``entries[].size``, cada ciclo deixava dust na exchange — origem
-        dos falsos positivos de reconciliação.
+        O size gravado no BUY é estimado (``funds / ticker``). O dealSize real
+        só aparece nos fills: a fee é cobrada em USDT (BTC creditado bruto) e o
+        ticker não é o preço de execução. Como o SELL vende ``entries[].size``,
+        cada ciclo sem essa correção deixa dust na exchange — origem dos falsos
+        positivos de reconciliação.
 
         Corrigir apenas o DB não basta: sem atualizar ``entries[].size`` o SELL
         continuaria vendendo o valor estimado. Ambos são corrigidos aqui.
+
+        Após o fill (ou se o fill falhar), dispara a reconciliação de posição
+        com a exchange — evita o alerta falso de "excesso" que ocorria quando
+        a comparação DB×exchange rodava em paralelo antes do size real.
 
         Roda em background thread após BUY real (nunca em dry_run).
         """
@@ -5684,6 +5696,16 @@ class BitcoinTradingAgent(
             logger.warning(
                 "⚠️ [buy-fill-reconcile] Falhou para order=%s: %s", order_id, exc,
             )
+        finally:
+            # Sempre re-checar DB×exchange depois do fill (ou da falha): a
+            # comparação pré-fill usava size estimado e gerava falso excesso.
+            try:
+                self._reconcile_position_with_exchange(estimated_price)
+            except Exception as exc:
+                logger.warning(
+                    "⚠️ [buy-fill-reconcile] post-fill position reconcile failed "
+                    "order=%s: %s", order_id, exc,
+                )
 
     def _reconcile_sell_fill(
         self,

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T00:15:03.213200+00:00",
+  "generated_at": "2026-08-05T22:37:46.928188+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-05T00:15:03.213200+00:00`
+- Generated at: `2026-08-05T22:37:46.928188+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`

--- a/tests/test_buy_fill_reconcile.py
+++ b/tests/test_buy_fill_reconcile.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import types
 
+import pytest
 import unittest.mock as _mock
 
 
@@ -76,7 +77,10 @@ from trading_agent import BitcoinTradingAgent
 REAL_TICKER = 63_400.95
 REAL_FILL_PRICE = 63_443.5
 REAL_DEAL_SIZE = 0.00023643
-EST_SIZE = 15.0 / REAL_TICKER * (1 - 0.001)  # fórmula atual: 0.00023635...
+# Estimativa atual: funds/ticker (fee em USDT — BTC bruto). Histórico pré-fix
+# usava *(1-fee) e gerava dust; o reconcile continua corrigindo para dealSize.
+EST_SIZE = 15.0 / REAL_TICKER
+LEGACY_EST_SIZE = 15.0 / REAL_TICKER * (1 - 0.001)  # 0.00023635… (pré-#303)
 ORDER_ID = "6a7132756b3c7c0007927616"
 TRADE_ID = 3833
 
@@ -112,6 +116,7 @@ def _agent(entries=None, *, position=None) -> BitcoinTradingAgent:
     )
     agent.db = _mock.MagicMock()
     agent.db.update_trade_fill.return_value = True
+    agent._reconcile_position_with_exchange = _mock.MagicMock(return_value=0)
     return agent
 
 
@@ -150,12 +155,15 @@ def test_entry_size_corrected_to_real_deal_size() -> None:
 
 
 def test_dust_eliminated_end_to_end() -> None:
-    """O que o SELL venderia passa a casar com o que a exchange creditou."""
-    agent = _agent()
-    dust_antes = REAL_DEAL_SIZE - agent.state.entries[0]["size"]
-    assert dust_antes > 0  # a estimativa subestima
+    """O que o SELL venderia passa a casar com o que a exchange creditou.
 
-    _run(agent, _fill())
+    Usa a estimativa legada *(1-fee), que subestimava o size e gerava dust.
+    """
+    agent = _agent(entries=[_entry(size=LEGACY_EST_SIZE)])
+    dust_antes = REAL_DEAL_SIZE - agent.state.entries[0]["size"]
+    assert dust_antes > 0  # a estimativa legada subestima
+
+    _run(agent, _fill(), est_size=LEGACY_EST_SIZE)
 
     assert REAL_DEAL_SIZE - agent.state.entries[0]["size"] == 0
 
@@ -176,7 +184,9 @@ def test_db_updated_with_fill_and_metadata() -> None:
     assert meta["fill_reconciled"] is True
     assert meta["fill_size"] == REAL_DEAL_SIZE
     assert meta["estimated_size"] == EST_SIZE
-    assert meta["size_correction"] > 0
+    # Com funds/ticker, slippage de preço pode deixar a correção ±; o
+    # importante é gravar o dealSize real, não o sinal da correção.
+    assert meta["size_correction"] == round(REAL_DEAL_SIZE - EST_SIZE, 8)
     assert meta["fee_currency"] == "USDT"
 
 
@@ -269,3 +279,31 @@ def test_holds_trade_lock_while_mutating_entries() -> None:
     _run(agent, _fill())
 
     assert observed == ["acquired", "released"]
+
+
+def test_position_reconcile_runs_after_fill_success() -> None:
+    """Pós-compra: reconciliação DB×exchange só depois do fill (evita falso excesso)."""
+    agent = _agent()
+
+    _run(agent, _fill())
+
+    agent._reconcile_position_with_exchange.assert_called_once_with(REAL_TICKER)
+
+
+def test_position_reconcile_runs_even_when_fill_missing() -> None:
+    agent = _agent()
+
+    _run(agent, {})
+
+    agent._reconcile_position_with_exchange.assert_called_once_with(REAL_TICKER)
+
+
+def test_legacy_fee_estimate_is_corrected_upward() -> None:
+    """Regressão do dust: size com *(1-fee) sobe para o dealSize real."""
+    agent = _agent(entries=[_entry(size=LEGACY_EST_SIZE)])
+
+    _run(agent, _fill(), est_size=LEGACY_EST_SIZE)
+
+    assert agent.state.entries[0]["size"] == REAL_DEAL_SIZE
+    meta = agent.db.merge_trade_metadata.call_args[0][1]
+    assert meta["size_correction"] > 0

--- a/tests/unit/test_position_manager_mixin.py
+++ b/tests/unit/test_position_manager_mixin.py
@@ -44,6 +44,22 @@ with (
     import position_manager_mixin
     from position_manager_mixin import PositionManagerMixin
 
+# Unit tests never hit the live exchange. The self-hosted runner has real
+# KuCoin credentials in the ambient env; if a mock is missed, the code used to
+# call the API, get 401, return 0, and fail assertions opaquely. Fail loud.
+_original_signed_request = getattr(kucoin_api, "_signed_request", None)
+
+
+def _block_live_kucoin(*_args, **_kwargs):
+    raise AssertionError(
+        "live KuCoin HTTP blocked in unit tests — mock get_balance / "
+        "get_sub_account_balances (got a call to _signed_request)"
+    )
+
+
+if _original_signed_request is not None:
+    kucoin_api._signed_request = _block_live_kucoin  # type: ignore[assignment]
+
 _FEE = 0.001
 
 


### PR DESCRIPTION
## Summary
- O #303 entrou no git, mas o **Deploy BTC Trading Profiles** falhou nos unit tests e o runtime `/apps/crypto-trader/trading` **nunca recebeu** `_reconcile_buy_fill` — resultado: **0/140** buys com `fill_reconciled` em 21 dias, apesar de sells já reconciliando.
- Cada BUY live agora:
  1. grava size estimado sem `(1 - fee)` (fee é em USDT; BTC é bruto)
  2. roda `_reconcile_buy_fill` em background
  3. só depois compara DB×exchange (evita o falso alerta de excesso visto no BUY #3843)
- Testes do `position_manager_mixin` passam a **bloquear HTTP live** no runner self-hosted (antes um mock perdido virava 401 opaco e derrubava o deploy).

## Test plan
- [x] `pytest tests/test_buy_fill_reconcile.py tests/test_update_trade_fill.py tests/unit/test_position_manager_mixin.py`
- [x] Deploy manual no runtime + restart `crypto-agent@BTC_USDT_{conservative,aggressive,shadow}`
- [ ] Backfill dos open buys sem `fill_reconciled`
- [ ] Confirmar log `buy-fill-reconcile` no próximo BUY live