### PR TITLE
fix(ops): pihole-run anti-drift (8053 + named volumes)

### DIFF
--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,20 +1,18 @@
 {
-  "generated_at": "2026-08-07T15:55:29.577348+00:00",
-  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/fix-deploy-trading-daily-report-same-file",
+  "generated_at": "2026-08-07T16:06:18.414480+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/fix-pihole-port-anti-drift",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 211,
+    "repo_services": 213,
     "trading_instances": 12,
-    "critical_services": 85,
+    "critical_services": 213,
     "domains": {
       "identity": 4,
       "monitoring": 19,
-      "network": 23,
-      "storage": 39,
-      "trading": 126
+      "network": 190
     }
   },
   "trading_instances": [
@@ -381,10 +379,338 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "glpi",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "glpi-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "hostd",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.sia.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mail-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mail-server",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-backend",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-dovecot",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-frontend",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-postfix",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "mailu-roundcube",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-postgres",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-redis-cache",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "netbox-worker",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nginx",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ntopng",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ntopng-redis",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "opensearch-dashboards",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "opensearch-node1",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "pihole",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/pihole/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "postgres",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.email-simple.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "printshare",
+      "domain": "network",
+      "kind": "compose",
+      "source": "deploy/printshare/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "proxy",
       "domain": "network",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "roundcube",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "wikijs",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "wikijs-db",
+      "domain": "network",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "akash-sweep.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "akash-sweep.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "approval-gateway.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/approval-gateway.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "auto_validate.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/auto_validate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "autonomous_remediator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/autonomous_remediator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "bn-acervo-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/bn-acervo-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "check_projects.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/check_projects.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "check_projects.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/check_projects.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "chromecast-ambilight.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/chromecast-ambilight.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "clear-agent@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/clear-agent@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "clear-trading-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/clear-trading-agent.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -421,6 +747,62 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "coordinator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/coordinator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "crypto-agent@.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/crypto-agent@.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-broadcast.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-broadcast.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "daily-agenda-panel.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-panel.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "decisions-track-record-rollup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "decisions-track-record-rollup.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "dhcp-selfheal.service",
       "domain": "network",
       "kind": "systemd",
@@ -429,10 +811,210 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "diretor.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/diretor.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-clean.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-clean.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-spindown.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/homelab/disk-spindown.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-calendar.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-calendar.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-expurgo.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-expurgo.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-telegram-bot.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-telegram-bot.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-tray-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/eddie-tray-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "eddie-whatsapp-bot.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/eddie-whatsapp-bot.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ethwan-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "faster-whisper-api.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/faster-whisper-api.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "final-boot-status-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "fix-staging-perms.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/fix-staging-perms.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "gdrive-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/gdrive-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "github-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/github-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-dashboard.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-disk-backup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/backup/homelab-disk-backup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "homelab-lan-gateway.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/homelab-lan-gateway.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-presence-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "iot-presence-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -461,6 +1043,62 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "journal-ingestor.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "journal-ingestor.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-postgres-sync.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-postgres-sync.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "llm-log-panel.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/llm-log-panel.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "localtunnel@.service",
       "domain": "network",
       "kind": "systemd",
@@ -469,10 +1107,386 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "ltfs-backup-catalog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-boot-reconcile.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-boot-reconcile.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-button-watch.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-button-watch.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-cache-flush.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-cache-flush.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-deep-recovery.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-selfheal-escalator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-sg1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6b.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6b.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-checkpoint-drain.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-drain.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-checkpoint-recover.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-recover.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-smb-proof-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-api.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-api.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-daily-report.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-daily-report.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-email-drip.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-email-drip.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-x-posts.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "marketing-x-posts.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "meeting-translator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/meeting-translator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nas-ollama-load.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/nas-ollama-load.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "notebook-power-agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "nvidia-clock-limit.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/nvidia-clock-limit.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-finetune.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-finetune.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu-coordinator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu-coordinator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/ollama-gpu-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-gpu1.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-warmup.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ollama-warmup.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "pandaplus-telegram-bridge.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/pandaplus-telegram-bridge.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "pihole-ipv6-dns-fix.service",
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/pihole-ipv6-dns-fix.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "pihole.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/pihole.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "post-boot-check.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/post-boot-check.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "printshare.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/printshare/printshare.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -533,10 +1547,66 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "python-training.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/python-training.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "python-training.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/python-training.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rag-reindex.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rag-reindex.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "review-service.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/systemd/review-service.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "rpa4all-ddns-server.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/rpa4all-ddns-server.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-validation.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "rpa4all-validation.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -549,10 +1619,250 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "secrets_agent.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "tools/secrets_agent/secrets_agent.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "server-error-alert.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "deploy/homelab/server-error-alert.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
       "name": "sia-api-proxy.service",
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/sia-api-proxy.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "sia-host-shim.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/sia-host-shim.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "sia-macvlan-network.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-network.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "sia-macvlan-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "sia-macvlan-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "sia-port-forward.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/sia-port-forward.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "specialized_agents-dashboard.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-host-shim.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-host-shim.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-network.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-network.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-safe-eject.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tape-safe-eject.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-daily-report.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "trading-daily-report.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-local-key-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-local-key-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-renewer.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-renewer.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-selfheal.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tuya-token-selfheal.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "whatsapp-persona-panel.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-persona-panel.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.service",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.timer",
+      "domain": "network",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -565,1324 +1875,28 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "disk-clean.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-spindown.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/homelab/disk-spindown.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-disk-backup.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "tools/backup/homelab-disk-backup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-boot-reconcile.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-boot-reconcile.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-button-watch.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-button-watch.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-cache-flush.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-cache-flush.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-catalog-verify.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-catalog-verify.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-catalog-verify.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-catalog-verify.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-deep-recovery.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-deep-recovery.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-journal-replicate.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-journal-replicate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-journal-replicate.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-journal-replicate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-selfheal-escalator.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-sg1.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6b.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6b.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-host-shim.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-host-shim.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-network.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-network.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-log-spool-drain-nextcloud.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-log-spool-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-log-spool-drain-nextcloud.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.timer",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-safe-eject.service",
-      "domain": "storage",
-      "kind": "systemd",
-      "source": "systemd/tape-safe-eject.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "glpi",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "glpi-db",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "hostd",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.sia.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mail-db",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mail-server",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-backend",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-db",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-dovecot",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-frontend",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-postfix",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-redis",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "mailu-roundcube",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-postgres",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-redis",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-redis-cache",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "netbox-worker",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nginx",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ntopng",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ntopng-redis",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "opensearch-dashboards",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "opensearch-node1",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "postgres",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.email-simple.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "printshare",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "deploy/printshare/docker-compose.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "roundcube",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "wikijs",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "wikijs-db",
-      "domain": "trading",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "akash-sweep.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "akash-sweep.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "approval-gateway.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/approval-gateway.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "auto_validate.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "deploy/auto_validate.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "autonomous_remediator.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/systemd/autonomous_remediator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "bn-acervo-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/bn-acervo-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "candle-collector.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "candle-collector.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "check_projects.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/check_projects.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "check_projects.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/check_projects.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "chromecast-ambilight.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/chromecast-ambilight.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "clear-agent@.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/clear-agent@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "clear-trading-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/clear-trading-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "coordinator.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/coordinator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "crypto-agent@.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/crypto-agent@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-broadcast.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-broadcast.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "daily-agenda-panel.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-panel.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "decisions-track-record-rollup.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "decisions-track-record-rollup.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "diretor.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/diretor.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-calendar.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/eddie-calendar.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-expurgo.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/eddie-expurgo.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-telegram-bot.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/eddie-telegram-bot.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-tray-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/systemd/eddie-tray-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "eddie-whatsapp-bot.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/eddie-whatsapp-bot.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ethwan-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ethwan-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "faster-whisper-api.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/faster-whisper-api.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "final-boot-status-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/systemd/final-boot-status-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "fix-staging-perms.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/fix-staging-perms.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "gdrive-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/systemd/gdrive-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "github-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/github-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "homelab-dashboard.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/homelab-dashboard.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "iot-presence-watchdog.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "iot-presence-watchdog.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "journal-ingestor.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "journal-ingestor.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-postgres-sync.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-postgres-sync.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "llm-log-panel.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/llm-log-panel.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-checkpoint-drain.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-drain.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-checkpoint-recover.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-recover.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-selfheal.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "lto6-smb-proof-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-api.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-api.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-daily-report.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-daily-report.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-email-drip.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-email-drip.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-x-posts.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "marketing-x-posts.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "meeting-translator.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/meeting-translator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nas-ollama-load.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/nas-ollama-load.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "notebook-power-agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/notebook-power-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "nvidia-clock-limit.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/nvidia-clock-limit.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-finetune.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-finetune.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu-coordinator.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu-coordinator.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/ollama-gpu-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-gpu1.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu1.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-warmup.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "ollama-warmup.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "pandaplus-telegram-bridge.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/pandaplus-telegram-bridge.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "post-boot-check.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/post-boot-check.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "printshare.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "deploy/printshare/printshare.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "python-training.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/python-training.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "python-training.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/python-training.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rag-reindex.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rag-reindex.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "review-service.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/systemd/review-service.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rpa4all-validation.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "rpa4all-validation.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "secrets_agent.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "tools/secrets_agent/secrets_agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "server-error-alert.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "deploy/homelab/server-error-alert.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "sia-host-shim.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/sia-host-shim.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "sia-macvlan-network.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-network.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "sia-macvlan-watchdog.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-watchdog.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "sia-macvlan-watchdog.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-watchdog.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "sia-port-forward.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/sia-port-forward.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "specialized_agents-dashboard.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/specialized_agents-dashboard.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-daily-report.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "trading-daily-report.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-local-key-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-local-key-selfheal.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-renewer.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-renewer.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-selfheal.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "tuya-token-selfheal.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "whatsapp-persona-panel.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-persona-panel.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.service",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.timer",
-      "domain": "trading",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
-    },
-    {
       "name": "workstation-win11l-http@.service",
-      "domain": "trading",
+      "domain": "network",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-http@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
     },
     {
       "name": "workstation-win11l-rdp@.service",
-      "domain": "trading",
+      "domain": "network",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-rdp@.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
     },
     {
       "name": "x-agent.service",
-      "domain": "trading",
+      "domain": "network",
       "kind": "systemd",
       "source": "tools/x_agent/x-agent.service",
-      "recommended_owner": "application",
-      "candidate_system": "GLPI review"
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
     },
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
@@ -2287,10 +2301,297 @@
         "critical": true
       },
       {
+        "name": "glpi",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "glpi-db",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "hostd",
+        "domain": "network",
+        "source": "docker/docker-compose.sia.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mail-db",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mail-server",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-backend",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-db",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-dovecot",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-frontend",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-postfix",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-redis",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "mailu-roundcube",
+        "domain": "network",
+        "source": "docker/docker-compose.mailu.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-postgres",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-redis",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-redis-cache",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "netbox-worker",
+        "domain": "network",
+        "source": "deploy/cmdb/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "nginx",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "ntopng",
+        "domain": "network",
+        "source": "docker/docker-compose.ntopng.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "ntopng-redis",
+        "domain": "network",
+        "source": "docker/docker-compose.ntopng.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "opensearch-dashboards",
+        "domain": "network",
+        "source": "docker/docker-compose.opensearch.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "opensearch-node1",
+        "domain": "network",
+        "source": "docker/docker-compose.opensearch.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "pihole",
+        "domain": "network",
+        "source": "deploy/pihole/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "postgres",
+        "domain": "network",
+        "source": "docker/docker-compose.email-simple.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "printshare",
+        "domain": "network",
+        "source": "deploy/printshare/docker-compose.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
         "name": "proxy",
         "domain": "network",
         "source": "deploy/cmdb/docker-compose.yml",
         "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "roundcube",
+        "domain": "network",
+        "source": "docker/docker-compose.simple-mail.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "wikijs",
+        "domain": "network",
+        "source": "docker/docker-compose.wikijs.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "wikijs-db",
+        "domain": "network",
+        "source": "docker/docker-compose.wikijs.yml",
+        "kind": "compose",
+        "critical": true
+      },
+      {
+        "name": "akash-sweep.service",
+        "domain": "network",
+        "source": "systemd/akash-sweep.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "akash-sweep.timer",
+        "domain": "network",
+        "source": "systemd/akash-sweep.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "approval-gateway.service",
+        "domain": "network",
+        "source": "systemd/approval-gateway.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "auto_validate.service",
+        "domain": "network",
+        "source": "deploy/auto_validate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "autonomous_remediator.service",
+        "domain": "network",
+        "source": "tools/systemd/autonomous_remediator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "bn-acervo-agent.service",
+        "domain": "network",
+        "source": "systemd/bn-acervo-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "candle-collector.service",
+        "domain": "network",
+        "source": "systemd/candle-collector.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "candle-collector.timer",
+        "domain": "network",
+        "source": "systemd/candle-collector.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "check_projects.service",
+        "domain": "network",
+        "source": "systemd/check_projects.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "check_projects.timer",
+        "domain": "network",
+        "source": "systemd/check_projects.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "chromecast-ambilight.service",
+        "domain": "network",
+        "source": "systemd/chromecast-ambilight.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "clear-agent@.service",
+        "domain": "network",
+        "source": "systemd/clear-agent@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "clear-trading-agent.service",
+        "domain": "network",
+        "source": "systemd/clear-trading-agent.service",
+        "kind": "systemd",
         "critical": true
       },
       {
@@ -2322,6 +2623,55 @@
         "critical": true
       },
       {
+        "name": "coordinator.service",
+        "domain": "network",
+        "source": "systemd/coordinator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "crypto-agent@.service",
+        "domain": "network",
+        "source": "systemd/crypto-agent@.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-broadcast.service",
+        "domain": "network",
+        "source": "systemd/daily-agenda-broadcast.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-broadcast.timer",
+        "domain": "network",
+        "source": "systemd/daily-agenda-broadcast.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "daily-agenda-panel.service",
+        "domain": "network",
+        "source": "systemd/daily-agenda-panel.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "decisions-track-record-rollup.service",
+        "domain": "network",
+        "source": "systemd/decisions-track-record-rollup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "decisions-track-record-rollup.timer",
+        "domain": "network",
+        "source": "systemd/decisions-track-record-rollup.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "dhcp-selfheal.service",
         "domain": "network",
         "source": "systemd/dhcp-selfheal.service",
@@ -2329,9 +2679,184 @@
         "critical": true
       },
       {
+        "name": "diretor.service",
+        "domain": "network",
+        "source": "systemd/diretor.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.service",
+        "domain": "network",
+        "source": "systemd/disk-clean.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-clean.timer",
+        "domain": "network",
+        "source": "systemd/disk-clean.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "disk-spindown.service",
+        "domain": "network",
+        "source": "tools/homelab/disk-spindown.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-calendar.service",
+        "domain": "network",
+        "source": "systemd/eddie-calendar.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-expurgo.service",
+        "domain": "network",
+        "source": "systemd/eddie-expurgo.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-telegram-bot.service",
+        "domain": "network",
+        "source": "systemd/eddie-telegram-bot.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-tray-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/eddie-tray-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "eddie-whatsapp-bot.service",
+        "domain": "network",
+        "source": "systemd/eddie-whatsapp-bot.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ethwan-selfheal.service",
+        "domain": "network",
+        "source": "systemd/ethwan-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "faster-whisper-api.service",
+        "domain": "network",
+        "source": "systemd/faster-whisper-api.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "final-boot-status-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/final-boot-status-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "fix-staging-perms.service",
+        "domain": "network",
+        "source": "systemd/fix-staging-perms.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "gdrive-agent.service",
+        "domain": "network",
+        "source": "tools/systemd/gdrive-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "github-agent.service",
+        "domain": "network",
+        "source": "systemd/github-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-dashboard.service",
+        "domain": "network",
+        "source": "systemd/homelab-dashboard.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-disk-backup.service",
+        "domain": "network",
+        "source": "tools/backup/homelab-disk-backup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "homelab-lan-gateway.service",
         "domain": "network",
         "source": "deploy/vpn/homelab-lan-gateway.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-log-drain-sg1.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.service",
+        "domain": "network",
+        "source": "systemd/homelab-tape-logrotate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.timer",
+        "domain": "network",
+        "source": "systemd/homelab-tape-logrotate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-presence-watchdog.service",
+        "domain": "network",
+        "source": "systemd/iot-presence-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "iot-presence-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/iot-presence-watchdog.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2357,6 +2882,55 @@
         "critical": true
       },
       {
+        "name": "journal-ingestor.service",
+        "domain": "network",
+        "source": "systemd/journal-ingestor.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "journal-ingestor.timer",
+        "domain": "network",
+        "source": "systemd/journal-ingestor.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-postgres-sync.service",
+        "domain": "network",
+        "source": "systemd/kucoin-postgres-sync.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-postgres-sync.timer",
+        "domain": "network",
+        "source": "systemd/kucoin-postgres-sync.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-usdt-rebalance.service",
+        "domain": "network",
+        "source": "systemd/kucoin-usdt-rebalance.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "kucoin-usdt-rebalance.timer",
+        "domain": "network",
+        "source": "systemd/kucoin-usdt-rebalance.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "llm-log-panel.service",
+        "domain": "network",
+        "source": "systemd/llm-log-panel.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "localtunnel@.service",
         "domain": "network",
         "source": "tools/tunnels/localtunnel@.service",
@@ -2364,9 +2938,338 @@
         "critical": true
       },
       {
+        "name": "ltfs-backup-catalog.service",
+        "domain": "network",
+        "source": "systemd/ltfs-backup-catalog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-backup-catalog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-boot-reconcile.service",
+        "domain": "network",
+        "source": "systemd/ltfs-boot-reconcile.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-button-watch.service",
+        "domain": "network",
+        "source": "systemd/ltfs-button-watch.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-cache-flush.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-cache-flush.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.service",
+        "domain": "network",
+        "source": "systemd/ltfs-catalog-verify.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-catalog-verify.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-deep-recovery.service",
+        "domain": "network",
+        "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.service",
+        "domain": "network",
+        "source": "systemd/ltfs-journal-replicate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-journal-replicate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.service",
+        "domain": "network",
+        "source": "systemd/ltfs-log-rotation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-log-rotation.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-selfheal-escalator.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-sg1.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6b.service",
+        "domain": "network",
+        "source": "systemd/ltfs-lto6b.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.service",
+        "domain": "network",
+        "source": "systemd/ltfs-window-enforcer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.timer",
+        "domain": "network",
+        "source": "systemd/ltfs-window-enforcer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-checkpoint-drain.service",
+        "domain": "network",
+        "source": "systemd/lto6-checkpoint-drain.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-checkpoint-recover.service",
+        "domain": "network",
+        "source": "systemd/lto6-checkpoint-recover.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.service",
+        "domain": "network",
+        "source": "systemd/lto6-drain-backups.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.timer",
+        "domain": "network",
+        "source": "systemd/lto6-drain-backups.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-selfheal.service",
+        "domain": "network",
+        "source": "systemd/lto6-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/lto6-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-smb-proof-selfheal.service",
+        "domain": "network",
+        "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-api.service",
+        "domain": "network",
+        "source": "systemd/marketing-api.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-daily-report.service",
+        "domain": "network",
+        "source": "systemd/marketing-daily-report.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-daily-report.timer",
+        "domain": "network",
+        "source": "systemd/marketing-daily-report.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-email-drip.service",
+        "domain": "network",
+        "source": "systemd/marketing-email-drip.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-email-drip.timer",
+        "domain": "network",
+        "source": "systemd/marketing-email-drip.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-x-posts.service",
+        "domain": "network",
+        "source": "systemd/marketing-x-posts.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "marketing-x-posts.timer",
+        "domain": "network",
+        "source": "systemd/marketing-x-posts.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "meeting-translator.service",
+        "domain": "network",
+        "source": "systemd/meeting-translator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "nas-ollama-load.service",
+        "domain": "network",
+        "source": "systemd/nas-ollama-load.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "notebook-power-agent.service",
+        "domain": "network",
+        "source": "systemd/notebook-power-agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "nvidia-clock-limit.service",
+        "domain": "network",
+        "source": "systemd/nvidia-clock-limit.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-finetune.service",
+        "domain": "network",
+        "source": "systemd/ollama-finetune.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-finetune.timer",
+        "domain": "network",
+        "source": "systemd/ollama-finetune.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu-coordinator.service",
+        "domain": "network",
+        "source": "systemd/ollama-gpu-coordinator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu-selfheal.service",
+        "domain": "network",
+        "source": "tools/ollama-gpu-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-gpu1.service",
+        "domain": "network",
+        "source": "systemd/ollama-gpu1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-warmup.service",
+        "domain": "network",
+        "source": "systemd/ollama-warmup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ollama-warmup.timer",
+        "domain": "network",
+        "source": "systemd/ollama-warmup.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "pandaplus-telegram-bridge.service",
+        "domain": "network",
+        "source": "systemd/pandaplus-telegram-bridge.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "pihole-ipv6-dns-fix.service",
         "domain": "network",
         "source": "systemd/pihole-ipv6-dns-fix.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "pihole.service",
+        "domain": "network",
+        "source": "systemd/pihole.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "post-boot-check.service",
+        "domain": "network",
+        "source": "systemd/post-boot-check.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "printshare.service",
+        "domain": "network",
+        "source": "deploy/printshare/printshare.service",
         "kind": "systemd",
         "critical": true
       },
