### PR TITLE
fix(test): isola path do position_manager_mixin no runner self-hosted

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T00:00:09.324100+00:00",
+  "generated_at": "2026-08-06T00:20:13.763681+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T22:37:46.928188+00:00",
+  "generated_at": "2026-08-06T00:00:09.324100+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-05T22:37:46.928188+00:00`
+- Generated at: `2026-08-06T00:00:09.324100+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-06T00:00:09.324100+00:00`
+- Generated at: `2026-08-06T00:20:13.763681+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`

--- a/tests/unit/test_position_manager_mixin.py
+++ b/tests/unit/test_position_manager_mixin.py
@@ -7,6 +7,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,12 +20,23 @@ os.environ.setdefault("KUCOIN_API_SECRET", "test_secret_xyz789")
 os.environ.setdefault("KUCOIN_API_PASSPHRASE", "x")
 os.environ.setdefault("SECRETS_AGENT_API_KEY", "")  # desativa tentativa ao secrets-agent
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "btc_trading_agent"))
+# Força o checkout do repo — no runner self-hosted o path de produção
+# (/apps/crypto-trader/trading/btc_trading_agent) pode aparecer no sys.path e
+# fazer o pytest carregar position_manager_mixin desatualizado (só get_balance).
+_BTC_AGENT_DIR = (Path(__file__).resolve().parents[2] / "btc_trading_agent").resolve()
+sys.path[:] = [str(_BTC_AGENT_DIR)] + [
+    p for p in sys.path if "crypto-trader" not in str(p).replace("\\", "/")
+]
 
-# Remover mocks parciais instalados por outros testes
-sys.modules.pop("kucoin_api", None)
-sys.modules.pop("secrets_helper", None)
-sys.modules.pop("position_manager_mixin", None)
+# Remover mocks parciais e módulos já importados de outros paths
+for _mod in (
+    "kucoin_api",
+    "secrets_helper",
+    "position_manager_mixin",
+    "slot_exit_policy",
+    "trading_agent",
+):
+    sys.modules.pop(_mod, None)
 
 # Importar com mock das funções de I/O para evitar side effects
 with (
@@ -44,6 +56,12 @@ with (
     import position_manager_mixin
     from position_manager_mixin import PositionManagerMixin
 
+_loaded = Path(position_manager_mixin.__file__).resolve()
+assert _loaded.parent == _BTC_AGENT_DIR, (
+    f"position_manager_mixin carregado de {_loaded}, esperado sob {_BTC_AGENT_DIR}. "
+    "No runner self-hosted isso indica path de produção vazando para o pytest."
+)
+
 # Unit tests never hit the live exchange. The self-hosted runner has real
 # KuCoin credentials in the ambient env; if a mock is missed, the code used to
 # call the API, get 401, return 0, and fail assertions opaquely. Fail loud.
@@ -61,6 +79,15 @@ if _original_signed_request is not None:
     kucoin_api._signed_request = _block_live_kucoin  # type: ignore[assignment]
 
 _FEE = 0.001
+
+
+def _subaccount_balance_patches(items):
+    """Context managers: subconta + fallback get_balance (runtime legado)."""
+    available_sum = sum(float(i.get("available", 0) or 0) for i in items)
+    return [
+        patch.object(kucoin_api, "get_sub_account_balances", return_value=items),
+        patch.object(kucoin_api, "get_balance", return_value=available_sum),
+    ]
 
 
 # ── Builders ─────────────────────────────────────────────────────────────────
@@ -730,19 +757,18 @@ class TestReconcilePositionWithExchange:
         }]
         agent.db.mark_open_buy_restored.return_value = True
 
-        with (
-            patch.object(
-                kucoin_api,
-                "get_sub_account_balances",
-                return_value=[{
-                    "sub_name": "BTCConservative",
-                    "account_type": "trade",
-                    "currency": "BTC",
-                    "available": 0.00046246638359418165,
-                }],
-            ),
-            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
-        ):
+        bal = [{
+            "sub_name": "BTCConservative",
+            "account_type": "trade",
+            "currency": "BTC",
+            "available": 0.00046246638359418165,
+        }]
+        with ExitStack() as stack:
+            for cm in _subaccount_balance_patches(bal):
+                stack.enter_context(cm)
+            mock_alert = stack.enter_context(
+                patch.object(position_manager_mixin, "_send_telegram_alert")
+            )
             result = agent._reconcile_position_with_exchange()
 
         assert result == 0
@@ -789,19 +815,18 @@ class TestReconcilePositionWithExchange:
             {"id": 11, "order_id": "order-b", "price": 90_000, "size": 0.001},
         ]
 
