### PR TITLE
fix(ci): checkout -B main no deploy do CI Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,9 @@ jobs:
 
             echo "📥 Atualizando código..."
             git fetch origin main
-            git reset --hard origin/main
+            # -B main: garante nome da branch local = main (reset --hard sozinho
+            # deixa HEAD no SHA certo mas pode manter branch feature antiga).
+            git checkout -B main origin/main
 
             echo "🔎 Resolvendo DATABASE_URL via Secrets Agent (como o runtime)..."
             SECRETS_AGENT_API_KEY="$(sudo grep '^SECRETS_AGENT_API_KEY=' /etc/crypto-agent/secrets-api.env 2>/dev/null | cut -d= -f2-)"

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T00:20:13.763681+00:00",
+  "generated_at": "2026-08-07T11:21:20.417666+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-06T00:20:13.763681+00:00`
+- Generated at: `2026-08-07T11:21:20.417666+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `211`


### PR DESCRIPTION
## Summary
- O job **Deploy no Servidor** usava `git reset --hard origin/main`, que deixa o SHA correto mas **não troca o nome da branch** se o checkout local estava em uma feature.
- No homelab, `/home/homelab/myClaude` ficou em `fix/approval-gateway-callback-compose` com HEAD = main (corrigido one-shot no servidor).
- Troca para `git checkout -B main origin/main` para o próximo deploy manter `main` + tracking.

## One-shot (já feito)
No servidor: `git checkout -B main origin/main` → branch `main`, SHA `81e5e77a`, up to date com `origin/main`. Sem restart de serviços (só nome da branch).

## Test plan
- [x] One-shot no homelab: `git branch --show-current` = `main`
- [ ] Após merge, próximo push em main: log do deploy mostra checkout em main
- [ ] `git status -sb` no deploy path: `## main...origin/main`