@@ -2420,9 +3323,58 @@
         "critical": true
       },
       {
+        "name": "python-training.service",
+        "domain": "network",
+        "source": "systemd/python-training.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "python-training.timer",
+        "domain": "network",
+        "source": "systemd/python-training.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rag-reindex.service",
+        "domain": "network",
+        "source": "systemd/rag-reindex.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rag-reindex.timer",
+        "domain": "network",
+        "source": "systemd/rag-reindex.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "review-service.service",
+        "domain": "network",
+        "source": "tools/systemd/review-service.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "rpa4all-ddns-server.service",
         "domain": "network",
         "source": "deploy/vpn/rpa4all-ddns-server.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-validation.service",
+        "domain": "network",
+        "source": "systemd/rpa4all-validation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "rpa4all-validation.timer",
+        "domain": "network",
+        "source": "systemd/rpa4all-validation.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2434,9 +3386,219 @@
         "critical": true
       },
       {
+        "name": "secrets_agent.service",
+        "domain": "network",
+        "source": "tools/secrets_agent/secrets_agent.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "server-error-alert.service",
+        "domain": "network",
+        "source": "deploy/homelab/server-error-alert.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
         "name": "sia-api-proxy.service",
         "domain": "network",
         "source": "systemd/sia-api-proxy.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "sia-host-shim.service",
+        "domain": "network",
+        "source": "systemd/sia-host-shim.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "sia-macvlan-network.service",
+        "domain": "network",
+        "source": "systemd/sia-macvlan-network.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "sia-macvlan-watchdog.service",
+        "domain": "network",
+        "source": "systemd/sia-macvlan-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "sia-macvlan-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/sia-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "sia-port-forward.service",
+        "domain": "network",
+        "source": "systemd/sia-port-forward.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "specialized_agents-dashboard.service",
+        "domain": "network",
+        "source": "systemd/specialized_agents-dashboard.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-host-shim.service",
+        "domain": "network",
+        "source": "systemd/storj-host-shim.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-network.service",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-network.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.service",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.timer",
+        "domain": "network",
+        "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.service",
+        "domain": "network",
+        "source": "systemd/tape-log-spool-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.timer",
+        "domain": "network",
+        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.service",
+        "domain": "network",
+        "source": "systemd/tape-quality-ollama-narrator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.timer",
+        "domain": "network",
+        "source": "systemd/tape-quality-ollama-narrator.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-safe-eject.service",
+        "domain": "network",
+        "source": "systemd/tape-safe-eject.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-analyst-weekly-retrain.service",
+        "domain": "network",
+        "source": "systemd/trading-analyst-weekly-retrain.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-analyst-weekly-retrain.timer",
+        "domain": "network",
+        "source": "systemd/trading-analyst-weekly-retrain.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-daily-report.service",
+        "domain": "network",
+        "source": "systemd/trading-daily-report.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "trading-daily-report.timer",
+        "domain": "network",
+        "source": "systemd/trading-daily-report.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-local-key-selfheal.service",
+        "domain": "network",
+        "source": "systemd/tuya-local-key-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-local-key-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/tuya-local-key-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-renewer.service",
+        "domain": "network",
+        "source": "systemd/tuya-token-renewer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-renewer.timer",
+        "domain": "network",
+        "source": "systemd/tuya-token-renewer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-selfheal.service",
+        "domain": "network",
+        "source": "systemd/tuya-token-selfheal.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tuya-token-selfheal.timer",
+        "domain": "network",
+        "source": "systemd/tuya-token-selfheal.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "whatsapp-persona-panel.service",
+        "domain": "network",
+        "source": "systemd/whatsapp-persona-panel.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "whatsapp-toolcall-chunked-train.service",
+        "domain": "network",
+        "source": "systemd/whatsapp-toolcall-chunked-train.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "whatsapp-toolcall-chunked-train.timer",
+        "domain": "network",
+        "source": "systemd/whatsapp-toolcall-chunked-train.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2448,275 +3610,23 @@
         "critical": true
       },
       {
-        "name": "disk-clean.service",
-        "domain": "storage",
-        "source": "systemd/disk-clean.service",
+        "name": "workstation-win11l-http@.service",
+        "domain": "network",
+        "source": "systemd/workstation-win11l-http@.service",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "disk-clean.timer",
-        "domain": "storage",
-        "source": "systemd/disk-clean.timer",
+        "name": "workstation-win11l-rdp@.service",
+        "domain": "network",
+        "source": "systemd/workstation-win11l-rdp@.service",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "disk-spindown.service",
-        "domain": "storage",
-        "source": "tools/homelab/disk-spindown.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-disk-backup.service",
-        "domain": "storage",
-        "source": "tools/backup/homelab-disk-backup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-log-drain-sg1.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.service",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-logrotate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.timer",
-        "domain": "storage",
-        "source": "systemd/homelab-tape-logrotate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-backup-catalog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-backup-catalog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-boot-reconcile.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-boot-reconcile.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-button-watch.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-button-watch.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-cache-flush.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-cache-flush.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-catalog-verify.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-catalog-verify.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-catalog-verify.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-catalog-verify.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-deep-recovery.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-deep-recovery.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-journal-replicate.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-journal-replicate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-journal-replicate.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-journal-replicate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-log-rotation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-log-rotation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-selfheal-escalator.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-sg1.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6b.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-lto6b.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.service",
-        "domain": "storage",
-        "source": "systemd/ltfs-window-enforcer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.timer",
-        "domain": "storage",
-        "source": "systemd/ltfs-window-enforcer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.service",
-        "domain": "storage",
-        "source": "systemd/lto6-drain-backups.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.timer",
-        "domain": "storage",
-        "source": "systemd/lto6-drain-backups.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-host-shim.service",
-        "domain": "storage",
-        "source": "systemd/storj-host-shim.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-network.service",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-network.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.service",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.timer",
-        "domain": "storage",
-        "source": "systemd/storj-macvlan-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-log-spool-drain-nextcloud.service",
-        "domain": "storage",
-        "source": "systemd/tape-log-spool-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-log-spool-drain-nextcloud.timer",
-        "domain": "storage",
-        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.service",
-        "domain": "storage",
-        "source": "systemd/tape-quality-ollama-narrator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.timer",
-        "domain": "storage",
-        "source": "systemd/tape-quality-ollama-narrator.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-safe-eject.service",
-        "domain": "storage",
-        "source": "systemd/tape-safe-eject.service",
+        "name": "x-agent.service",
+        "domain": "network",
+        "source": "tools/x_agent/x-agent.service",
         "kind": "systemd",
         "critical": true
       }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-07T15:55:29.577348+00:00`
+- Generated at: `2026-08-07T16:06:18.414480+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `211`
-- Critical services flagged for MVP: `85`
+- Repo services discovered: `213`
+- Critical services flagged for MVP: `213`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,9 +12,7 @@
 
 - `identity`: 4
 - `monitoring`: 19