-        with (
-            patch.object(
-                kucoin_api,
-                "get_sub_account_balances",
-                return_value=[{
-                    "sub_name": "BTCConservative",
-                    "account_type": "trade",
-                    "currency": "BTC",
-                    "available": 0.002,
-                }],
-            ),
-            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
-        ):
+        bal = [{
+            "sub_name": "BTCConservative",
+            "account_type": "trade",
+            "currency": "BTC",
+            "available": 0.002,
+        }]
+        with ExitStack() as stack:
+            for cm in _subaccount_balance_patches(bal):
+                stack.enter_context(cm)
+            mock_alert = stack.enter_context(
+                patch.object(position_manager_mixin, "_send_telegram_alert")
+            )
             result = agent._reconcile_position_with_exchange()
 
         assert result == 0
@@ -821,19 +846,18 @@ class TestReconcilePositionWithExchange:
         ]
         agent.db.mark_open_buy_restored.return_value = False
 
-        with (
-            patch.object(
-                kucoin_api,
-                "get_sub_account_balances",
-                return_value=[{
-                    "sub_name": "BTCConservative",
-                    "account_type": "trade",
-                    "currency": "BTC",
-                    "available": 0.002,
-                }],
-            ),
-            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
-        ):
+        bal = [{
+            "sub_name": "BTCConservative",
+            "account_type": "trade",
+            "currency": "BTC",
+            "available": 0.002,
+        }]
+        with ExitStack() as stack:
+            for cm in _subaccount_balance_patches(bal):
+                stack.enter_context(cm)
+            mock_alert = stack.enter_context(
+                patch.object(position_manager_mixin, "_send_telegram_alert")
+            )
             result = agent._reconcile_position_with_exchange()
 
         assert result == 0
@@ -848,20 +872,19 @@ class TestReconcilePositionWithExchange:
             live_cfg={"kucoin_subaccount_name": "BTCConservative"},
         )
 
-        with (
-            patch.object(
-                kucoin_api,
-                "get_sub_account_balances",
-                return_value=[{
-                    "sub_name": "BTCConservative",
-                    "account_type": "trade",
-                    "currency": "BTC",
-                    "balance": 0.002,
-                    "available": 0.001,
-                }],
-            ),
-            patch.object(position_manager_mixin, "_send_telegram_alert") as mock_alert,
-        ):
+        bal = [{
+            "sub_name": "BTCConservative",
+            "account_type": "trade",
+            "currency": "BTC",
+            "balance": 0.002,
+            "available": 0.001,
+        }]
+        with ExitStack() as stack:
+            for cm in _subaccount_balance_patches(bal):
+                stack.enter_context(cm)
+            mock_alert = stack.enter_context(
+                patch.object(position_manager_mixin, "_send_telegram_alert")
+            )
             result = agent._reconcile_position_with_exchange()
 
         assert result == 0
@@ -876,17 +899,16 @@ class TestReconcilePositionWithExchange:
             live_cfg={"kucoin_subaccount_name": "BTCConservative"},
         )
 
-        with patch.object(
-            kucoin_api,
-            "get_sub_account_balances",
-            return_value=[{
-                "sub_name": "BTCConservative",
-                "account_type": "trade",
-                "currency": "BTC",
-                "balance": 0.0,
-                "available": 0.0,
-            }],
-        ):
+        bal = [{
+            "sub_name": "BTCConservative",
+            "account_type": "trade",
+            "currency": "BTC",
+            "balance": 0.0,
+            "available": 0.0,
+        }]
+        with ExitStack() as stack:
+            for cm in _subaccount_balance_patches(bal):
+                stack.enter_context(cm)
             result = agent._reconcile_position_with_exchange(current_price=90_000.0)
 
         assert result == 1

--- a/tests/unit/test_position_manager_mixin.py
+++ b/tests/unit/test_position_manager_mixin.py
@@ -1,12 +1,13 @@
 """Testes unitários para PositionManagerMixin."""
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 import threading
 import time
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
@@ -20,46 +21,71 @@ os.environ.setdefault("KUCOIN_API_SECRET", "test_secret_xyz789")
 os.environ.setdefault("KUCOIN_API_PASSPHRASE", "x")
 os.environ.setdefault("SECRETS_AGENT_API_KEY", "")  # desativa tentativa ao secrets-agent
 
-# Força o checkout do repo — no runner self-hosted o path de produção
-# (/apps/crypto-trader/trading/btc_trading_agent) pode aparecer no sys.path e
-# fazer o pytest carregar position_manager_mixin desatualizado (só get_balance).
+# No runner self-hosted o path de produção (/apps/crypto-trader/trading/...)
+# vaza no sys.path e o import normal de position_manager_mixin carrega o
+# runtime legado. Carregamos os módulos POR ARQUIVO do checkout.
 _BTC_AGENT_DIR = (Path(__file__).resolve().parents[2] / "btc_trading_agent").resolve()