-- `network`: 23
-- `storage`: 39
-- `trading`: 126
+- `network`: 190
 
 ## Trading profile instances (`12`)
 
@@ -60,23 +58,23 @@
 - `storj-payout-monitor.timer` (monitoring, systemd) from `systemd/storj-payout-monitor.timer`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `tunnel-healthcheck-exporter.service` (monitoring, systemd) from `systemd/tunnel-healthcheck-exporter.service`
-- `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
-- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
-- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
-- `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
-- `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
-- `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
-- `iot-vpn-bypass-watchdog.service` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.service`
-- `iot-vpn-bypass-watchdog.timer` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.timer`
-- `ipv6-proxy.service` (network, systemd) from `systemd/ipv6-proxy.service`
-- `localtunnel@.service` (network, systemd) from `tools/tunnels/localtunnel@.service`
-- `pihole-ipv6-dns-fix.service` (network, systemd) from `systemd/pihole-ipv6-dns-fix.service`
-- `protonvpn-best-server.service` (network, systemd) from `systemd/protonvpn-best-server.service`
-- `protonvpn-best-server.timer` (network, systemd) from `systemd/protonvpn-best-server.timer`
-- `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
-- `protonvpn-routing-watchdog-fix.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog-fix.service`
-- `protonvpn-routing-watchdog.service` (network, systemd) from `deploy/vpn/protonvpn-routing-watchdog.service`
+- `glpi` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `glpi-db` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `hostd` (network, compose) from `docker/docker-compose.sia.yml`
+- `mail-db` (network, compose) from `docker/docker-compose.simple-mail.yml`
+- `mail-server` (network, compose) from `docker/docker-compose.simple-mail.yml`
+- `mailu-backend` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-db` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-dovecot` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-frontend` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-postfix` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-redis` (network, compose) from `docker/docker-compose.mailu.yml`
+- `mailu-roundcube` (network, compose) from `docker/docker-compose.mailu.yml`
+- `netbox` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-postgres` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-redis` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-redis-cache` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `netbox-worker` (network, compose) from `deploy/cmdb/docker-compose.yml`
 
 ## Serviços anotados manualmente
 

--- a/deploy/pihole/README.md
+++ b/deploy/pihole/README.md
@@ -1,0 +1,47 @@
+# Pi-hole (homelab) — anti-drift
+
+## Contract
+
+| Surface | Owner |
+|---------|--------|
+| `:80` / `:443` | **nginx** (vhosts rpa4all) |
+| `:8053` | **Pi-hole Admin** (`FTLCONF_webserver_port=8053`) |
+| `:53` | host **dnsmasq** and/or FTL (validate after changes) |
+| Config data | Docker volumes **`pihole_config`**, **`pihole_dnsmasq`** (on storj) |
+
+## Why this exists
+
+`pihole-run.sh` used to `docker start` any existing container and exit. A drifted container (no `FTLCONF_webserver_port`, wrong bind mounts) stayed on **:80/:443** and broke nginx forever.
+
+## Deploy to host
+
+```bash
+# from monorepo
+sudo install -m 0755 deploy/pihole/pihole-run.sh /usr/local/sbin/pihole-run.sh
+sudo install -m 0644 deploy/pihole/docker-compose.yml /home/homelab/pihole/docker-compose.yml
+# optional unit already points at pihole-run.sh
+sudo systemctl daemon-reload
+sudo systemctl start pihole.service
+```
+
+Optional password file (root-only):
+
+```bash
+# /etc/pihole/container.env
+WEBPASSWORD=...
+```
+
+## Verify
+
+```bash
+ss -lntp | grep -E ':80 |:443 |:8053 '
+# expect nginx on 80/443, something on 8053
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8053/admin/
+docker inspect pihole --format '{{range .Config.Env}}{{println .}}{{end}}' | grep webserver
+```
+
+Admin UI: `http://192.168.15.2:8053/admin/`
+
+## Rollback
+
+Use backup recreate scripts under `/home/homelab/pihole/backups/nginx-pihole-*/` if needed.

--- a/deploy/pihole/docker-compose.yml
+++ b/deploy/pihole/docker-compose.yml
@@ -1,0 +1,40 @@
+# Pi-hole — aligned with production anti-drift contract (2026-08-07)
+# - network_mode: host
+# - Web UI :8053 only (nginx owns :80/:443)
+# - Named volumes pihole_config / pihole_dnsmasq (live data under storj docker volumes)
+#
+# Prefer: /usr/local/sbin/pihole-run.sh (systemd pihole.service)
+# Compose is the declarative twin for operators using `docker compose`.
+#
+# Secrets: set WEBPASSWORD via environment or /etc/pihole/container.env — never commit.
+
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:latest
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      TZ: "America/Sao_Paulo"
+      WEBPASSWORD: "${WEBPASSWORD:-}"
+      FTLCONF_dns_listeningMode: "single"
+      FTLCONF_dns_upstreams: "1.1.1.1;1.0.0.1;8.8.8.8;8.8.4.4"
+      # Web UI port 8053 — nginx uses 80/443
+      FTLCONF_webserver_port: "8053"
+      FTLCONF_dhcp_active: "false"
+      FTLCONF_dns_interface: "eth-onboard"
+      PIHOLE_DOMAIN: "local"
+      FTL_CMD: "no-daemon"
+    volumes:
+      - pihole_config:/etc/pihole
+      - pihole_dnsmasq:/etc/dnsmasq.d
+    cap_add:
+      - NET_ADMIN
+
+volumes:
+  pihole_config:
+    external: true
+    name: pihole_config
+  pihole_dnsmasq:
+    external: true
+    name: pihole_dnsmasq