-sys.path[:] = [str(_BTC_AGENT_DIR)] + [
-    p for p in sys.path if "crypto-trader" not in str(p).replace("\\", "/")
+assert _BTC_AGENT_DIR.is_dir(), f"btc_trading_agent ausente: {_BTC_AGENT_DIR}"
+
+# Remove path de produção e qualquer entrada residual dos módulos
+sys.path[:] = [
+    str(_BTC_AGENT_DIR),
+    *[
+        p
+        for p in sys.path
+        if "crypto-trader" not in str(p).replace("\\", "/")
+        and str(Path(p).resolve()) != str(_BTC_AGENT_DIR)
+    ],
 ]
+for _mod in list(sys.modules):
+    if _mod in {
+        "kucoin_api",
+        "secrets_helper",
+        "position_manager_mixin",
+        "slot_exit_policy",
+        "trading_agent",
+    } or _mod.startswith("btc_trading_agent"):
+        sys.modules.pop(_mod, None)
 
-# Remover mocks parciais e módulos já importados de outros paths
-for _mod in (
-    "kucoin_api",
-    "secrets_helper",
-    "position_manager_mixin",
-    "slot_exit_policy",
-    "trading_agent",
-):
-    sys.modules.pop(_mod, None)
 
-# Importar com mock das funções de I/O para evitar side effects
-with (
-    patch("secrets_helper.get_secret", return_value=None),
-    patch(
-        "secrets_helper.get_kucoin_credentials_with_source",
-        return_value=(
-            os.environ.get("KUCOIN_API_KEY", ""),
-            os.environ.get("KUCOIN_API_SECRET", ""),
-            os.environ.get("KUCOIN_API_PASSPHRASE", ""),
-            "env",
-        ),
-    ),
-    patch("requests.post"),  # mock do _send_telegram_alert
-):
-    import kucoin_api
-    import position_manager_mixin
-    from position_manager_mixin import PositionManagerMixin
+def _load_checkout_module(name: str) -> ModuleType:
+    """Importa um .py do checkout por caminho absoluto (ignora sys.path)."""
+    path = _BTC_AGENT_DIR / f"{name}.py"
+    assert path.is_file(), f"módulo ausente no checkout: {path}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Stub secrets_helper no sys.modules antes de carregar kucoin_api (evita
+# secrets-agent / path de produção durante o import).
+_secrets_stub = ModuleType("secrets_helper")
+_secrets_stub.get_secret = lambda *a, **k: None  # type: ignore[attr-defined]
+_secrets_stub.get_kucoin_credentials_with_source = (  # type: ignore[attr-defined]
+    lambda *a, **k: (
+        os.environ.get("KUCOIN_API_KEY", ""),
+        os.environ.get("KUCOIN_API_SECRET", ""),
+        os.environ.get("KUCOIN_API_PASSPHRASE", ""),
+        "env",
+    )
+)
+_secrets_stub.clear_secret_cache = lambda: None  # type: ignore[attr-defined]
+sys.modules["secrets_helper"] = _secrets_stub
+
+# Importar com mock de I/O (Telegram) e carregar módulos do checkout por arquivo
+with patch("requests.post"):
+    # Dependências primeiro (position_manager_mixin importa kucoin_api / slot_exit_policy)
+    kucoin_api = _load_checkout_module("kucoin_api")
+    _load_checkout_module("slot_exit_policy")
+    position_manager_mixin = _load_checkout_module("position_manager_mixin")
+    PositionManagerMixin = position_manager_mixin.PositionManagerMixin
 
 _loaded = Path(position_manager_mixin.__file__).resolve()
 assert _loaded.parent == _BTC_AGENT_DIR, (
-    f"position_manager_mixin carregado de {_loaded}, esperado sob {_BTC_AGENT_DIR}. "
-    "No runner self-hosted isso indica path de produção vazando para o pytest."
+    f"position_manager_mixin carregado de {_loaded}, esperado sob {_BTC_AGENT_DIR}."
 )
 
 # Unit tests never hit the live exchange. The self-hosted runner has real


### PR DESCRIPTION
## Summary
- O **Deploy BTC Trading Profiles** do #308 falhou no step de validação: o runner self-hosted importava o `position_manager_mixin` de **produção** (`/apps/crypto-trader/...`, só `get_balance`) em vez do checkout.
- Os testes mockavam `get_sub_account_balances` (código novo) → mock não batia → `_signed_request` bloqueado → falha opaca.

## Fix
- Força `sys.path` para o `btc_trading_agent` do checkout e remove paths `crypto-trader`
- Asserta o `__file__` do módulo carregado
- Mocka `get_balance` + `get_sub_account_balances` nos testes de subconta

## Test plan
- [x] Suite do workflow deploy-btc-trading-profiles
- [ ] Deploy BTC Trading Profiles verde no push para main