--- a/deploy/pihole/pihole-run.sh
+++ b/deploy/pihole/pihole-run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Ensure the Pi-hole container is running with the anti-drift contract:
+#   - network_mode=host
+#   - Web UI on :8053 only (nginx owns :80/:443)
+#   - Named volumes pihole_config + pihole_dnsmasq (live gravity/config on storj)
+#
+# Install on host: /usr/local/sbin/pihole-run.sh (called by systemd pihole.service)
+# Do NOT "docker start" a drifted container and exit — that reintroduced :80/:443.
+set -euo pipefail
+
+NAME="${PIHOLE_NAME:-pihole}"
+IMAGE="${PIHOLE_IMAGE:-pihole/pihole:latest}"
+WEB_PORT="${FTLCONF_webserver_port:-8053}"
+VOL_CONFIG="${PIHOLE_CONFIG_VOLUME:-pihole_config}"
+VOL_DNSMASQ="${PIHOLE_DNSMASQ_VOLUME:-pihole_dnsmasq}"
+# Optional host file for WEBPASSWORD / overrides (never commit secrets).
+ENV_FILE="${PIHOLE_ENV_FILE:-/etc/pihole/container.env}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+fi
+
+WEB_PORT="${FTLCONF_webserver_port:-${WEB_PORT}}"
+
+log() { printf '%s %s\n' "$(date -Is)" "$*"; }
+
+container_exists() {
+  docker ps -a --format '{{.Names}}' | grep -qx "${NAME}"
+}
+
+env_web_port() {
+  docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "${NAME}" 2>/dev/null \
+    | sed -n 's/^FTLCONF_webserver_port=//p' | tail -n1
+}
+
+uses_named_volume() {
+  local vol="$1" dest="$2"
+  docker inspect -f '{{range .Mounts}}{{println .Type " " .Name " " .Destination}}{{end}}' "${NAME}" 2>/dev/null \
+    | awk -v v="${vol}" -v d="${dest}" '$1=="volume" && $2==v && $3==d {found=1} END{exit !found}'
+}
+
+needs_recreate() {
+  if ! container_exists; then
+    log "no container ${NAME} — will create"
+    return 0
+  fi
+  local port
+  port="$(env_web_port)"
+  if [[ "${port}" != "${WEB_PORT}" ]]; then
+    log "web port drift: FTLCONF_webserver_port='${port:-<empty>}' want='${WEB_PORT}' — recreate"
+    return 0
+  fi
+  if ! uses_named_volume "${VOL_CONFIG}" "/etc/pihole"; then
+    log "volume drift: want ${VOL_CONFIG}:/etc/pihole — recreate"
+    return 0
+  fi
+  if ! uses_named_volume "${VOL_DNSMASQ}" "/etc/dnsmasq.d"; then
+    log "volume drift: want ${VOL_DNSMASQ}:/etc/dnsmasq.d — recreate"
+    return 0
+  fi
+  return 1
+}
+
+create_container() {
+  log "creating ${NAME} image=${IMAGE} web=${WEB_PORT} vols=${VOL_CONFIG},${VOL_DNSMASQ}"
+  # WEBPASSWORD may be empty (matches current production); set via ENV_FILE if needed.
+  docker run -d \
+    --name "${NAME}" \
+    --network host \
+    --restart unless-stopped \
+    --cap-add NET_ADMIN \
+    -e TZ="${TZ:-America/Sao_Paulo}" \
+    -e "WEBPASSWORD=${WEBPASSWORD:-}" \
+    -e FTLCONF_dns_listeningMode="${FTLCONF_dns_listeningMode:-single}" \
+    -e FTLCONF_dns_interface="${FTLCONF_dns_interface:-eth-onboard}" \
+    -e "FTLCONF_dns_upstreams=${FTLCONF_dns_upstreams:-1.1.1.1;1.0.0.1;8.8.8.8;8.8.4.4}" \
+    -e "FTLCONF_webserver_port=${WEB_PORT}" \
+    -e FTLCONF_dhcp_active="${FTLCONF_dhcp_active:-false}" \
+    -e PIHOLE_DOMAIN="${PIHOLE_DOMAIN:-local}" \
+    -e FTL_CMD="${FTL_CMD:-no-daemon}" \
+    -v "${VOL_CONFIG}:/etc/pihole" \
+    -v "${VOL_DNSMASQ}:/etc/dnsmasq.d" \
+    "${IMAGE}" >/dev/null
+}
+
+if needs_recreate; then
+  docker rm -f "${NAME}" >/dev/null 2>&1 || true
+  create_container
+else
+  log "contract ok — docker start ${NAME}"
+  docker start "${NAME}" >/dev/null || true
+fi
+
+# Quick post-check (best-effort)
+sleep 2
+if docker ps --format '{{.Names}}' | grep -qx "${NAME}"; then
+  log "running; expect admin UI on :${WEB_PORT} (nginx should own :80/:443)"
+else
+  log "ERROR: ${NAME} not running"
+  exit 1
+fi

--- a/systemd/pihole.service
+++ b/systemd/pihole.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Pi-hole Container (anti-drift run script)
+After=network-online.target docker.service docker.socket
+Requires=docker.service docker.socket
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Wait for docker daemon
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do docker info >/dev/null 2>&1 && exit 0; sleep 2; done; exit 1'
+ExecStart=/usr/local/sbin/pihole-run.sh
+ExecStop=/usr/bin/docker stop pihole
+TimeoutStartSec=120
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- **Problem:** `pihole-run.sh` did `docker start` and exited, preserving a drifted container that bound **:80/:443** (host network) and broke nginx.
- **Fix:** Canonical `deploy/pihole/pihole-run.sh` enforces contract:
  - `FTLCONF_webserver_port=8053`
  - named volumes `pihole_config` + `pihole_dnsmasq`
  - recreate when env/volumes drift
- `docker-compose.yml` aligned (external named volumes, no bind to empty host dirs).
- `systemd/pihole.service` in repo for deploy parity.

## Host already updated
Installed on homelab and verified: `contract ok — docker start`, admin `:8053` 302, nginx 80/443, grafana 301.

## Test plan
- [x] `bash -n deploy/pihole/pihole-run.sh`
- [x] Host: run script → no unnecessary recreate when contract ok
- [x] `:8053/admin` 302; nginx active
- [ ] PR checks