### PR TITLE
fix(tuya): rate-limit bypass e reload zumbi sem queimar MAX_HEALS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 
 set -e
 
-echo "🔍 Running pre-commit checks..."
+echo "🔍 Running pre-commit checks (13 checks)..."
 
 # ─── Check 1: Blocked hardcoded tokens ───────────────────────────────────────
 echo "  [1/6] Checking for hardcoded API tokens..."
@@ -231,6 +231,20 @@ fi
 echo "  [12/12] Checking API taxonomy (duplicates)..."
 if [ -f "tools/hooks/api_registry_validate.py" ]; then
     if ! python3 tools/hooks/api_registry_validate.py --staged; then
+        exit 1
+    fi
+fi
+
+# ─── Check 13: Wiki documentation analysis ────────────────────────────────────
+# Valida estrutura, extrai termos-chave e detecta duplicatas em .md staged.
+# Alimenta memória do agente wiki para decisões futuras.
+echo "  [13/13] Analyzing wiki documentation..."
+if [ -f "tools/hooks/wiki_doc_analyzer.py" ]; then
+    PY_WIKI="$(dirname "$0")/../.venv/bin/python"
+    [ -x "$PY_WIKI" ] || PY_WIKI="python3"
+    if ! "$PY_WIKI" tools/hooks/wiki_doc_analyzer.py --staged --verbose; then
+        echo "❌ BLOCKED: Wiki documentation analysis failed"
+        echo "   Fix the errors or use --no-verify to skip"
         exit 1
     fi
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,26 @@ Monorepo do homelab RPA4All: automação, trading, Nextcloud/LTO, wiki, agentes 
 
 | Ferramenta | Quando usar |
 |------------|-------------|
-| **Claude Code / Grok Build** | Refactors grandes, multi-file, arquitetura |
-| **Codex** | Trechos com modelos OpenAI |
+| **Claude Code / Grok Build** | Orquestração paga: interpretar pedido, validar, acompanhar até sucesso; refactors grandes só quando free não bastar |
+| **Codex** | Trechos com modelos OpenAI (preferir free OpenRouter antes) |
+| **OpenRouter free / fleet PASS** | **Execução padrão** de coding, explore, drafts, review barato |
 | **Pi + Ollama** | Coding local barato / fallback (este arquivo é lido pelo Pi) |
 | **specialized_agents + systemd** | Domínio 24/7 (trading, Nextcloud, wiki, selfheal) |
 
 Setup Pi: `docs/PI_CODING_AGENT_SETUP.md`  
-Hooks Pi: `.pi/extensions/rpa4all-hooks/` (bridge para `tools/hooks` + `tools/copilot_hooks`)
+Hooks Pi: `.pi/extensions/rpa4all-hooks/` (bridge para `tools/hooks` + `tools/copilot_hooks`)  
+Fleet free: `~/apps/agents/agents/free-openrouter/fleet.yaml` · Traycer guide: `~/.traycer/agent-selection-guide.md`
+
+### 0. Free-first orchestration (2026-08-07)
+
+**Sempre distribuir atividades para agentes gratuitos.** Modelos pagos (Grok/Claude/GPT parent) são para:
+
+1. **Pensar** na requisição (escopo, riscos, plano, critérios de sucesso)
+2. **Delegar** a free workers com handoff completo
+3. **Validar** o resultado (código, testes, logs, claims)
+4. **Acompanhar** o loop até o sucesso — não abandonar após o primeiro handoff
+
+Exceções: skill Traycer que **exige** harness pago; risco extremo trading/LTO/rede onde o orquestrador age sob confirmação do usuário. Free **nunca** usa LLM chinês nem fleet `excluded`.
 
 ## Políticas críticas (não violar)
 
@@ -26,6 +39,7 @@ Hooks Pi: `.pi/extensions/rpa4all-hooks/` (bridge para `tools/hooks` + `tools/co
 7. Wiki: publicar via agent `wiki_rpa4all`, não scrape/update direto arbitrário.
 8. **Internet desta workstation**: preferir **RJ45** (`enp0s31f6`) e **Wi‑Fi GVT-38AA**; SSID **TANK** só como fallback. Hook: `tools/copilot_hooks/internet_preference_context.py`.
 9. **Web-agent log em tempo real**: ao chamar qualquer tool `web-agent__*`, o hook `tools/hooks/open_agent_log_terminal.py` abre (se ainda não estiver aberta) uma janela de terminal com `tail -F` do log `~/.grok/logs/mcp/web-agent.stderr.log`. Não é preciso chamar `monitor` só por causa do log.
+10. **Governança de ações (2026-08-08)**: todo agente (incl. Traycer GUI) que chamar `intent_declare(risk_level='medium'|'high'|'critical')` **DEVE** aguardar `intent_check_status(intent_id)` retornar `"approved"` antes de executar. O MCP server rejeita `intent_complete()` em intents `pending` — não tente bypassar. Aprovação é via Telegram (botões ✅/❌) ou texto livre ("sim"/"não"). **Trava de deploy (2026-08-09)**: ações com `action_type='deploy'` ou `action_type='restart'` **SEMPRE** exigem aprovação humana — o MCP server força `risk_level` para no mínimo `'medium'` mesmo que o agente declare `'low'` ou `'none'`.
 
 ## Layout útil
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T14:23:29.703647+00:00",
+  "generated_at": "2026-08-08T20:56:02.494018+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-07T16:06:18.414480+00:00",
-  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/fix-pihole-port-anti-drift",
+  "generated_at": "2026-08-08T14:20:29.760838+00:00",
+  "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
@@ -8,11 +8,14 @@
     "hosts": 1,
     "repo_services": 213,
     "trading_instances": 12,
-    "critical_services": 213,
+    "critical_services": 87,
     "domains": {
       "identity": 4,
       "monitoring": 19,
-      "network": 190
+      "network": 25,
+      "operations": 115,
+      "storage": 39,
+      "trading": 11
     }
   },
   "trading_instances": [
@@ -379,182 +382,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "glpi",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "glpi-db",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "hostd",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.sia.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mail-db",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mail-server",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-backend",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-db",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-dovecot",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-frontend",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-postfix",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-redis",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "mailu-roundcube",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.mailu.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-postgres",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-redis",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-redis-cache",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "netbox-worker",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nginx",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ntopng",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ntopng-redis",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.ntopng.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "opensearch-dashboards",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "opensearch-node1",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.opensearch.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "pihole",
       "domain": "network",
       "kind": "compose",
@@ -563,154 +390,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "postgres",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.email-simple.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "printshare",
-      "domain": "network",
-      "kind": "compose",
-      "source": "deploy/printshare/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "proxy",
       "domain": "network",
       "kind": "compose",
       "source": "deploy/cmdb/docker-compose.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "roundcube",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.simple-mail.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "wikijs",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "wikijs-db",
-      "domain": "network",
-      "kind": "compose",
-      "source": "docker/docker-compose.wikijs.yml",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "akash-sweep.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "akash-sweep.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/akash-sweep.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "approval-gateway.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/approval-gateway.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "auto_validate.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "deploy/auto_validate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "autonomous_remediator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/systemd/autonomous_remediator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "bn-acervo-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/bn-acervo-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "candle-collector.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/candle-collector.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "check_projects.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/check_projects.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "check_projects.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/check_projects.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "chromecast-ambilight.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/chromecast-ambilight.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "clear-agent@.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/clear-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "clear-trading-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/clear-trading-agent.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -747,62 +430,6 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "coordinator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "crypto-agent@.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/crypto-agent@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-broadcast.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-broadcast.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-broadcast.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "daily-agenda-panel.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/daily-agenda-panel.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "decisions-track-record-rollup.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "decisions-track-record-rollup.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/decisions-track-record-rollup.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "dhcp-selfheal.service",
       "domain": "network",
       "kind": "systemd",
@@ -811,210 +438,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "diretor.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/diretor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-clean.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/disk-clean.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "disk-spindown.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/homelab/disk-spindown.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-calendar.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/eddie-calendar.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-expurgo.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/eddie-expurgo.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-telegram-bot.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/eddie-telegram-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-tray-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/systemd/eddie-tray-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "eddie-whatsapp-bot.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/eddie-whatsapp-bot.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ethwan-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ethwan-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "faster-whisper-api.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/faster-whisper-api.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "final-boot-status-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/systemd/final-boot-status-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "fix-staging-perms.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/fix-staging-perms.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "gdrive-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/systemd/gdrive-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "github-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/github-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-dashboard.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-dashboard.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-disk-backup.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/backup/homelab-disk-backup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "homelab-lan-gateway.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/homelab-lan-gateway.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-nextcloud.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-log-drain-sg1.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-log-drain-sg1.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "homelab-tape-logrotate.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/homelab-tape-logrotate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-presence-watchdog.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "iot-presence-watchdog.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/iot-presence-watchdog.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1043,418 +470,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "journal-ingestor.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "journal-ingestor.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/journal-ingestor.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-postgres-sync.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-postgres-sync.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/kucoin-postgres-sync.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "kucoin-usdt-rebalance.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/kucoin-usdt-rebalance.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "llm-log-panel.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/llm-log-panel.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "localtunnel@.service",
       "domain": "network",
       "kind": "systemd",
       "source": "tools/tunnels/localtunnel@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-backup-catalog.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-backup-catalog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-boot-reconcile.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-boot-reconcile.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-button-watch.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-button-watch.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-cache-flush.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-cache-flush.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-catalog-verify.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-catalog-verify.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-catalog-verify.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-catalog-verify.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-deep-recovery.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-deep-recovery.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-journal-replicate.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-journal-replicate.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-journal-replicate.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-journal-replicate.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-log-rotation.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-log-rotation.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-selfheal-escalator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6-sg1.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6-sg1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-lto6b.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-lto6b.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ltfs-window-enforcer.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ltfs-window-enforcer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-checkpoint-drain.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-drain.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-checkpoint-recover.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-checkpoint-recover.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-drain-backups.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-drain-backups.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-selfheal.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/lto6-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "lto6-smb-proof-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-api.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-api.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-daily-report.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-daily-report.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-email-drip.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-email-drip.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "marketing-x-posts.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/marketing-x-posts.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "meeting-translator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/meeting-translator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nas-ollama-load.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/nas-ollama-load.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "notebook-power-agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/notebook-power-agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "nvidia-clock-limit.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/nvidia-clock-limit.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-finetune.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-finetune.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-coordinator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu-coordinator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/ollama-gpu-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-gpu1.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-gpu1.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "ollama-warmup.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/ollama-warmup.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "pandaplus-telegram-bridge.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/pandaplus-telegram-bridge.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1471,22 +490,6 @@
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/pihole.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "post-boot-check.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/post-boot-check.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "printshare.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "deploy/printshare/printshare.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1547,66 +550,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "python-training.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/python-training.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "python-training.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/python-training.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rag-reindex.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/rag-reindex.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "review-service.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/systemd/review-service.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "rpa4all-ddns-server.service",
       "domain": "network",
       "kind": "systemd",
       "source": "deploy/vpn/rpa4all-ddns-server.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "rpa4all-validation.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/rpa4all-validation.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1619,250 +566,10 @@
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "secrets_agent.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "tools/secrets_agent/secrets_agent.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "server-error-alert.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "deploy/homelab/server-error-alert.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
       "name": "sia-api-proxy.service",
       "domain": "network",
       "kind": "systemd",
       "source": "systemd/sia-api-proxy.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "sia-host-shim.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/sia-host-shim.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "sia-macvlan-network.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-network.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "sia-macvlan-watchdog.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "sia-macvlan-watchdog.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/sia-macvlan-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "sia-port-forward.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/sia-port-forward.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "specialized_agents-dashboard.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/specialized_agents-dashboard.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-host-shim.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/storj-host-shim.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-network.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-network.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "storj-macvlan-watchdog.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/storj-macvlan-watchdog.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-log-spool-drain-nextcloud.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tape-log-spool-drain-nextcloud.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-log-spool-drain-nextcloud.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-quality-ollama-narrator.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tape-quality-ollama-narrator.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tape-safe-eject.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tape-safe-eject.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-analyst-weekly-retrain.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/trading-analyst-weekly-retrain.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-daily-report.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "trading-daily-report.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/trading-daily-report.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-local-key-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-local-key-selfheal.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-local-key-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-renewer.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-renewer.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-renewer.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-selfheal.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "tuya-token-selfheal.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/tuya-token-selfheal.timer",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "whatsapp-persona-panel.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-persona-panel.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.service",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
-    },
-    {
-      "name": "whatsapp-toolcall-chunked-train.timer",
-      "domain": "network",
-      "kind": "systemd",
-      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
@@ -1875,28 +582,1324 @@
       "candidate_system": "NetBox service model"
     },
     {
+      "name": "glpi",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "glpi-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "hostd",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.sia.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mail-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mail-server",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-backend",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-dovecot",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-frontend",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-postfix",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "mailu-roundcube",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.mailu.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-postgres",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-redis-cache",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "netbox-worker",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/cmdb/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nginx",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ntopng",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ntopng-redis",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.ntopng.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "opensearch-dashboards",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "opensearch-node1",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.opensearch.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "postgres",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.email-simple.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "printshare",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "deploy/printshare/docker-compose.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "roundcube",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.simple-mail.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "wikijs",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "wikijs-db",
+      "domain": "operations",
+      "kind": "compose",
+      "source": "docker/docker-compose.wikijs.yml",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "akash-sweep.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "akash-sweep.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/akash-sweep.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "approval-gateway.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/approval-gateway.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "auto_validate.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/auto_validate.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "autonomous_remediator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/autonomous_remediator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "bn-acervo-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/bn-acervo-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "check_projects.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/check_projects.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "check_projects.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/check_projects.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "chromecast-ambilight.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/chromecast-ambilight.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "clear-agent@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/clear-agent@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "coordinator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/coordinator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "crypto-agent@.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/crypto-agent@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-broadcast.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-broadcast.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-broadcast.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "daily-agenda-panel.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/daily-agenda-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "decisions-track-record-rollup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/decisions-track-record-rollup.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "diretor.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/diretor.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-calendar.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-calendar.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-expurgo.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-expurgo.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-telegram-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-telegram-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-tray-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/eddie-tray-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "eddie-whatsapp-bot.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/eddie-whatsapp-bot.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ethwan-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ethwan-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "faster-whisper-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/faster-whisper-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "final-boot-status-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/final-boot-status-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "fix-staging-perms.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/fix-staging-perms.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "gdrive-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/gdrive-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "github-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/github-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "homelab-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/homelab-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "iot-presence-watchdog.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/iot-presence-watchdog.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "journal-ingestor.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/journal-ingestor.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "llm-log-panel.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/llm-log-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-drain.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-drain.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-checkpoint-recover.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-checkpoint-recover.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/lto6-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "lto6-smb-proof-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-api.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-api.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-daily-report.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-daily-report.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-email-drip.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-email-drip.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "marketing-x-posts.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/marketing-x-posts.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "meeting-translator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/meeting-translator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nas-ollama-load.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nas-ollama-load.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "notebook-power-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/notebook-power-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "nvidia-clock-limit.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/nvidia-clock-limit.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-finetune.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-finetune.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-coordinator.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu-coordinator.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/ollama-gpu-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-gpu1.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-gpu1.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "ollama-warmup.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/ollama-warmup.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "pandaplus-telegram-bridge.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/pandaplus-telegram-bridge.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "post-boot-check.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/post-boot-check.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "printshare.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/printshare/printshare.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "python-training.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/python-training.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rag-reindex.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rag-reindex.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "review-service.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/systemd/review-service.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "rpa4all-validation.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/rpa4all-validation.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "secrets_agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/secrets_agent/secrets_agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "server-error-alert.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "deploy/homelab/server-error-alert.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "sia-host-shim.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/sia-host-shim.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "sia-macvlan-network.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-network.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "sia-macvlan-watchdog.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-watchdog.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "sia-macvlan-watchdog.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/sia-macvlan-watchdog.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "sia-port-forward.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/sia-port-forward.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "specialized_agents-dashboard.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-local-key-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-local-key-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-renewer.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-renewer.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-selfheal.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "tuya-token-selfheal.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/tuya-token-selfheal.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-persona-panel.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-persona-panel.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "whatsapp-toolcall-chunked-train.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/whatsapp-toolcall-chunked-train.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
       "name": "workstation-win11l-http@.service",
-      "domain": "network",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-http@.service",
-      "recommended_owner": "platform",
-      "candidate_system": "NetBox service model"
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "workstation-win11l-rdp@.service",
-      "domain": "network",
+      "domain": "operations",
       "kind": "systemd",
       "source": "systemd/workstation-win11l-rdp@.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "x-agent.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "tools/x_agent/x-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "disk-clean.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/disk-clean.service",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
     },
     {
-      "name": "x-agent.service",
-      "domain": "network",
+      "name": "disk-clean.timer",
+      "domain": "storage",
       "kind": "systemd",
-      "source": "tools/x_agent/x-agent.service",
+      "source": "systemd/disk-clean.timer",
       "recommended_owner": "platform",
       "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "disk-spindown.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "tools/homelab/disk-spindown.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-disk-backup.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "tools/backup/homelab-disk-backup.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-nextcloud.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-log-drain-sg1.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-log-drain-sg1.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "homelab-tape-logrotate.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/homelab-tape-logrotate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-backup-catalog.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-backup-catalog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-boot-reconcile.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-boot-reconcile.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-button-watch.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-button-watch.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-cache-flush.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-cache-flush.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-catalog-verify.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-catalog-verify.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-deep-recovery.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-deep-recovery.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-journal-replicate.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-journal-replicate.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-log-rotation.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-log-rotation.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-selfheal-escalator.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6-sg1.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6-sg1.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-lto6b.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-lto6b.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "ltfs-window-enforcer.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/ltfs-window-enforcer.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "lto6-drain-backups.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/lto6-drain-backups.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-host-shim.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-host-shim.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-network.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-network.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "storj-macvlan-watchdog.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/storj-macvlan-watchdog.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-log-spool-drain-nextcloud.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-log-spool-drain-nextcloud.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-quality-ollama-narrator.timer",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-quality-ollama-narrator.timer",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "tape-safe-eject.service",
+      "domain": "storage",
+      "kind": "systemd",
+      "source": "systemd/tape-safe-eject.service",
+      "recommended_owner": "platform",
+      "candidate_system": "NetBox service model"
+    },
+    {
+      "name": "candle-collector.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "candle-collector.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/candle-collector.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "clear-trading-agent.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/clear-trading-agent.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-postgres-sync.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-postgres-sync.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "kucoin-usdt-rebalance.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/kucoin-usdt-rebalance.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-analyst-weekly-retrain.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-analyst-weekly-retrain.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-daily-report.service",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "trading-daily-report.timer",
+      "domain": "trading",
+      "kind": "systemd",
+      "source": "systemd/trading-daily-report.timer",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
     },
     {
       "name": "crypto-agent@BTC_USDT_aggressive.service",
@@ -2301,177 +2304,9 @@
         "critical": true
       },
       {
-        "name": "glpi",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "glpi-db",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "hostd",
-        "domain": "network",
-        "source": "docker/docker-compose.sia.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-db",
-        "domain": "network",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mail-server",
-        "domain": "network",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-backend",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-db",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-dovecot",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-frontend",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-postfix",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-redis",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "mailu-roundcube",
-        "domain": "network",
-        "source": "docker/docker-compose.mailu.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-postgres",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-redis-cache",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "netbox-worker",
-        "domain": "network",
-        "source": "deploy/cmdb/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "nginx",
-        "domain": "network",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng",
-        "domain": "network",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "ntopng-redis",
-        "domain": "network",
-        "source": "docker/docker-compose.ntopng.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-dashboards",
-        "domain": "network",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "opensearch-node1",
-        "domain": "network",
-        "source": "docker/docker-compose.opensearch.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
         "name": "pihole",
         "domain": "network",
         "source": "deploy/pihole/docker-compose.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "postgres",
-        "domain": "network",
-        "source": "docker/docker-compose.email-simple.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "printshare",
-        "domain": "network",
-        "source": "deploy/printshare/docker-compose.yml",
         "kind": "compose",
         "critical": true
       },
@@ -2480,118 +2315,6 @@
         "domain": "network",
         "source": "deploy/cmdb/docker-compose.yml",
         "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "roundcube",
-        "domain": "network",
-        "source": "docker/docker-compose.simple-mail.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs",
-        "domain": "network",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "wikijs-db",
-        "domain": "network",
-        "source": "docker/docker-compose.wikijs.yml",
-        "kind": "compose",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.service",
-        "domain": "network",
-        "source": "systemd/akash-sweep.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "akash-sweep.timer",
-        "domain": "network",
-        "source": "systemd/akash-sweep.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "approval-gateway.service",
-        "domain": "network",
-        "source": "systemd/approval-gateway.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "auto_validate.service",
-        "domain": "network",
-        "source": "deploy/auto_validate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "autonomous_remediator.service",
-        "domain": "network",
-        "source": "tools/systemd/autonomous_remediator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "bn-acervo-agent.service",
-        "domain": "network",
-        "source": "systemd/bn-acervo-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.service",
-        "domain": "network",
-        "source": "systemd/candle-collector.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "candle-collector.timer",
-        "domain": "network",
-        "source": "systemd/candle-collector.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.service",
-        "domain": "network",
-        "source": "systemd/check_projects.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "check_projects.timer",
-        "domain": "network",
-        "source": "systemd/check_projects.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "chromecast-ambilight.service",
-        "domain": "network",
-        "source": "systemd/chromecast-ambilight.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-agent@.service",
-        "domain": "network",
-        "source": "systemd/clear-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "clear-trading-agent.service",
-        "domain": "network",
-        "source": "systemd/clear-trading-agent.service",
-        "kind": "systemd",
         "critical": true
       },
       {
@@ -2623,55 +2346,6 @@
         "critical": true
       },
       {
-        "name": "coordinator.service",
-        "domain": "network",
-        "source": "systemd/coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "crypto-agent@.service",
-        "domain": "network",
-        "source": "systemd/crypto-agent@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-broadcast.service",
-        "domain": "network",
-        "source": "systemd/daily-agenda-broadcast.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-broadcast.timer",
-        "domain": "network",
-        "source": "systemd/daily-agenda-broadcast.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "daily-agenda-panel.service",
-        "domain": "network",
-        "source": "systemd/daily-agenda-panel.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "decisions-track-record-rollup.service",
-        "domain": "network",
-        "source": "systemd/decisions-track-record-rollup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "decisions-track-record-rollup.timer",
-        "domain": "network",
-        "source": "systemd/decisions-track-record-rollup.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "dhcp-selfheal.service",
         "domain": "network",
         "source": "systemd/dhcp-selfheal.service",
@@ -2679,184 +2353,9 @@
         "critical": true
       },
       {
-        "name": "diretor.service",
-        "domain": "network",
-        "source": "systemd/diretor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-clean.service",
-        "domain": "network",
-        "source": "systemd/disk-clean.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-clean.timer",
-        "domain": "network",
-        "source": "systemd/disk-clean.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "disk-spindown.service",
-        "domain": "network",
-        "source": "tools/homelab/disk-spindown.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-calendar.service",
-        "domain": "network",
-        "source": "systemd/eddie-calendar.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-expurgo.service",
-        "domain": "network",
-        "source": "systemd/eddie-expurgo.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-telegram-bot.service",
-        "domain": "network",
-        "source": "systemd/eddie-telegram-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-tray-agent.service",
-        "domain": "network",
-        "source": "tools/systemd/eddie-tray-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "eddie-whatsapp-bot.service",
-        "domain": "network",
-        "source": "systemd/eddie-whatsapp-bot.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ethwan-selfheal.service",
-        "domain": "network",
-        "source": "systemd/ethwan-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "faster-whisper-api.service",
-        "domain": "network",
-        "source": "systemd/faster-whisper-api.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "final-boot-status-agent.service",
-        "domain": "network",
-        "source": "tools/systemd/final-boot-status-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "fix-staging-perms.service",
-        "domain": "network",
-        "source": "systemd/fix-staging-perms.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "gdrive-agent.service",
-        "domain": "network",
-        "source": "tools/systemd/gdrive-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "github-agent.service",
-        "domain": "network",
-        "source": "systemd/github-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-dashboard.service",
-        "domain": "network",
-        "source": "systemd/homelab-dashboard.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-disk-backup.service",
-        "domain": "network",
-        "source": "tools/backup/homelab-disk-backup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "homelab-lan-gateway.service",
         "domain": "network",
         "source": "deploy/vpn/homelab-lan-gateway.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.service",
-        "domain": "network",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-nextcloud.timer",
-        "domain": "network",
-        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.service",
-        "domain": "network",
-        "source": "systemd/homelab-tape-log-drain-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-log-drain-sg1.timer",
-        "domain": "network",
-        "source": "systemd/homelab-tape-log-drain-sg1.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.service",
-        "domain": "network",
-        "source": "systemd/homelab-tape-logrotate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "homelab-tape-logrotate.timer",
-        "domain": "network",
-        "source": "systemd/homelab-tape-logrotate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-presence-watchdog.service",
-        "domain": "network",
-        "source": "systemd/iot-presence-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "iot-presence-watchdog.timer",
-        "domain": "network",
-        "source": "systemd/iot-presence-watchdog.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -2882,366 +2381,9 @@
         "critical": true
       },
       {
-        "name": "journal-ingestor.service",
-        "domain": "network",
-        "source": "systemd/journal-ingestor.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "journal-ingestor.timer",
-        "domain": "network",
-        "source": "systemd/journal-ingestor.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-postgres-sync.service",
-        "domain": "network",
-        "source": "systemd/kucoin-postgres-sync.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-postgres-sync.timer",
-        "domain": "network",
-        "source": "systemd/kucoin-postgres-sync.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-usdt-rebalance.service",
-        "domain": "network",
-        "source": "systemd/kucoin-usdt-rebalance.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "kucoin-usdt-rebalance.timer",
-        "domain": "network",
-        "source": "systemd/kucoin-usdt-rebalance.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "llm-log-panel.service",
-        "domain": "network",
-        "source": "systemd/llm-log-panel.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "localtunnel@.service",
         "domain": "network",
         "source": "tools/tunnels/localtunnel@.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.service",
-        "domain": "network",
-        "source": "systemd/ltfs-backup-catalog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-backup-catalog.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-backup-catalog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-boot-reconcile.service",
-        "domain": "network",
-        "source": "systemd/ltfs-boot-reconcile.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-button-watch.service",
-        "domain": "network",
-        "source": "systemd/ltfs-button-watch.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-cache-flush.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-cache-flush.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-catalog-verify.service",
-        "domain": "network",
-        "source": "systemd/ltfs-catalog-verify.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-catalog-verify.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-catalog-verify.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-deep-recovery.service",
-        "domain": "network",
-        "source": "systemd/ltfs-deep-recovery.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-journal-replicate.service",
-        "domain": "network",
-        "source": "systemd/ltfs-journal-replicate.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-journal-replicate.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-journal-replicate.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.service",
-        "domain": "network",
-        "source": "systemd/ltfs-log-rotation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-log-rotation.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-log-rotation.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-selfheal-escalator.service",
-        "domain": "network",
-        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6-sg1.service",
-        "domain": "network",
-        "source": "systemd/ltfs-lto6-sg1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6.service",
-        "domain": "network",
-        "source": "systemd/ltfs-lto6.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-lto6b.service",
-        "domain": "network",
-        "source": "systemd/ltfs-lto6b.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.service",
-        "domain": "network",
-        "source": "systemd/ltfs-window-enforcer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ltfs-window-enforcer.timer",
-        "domain": "network",
-        "source": "systemd/ltfs-window-enforcer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-checkpoint-drain.service",
-        "domain": "network",
-        "source": "systemd/lto6-checkpoint-drain.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-checkpoint-recover.service",
-        "domain": "network",
-        "source": "systemd/lto6-checkpoint-recover.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.service",
-        "domain": "network",
-        "source": "systemd/lto6-drain-backups.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-drain-backups.timer",
-        "domain": "network",
-        "source": "systemd/lto6-drain-backups.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.service",
-        "domain": "network",
-        "source": "systemd/lto6-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-selfheal.timer",
-        "domain": "network",
-        "source": "systemd/lto6-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "lto6-smb-proof-selfheal.service",
-        "domain": "network",
-        "source": "tools/selfheal/lto6-smb-proof-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-api.service",
-        "domain": "network",
-        "source": "systemd/marketing-api.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.service",
-        "domain": "network",
-        "source": "systemd/marketing-daily-report.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-daily-report.timer",
-        "domain": "network",
-        "source": "systemd/marketing-daily-report.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.service",
-        "domain": "network",
-        "source": "systemd/marketing-email-drip.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-email-drip.timer",
-        "domain": "network",
-        "source": "systemd/marketing-email-drip.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.service",
-        "domain": "network",
-        "source": "systemd/marketing-x-posts.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "marketing-x-posts.timer",
-        "domain": "network",
-        "source": "systemd/marketing-x-posts.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "meeting-translator.service",
-        "domain": "network",
-        "source": "systemd/meeting-translator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "nas-ollama-load.service",
-        "domain": "network",
-        "source": "systemd/nas-ollama-load.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "notebook-power-agent.service",
-        "domain": "network",
-        "source": "systemd/notebook-power-agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "nvidia-clock-limit.service",
-        "domain": "network",
-        "source": "systemd/nvidia-clock-limit.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.service",
-        "domain": "network",
-        "source": "systemd/ollama-finetune.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-finetune.timer",
-        "domain": "network",
-        "source": "systemd/ollama-finetune.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-coordinator.service",
-        "domain": "network",
-        "source": "systemd/ollama-gpu-coordinator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu-selfheal.service",
-        "domain": "network",
-        "source": "tools/ollama-gpu-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-gpu1.service",
-        "domain": "network",
-        "source": "systemd/ollama-gpu1.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.service",
-        "domain": "network",
-        "source": "systemd/ollama-warmup.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "ollama-warmup.timer",
-        "domain": "network",
-        "source": "systemd/ollama-warmup.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "pandaplus-telegram-bridge.service",
-        "domain": "network",
-        "source": "systemd/pandaplus-telegram-bridge.service",
         "kind": "systemd",
         "critical": true
       },
@@ -3256,20 +2398,6 @@
         "name": "pihole.service",
         "domain": "network",
         "source": "systemd/pihole.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "post-boot-check.service",
-        "domain": "network",
-        "source": "systemd/post-boot-check.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "printshare.service",
-        "domain": "network",
-        "source": "deploy/printshare/printshare.service",
         "kind": "systemd",
         "critical": true
       },
@@ -3323,58 +2451,9 @@
         "critical": true
       },
       {
-        "name": "python-training.service",
-        "domain": "network",
-        "source": "systemd/python-training.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "python-training.timer",
-        "domain": "network",
-        "source": "systemd/python-training.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.service",
-        "domain": "network",
-        "source": "systemd/rag-reindex.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rag-reindex.timer",
-        "domain": "network",
-        "source": "systemd/rag-reindex.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "review-service.service",
-        "domain": "network",
-        "source": "tools/systemd/review-service.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "rpa4all-ddns-server.service",
         "domain": "network",
         "source": "deploy/vpn/rpa4all-ddns-server.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.service",
-        "domain": "network",
-        "source": "systemd/rpa4all-validation.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "rpa4all-validation.timer",
-        "domain": "network",
-        "source": "systemd/rpa4all-validation.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -3386,219 +2465,9 @@
         "critical": true
       },
       {
-        "name": "secrets_agent.service",
-        "domain": "network",
-        "source": "tools/secrets_agent/secrets_agent.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "server-error-alert.service",
-        "domain": "network",
-        "source": "deploy/homelab/server-error-alert.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
         "name": "sia-api-proxy.service",
         "domain": "network",
         "source": "systemd/sia-api-proxy.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "sia-host-shim.service",
-        "domain": "network",
-        "source": "systemd/sia-host-shim.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "sia-macvlan-network.service",
-        "domain": "network",
-        "source": "systemd/sia-macvlan-network.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "sia-macvlan-watchdog.service",
-        "domain": "network",
-        "source": "systemd/sia-macvlan-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "sia-macvlan-watchdog.timer",
-        "domain": "network",
-        "source": "systemd/sia-macvlan-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "sia-port-forward.service",
-        "domain": "network",
-        "source": "systemd/sia-port-forward.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "specialized_agents-dashboard.service",
-        "domain": "network",
-        "source": "systemd/specialized_agents-dashboard.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-host-shim.service",
-        "domain": "network",
-        "source": "systemd/storj-host-shim.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-network.service",
-        "domain": "network",
-        "source": "systemd/storj-macvlan-network.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.service",
-        "domain": "network",
-        "source": "systemd/storj-macvlan-watchdog.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "storj-macvlan-watchdog.timer",
-        "domain": "network",
-        "source": "systemd/storj-macvlan-watchdog.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-log-spool-drain-nextcloud.service",
-        "domain": "network",
-        "source": "systemd/tape-log-spool-drain-nextcloud.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-log-spool-drain-nextcloud.timer",
-        "domain": "network",
-        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.service",
-        "domain": "network",
-        "source": "systemd/tape-quality-ollama-narrator.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-quality-ollama-narrator.timer",
-        "domain": "network",
-        "source": "systemd/tape-quality-ollama-narrator.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tape-safe-eject.service",
-        "domain": "network",
-        "source": "systemd/tape-safe-eject.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-analyst-weekly-retrain.service",
-        "domain": "network",
-        "source": "systemd/trading-analyst-weekly-retrain.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-analyst-weekly-retrain.timer",
-        "domain": "network",
-        "source": "systemd/trading-analyst-weekly-retrain.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-daily-report.service",
-        "domain": "network",
-        "source": "systemd/trading-daily-report.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "trading-daily-report.timer",
-        "domain": "network",
-        "source": "systemd/trading-daily-report.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-local-key-selfheal.service",
-        "domain": "network",
-        "source": "systemd/tuya-local-key-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-local-key-selfheal.timer",
-        "domain": "network",
-        "source": "systemd/tuya-local-key-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.service",
-        "domain": "network",
-        "source": "systemd/tuya-token-renewer.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-renewer.timer",
-        "domain": "network",
-        "source": "systemd/tuya-token-renewer.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-selfheal.service",
-        "domain": "network",
-        "source": "systemd/tuya-token-selfheal.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "tuya-token-selfheal.timer",
-        "domain": "network",
-        "source": "systemd/tuya-token-selfheal.timer",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "whatsapp-persona-panel.service",
-        "domain": "network",
-        "source": "systemd/whatsapp-persona-panel.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "whatsapp-toolcall-chunked-train.service",
-        "domain": "network",
-        "source": "systemd/whatsapp-toolcall-chunked-train.service",
-        "kind": "systemd",
-        "critical": true
-      },
-      {
-        "name": "whatsapp-toolcall-chunked-train.timer",
-        "domain": "network",
-        "source": "systemd/whatsapp-toolcall-chunked-train.timer",
         "kind": "systemd",
         "critical": true
       },
@@ -3610,23 +2479,275 @@
         "critical": true
       },
       {
-        "name": "workstation-win11l-http@.service",
-        "domain": "network",
-        "source": "systemd/workstation-win11l-http@.service",
+        "name": "disk-clean.service",
+        "domain": "storage",
+        "source": "systemd/disk-clean.service",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "workstation-win11l-rdp@.service",
-        "domain": "network",
-        "source": "systemd/workstation-win11l-rdp@.service",
+        "name": "disk-clean.timer",
+        "domain": "storage",
+        "source": "systemd/disk-clean.timer",
         "kind": "systemd",
         "critical": true
       },
       {
-        "name": "x-agent.service",
-        "domain": "network",
-        "source": "tools/x_agent/x-agent.service",
+        "name": "disk-spindown.service",
+        "domain": "storage",
+        "source": "tools/homelab/disk-spindown.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-disk-backup.service",
+        "domain": "storage",
+        "source": "tools/backup/homelab-disk-backup.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-nextcloud.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-log-drain-sg1.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-log-drain-sg1.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.service",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-logrotate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "homelab-tape-logrotate.timer",
+        "domain": "storage",
+        "source": "systemd/homelab-tape-logrotate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-backup-catalog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-backup-catalog.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-backup-catalog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-boot-reconcile.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-boot-reconcile.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-button-watch.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-button-watch.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-cache-flush.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-cache-flush.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-catalog-verify.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-catalog-verify.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-deep-recovery.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-deep-recovery.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-journal-replicate.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-journal-replicate.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-log-rotation.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-log-rotation.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-log-rotation.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-selfheal-escalator.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6-selfheal-escalator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6-sg1.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6-sg1.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-lto6b.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-lto6b.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.service",
+        "domain": "storage",
+        "source": "systemd/ltfs-window-enforcer.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "ltfs-window-enforcer.timer",
+        "domain": "storage",
+        "source": "systemd/ltfs-window-enforcer.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.service",
+        "domain": "storage",
+        "source": "systemd/lto6-drain-backups.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "lto6-drain-backups.timer",
+        "domain": "storage",
+        "source": "systemd/lto6-drain-backups.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-host-shim.service",
+        "domain": "storage",
+        "source": "systemd/storj-host-shim.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-network.service",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-network.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.service",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-watchdog.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "storj-macvlan-watchdog.timer",
+        "domain": "storage",
+        "source": "systemd/storj-macvlan-watchdog.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.service",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-log-spool-drain-nextcloud.timer",
+        "domain": "storage",
+        "source": "systemd/tape-log-spool-drain-nextcloud.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.service",
+        "domain": "storage",
+        "source": "systemd/tape-quality-ollama-narrator.service",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-quality-ollama-narrator.timer",
+        "domain": "storage",
+        "source": "systemd/tape-quality-ollama-narrator.timer",
+        "kind": "systemd",
+        "critical": true
+      },
+      {
+        "name": "tape-safe-eject.service",
+        "domain": "storage",
+        "source": "systemd/tape-safe-eject.service",
         "kind": "systemd",
         "critical": true
       }

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T20:56:02.494018+00:00",
+  "generated_at": "2026-08-08T21:17:51.066133+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T14:20:29.760838+00:00",
+  "generated_at": "2026-08-08T14:23:29.703647+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T21:17:51.066133+00:00",
+  "generated_at": "2026-08-08T21:46:39.628488+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,19 +1,19 @@
 {
-  "generated_at": "2026-08-09T14:29:37.225924+00:00",
+  "generated_at": "2026-08-09T16:30:14.503379+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",
   "site_name": "homelab-main",
   "summary": {
     "hosts": 1,
-    "repo_services": 213,
+    "repo_services": 215,
     "trading_instances": 12,
     "critical_services": 87,
     "domains": {
       "identity": 4,
       "monitoring": 19,
       "network": 25,
-      "operations": 115,
+      "operations": 117,
       "storage": 39,
       "trading": 11
     }
@@ -1402,6 +1402,22 @@
       "domain": "operations",
       "kind": "systemd",
       "source": "systemd/specialized_agents-dashboard.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "telegram-alarm-manager.service",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/telegram-alarm-manager.service",
+      "recommended_owner": "application",
+      "candidate_system": "GLPI review"
+    },
+    {
+      "name": "telegram-alarm-manager.timer",
+      "domain": "operations",
+      "kind": "systemd",
+      "source": "systemd/telegram-alarm-manager.timer",
       "recommended_owner": "application",
       "candidate_system": "GLPI review"
     },

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T21:46:39.628488+00:00",
+  "generated_at": "2026-08-08T21:49:50.454880+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-09T16:30:14.503379+00:00",
+  "generated_at": "2026-08-09T16:36:44.003286+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T21:49:50.454880+00:00",
+  "generated_at": "2026-08-09T14:29:37.225924+00:00",
   "repo_root": "/home/edenilson/.traycer/worktrees/eddiejdi__eddie-auto-dev/traycer-daring-raven",
   "inventory_file": "config/inventory_homelab.yml",
   "output_dir": "deploy/cmdb/bootstrap/generated",

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T14:20:29.760838+00:00`
+- Generated at: `2026-08-08T14:23:29.703647+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T21:49:50.454880+00:00`
+- Generated at: `2026-08-09T14:29:37.225924+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T21:46:39.628488+00:00`
+- Generated at: `2026-08-08T21:49:50.454880+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T20:56:02.494018+00:00`
+- Generated at: `2026-08-08T21:17:51.066133+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-09T16:30:14.503379+00:00`
+- Generated at: `2026-08-09T16:36:44.003286+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `215`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T14:23:29.703647+00:00`
+- Generated at: `2026-08-08T20:56:02.494018+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,10 +1,10 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-07T16:06:18.414480+00:00`
+- Generated at: `2026-08-08T14:20:29.760838+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`
-- Critical services flagged for MVP: `213`
+- Critical services flagged for MVP: `87`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
 
@@ -12,7 +12,10 @@
 
 - `identity`: 4
 - `monitoring`: 19
-- `network`: 190
+- `network`: 25
+- `operations`: 115
+- `storage`: 39
+- `trading`: 11
 
 ## Trading profile instances (`12`)
 
@@ -58,23 +61,23 @@
 - `storj-payout-monitor.timer` (monitoring, systemd) from `systemd/storj-payout-monitor.timer`
 - `tape-component-quality-exporter.service` (monitoring, systemd) from `systemd/tape-component-quality-exporter.service`
 - `tunnel-healthcheck-exporter.service` (monitoring, systemd) from `systemd/tunnel-healthcheck-exporter.service`
-- `glpi` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `glpi-db` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `hostd` (network, compose) from `docker/docker-compose.sia.yml`
-- `mail-db` (network, compose) from `docker/docker-compose.simple-mail.yml`
-- `mail-server` (network, compose) from `docker/docker-compose.simple-mail.yml`
-- `mailu-backend` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-db` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-dovecot` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-frontend` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-postfix` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-redis` (network, compose) from `docker/docker-compose.mailu.yml`
-- `mailu-roundcube` (network, compose) from `docker/docker-compose.mailu.yml`
-- `netbox` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-postgres` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-redis` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-redis-cache` (network, compose) from `deploy/cmdb/docker-compose.yml`
-- `netbox-worker` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `pihole` (network, compose) from `deploy/pihole/docker-compose.yml`
+- `proxy` (network, compose) from `deploy/cmdb/docker-compose.yml`
+- `cloudflared-named@.service` (network, systemd) from `tools/tunnels/cloudflared-named@.service`
+- `cloudflared-tunnel-guardian.service` (network, systemd) from `systemd/cloudflared-tunnel-guardian.service`
+- `cloudflared-tunnel-guardian.timer` (network, systemd) from `systemd/cloudflared-tunnel-guardian.timer`
+- `cloudflared.service` (network, systemd) from `tools/tunnels/cloudflared/cloudflared.service`
+- `dhcp-selfheal.service` (network, systemd) from `systemd/dhcp-selfheal.service`
+- `homelab-lan-gateway.service` (network, systemd) from `deploy/vpn/homelab-lan-gateway.service`
+- `iot-vpn-bypass-watchdog.service` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.service`
+- `iot-vpn-bypass-watchdog.timer` (network, systemd) from `systemd/iot-vpn-bypass-watchdog.timer`
+- `ipv6-proxy.service` (network, systemd) from `systemd/ipv6-proxy.service`
+- `localtunnel@.service` (network, systemd) from `tools/tunnels/localtunnel@.service`
+- `pihole-ipv6-dns-fix.service` (network, systemd) from `systemd/pihole-ipv6-dns-fix.service`
+- `pihole.service` (network, systemd) from `systemd/pihole.service`
+- `protonvpn-best-server.service` (network, systemd) from `systemd/protonvpn-best-server.service`
+- `protonvpn-best-server.timer` (network, systemd) from `systemd/protonvpn-best-server.timer`
+- `protonvpn-boot-selfheal.service` (network, systemd) from `systemd/protonvpn-boot-selfheal.service`
 
 ## Serviços anotados manualmente
 

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,6 +1,6 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-08T21:17:51.066133+00:00`
+- Generated at: `2026-08-08T21:46:39.628488+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
 - Repo services discovered: `213`

--- a/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
+++ b/deploy/cmdb/bootstrap/generated/cmdb-baseline.md
@@ -1,9 +1,9 @@
 # CMDB Baseline
 
-- Generated at: `2026-08-09T14:29:37.225924+00:00`
+- Generated at: `2026-08-09T16:30:14.503379+00:00`
 - Site: `homelab-main`
 - Hosts discovered: `1`
-- Repo services discovered: `213`
+- Repo services discovered: `215`
 - Critical services flagged for MVP: `87`
 - Project: [eddie-auto-dev](https://github.com/eddiejdi/eddie-auto-dev)
 - Owner: `edenilson.adm@gmail.com`
@@ -13,7 +13,7 @@
 - `identity`: 4
 - `monitoring`: 19
 - `network`: 25
-- `operations`: 115
+- `operations`: 117
 - `storage`: 39
 - `trading`: 11
 

--- a/docs/GRAFANA_KUMINING_DASHBOARD.md
+++ b/docs/GRAFANA_KUMINING_DASHBOARD.md
@@ -1,0 +1,221 @@
+# Grafana KuMining Dashboard — Mineração
+
+**Data:** 2026-08-08  
+**Dashboard:** [btc-trading-monitor](https://grafana.rpa4all.com/d/btc-trading-monitor/btc-trading-monitor)  
+**UID:** `btc-trading-monitor`  
+**Folder:** Eddie Auto-Dev (uid: `fffxoniykngn4e`)
+
+## Visão Geral
+
+Seção de mineração KuMining adicionada ao dashboard principal de trading. Monitora saldos BTC em sub-contas de trading, ganhos de mineração e USDT disponível para transferência.
+
+## Painéis Adicionados (IDs 300-308)
+
+| ID | Tipo | Título | Descrição |
+|----|------|--------|-----------|
+| 300 | row | ⛏️ Mineração KuMining | Seção colapsável |
+| 301 | stat | ₿ Saldo BTC (Main) | Saldo BTC total nas sub-contas de trading |
+| 302 | stat | 📈 Ganhos BTC no Período | Delta de BTC no período selecionado |
+| 303 | stat | 💰 Ganhos em USDT | Valor dos ganhos convertido em USDT |
+| 304 | text | 📋 Contrato Ativo | Detalhes do contrato (10 TH, 7 dias) |
+| 305 | timeseries | 📈 Saldo BTC ao Longo do Tempo | Evolução do saldo BTC |
+| 306 | timeseries | ⛏️ Ganhos de Mineração por Snapshot | Ganhos diários por snapshot |
+| 307 | stat | 💵 USDT Disponível (Main) | USDT disponível na conta main |
+| 308 | text | 🚀 Ações Rápidas | Botões de transferência KuCoin |
+
+## Fonte de Dados
+
+- **PostgreSQL:** `btc-trading-pg` (uid)
+- **Tabela:** `btc.exchange_balance_snapshots`
+- **Colunas relevantes:**
+  - `synced_at` — timestamp do snapshot
+  - `account_type` — tipo da conta (`main`, `trade`, `sub:BTCAgressive`, `sub:BTCConservative`)
+  - `currency` — moeda (`BTC`, `USDT`, etc.)
+  - `balance` — saldo total
+  - `available` — saldo disponível
+  - `holds` — saldo em hold
+  - `price_usdt` — preço em USDT
+
+## Contas de Trading
+
+| account_type | Uso |
+|--------------|-----|
+| `main` | Conta principal (USDT, BRL) |
+| `trade` | Conta de trading |
+| `sub:BTCAgressive` | Sub-conta BTC agressiva |
+| `sub:BTCConservative` | Sub-conta BTC conservadora |
+| `sub:ETHAgressive` | Sub-conta ETH agressiva |
+| `sub:ETHConservative` | Sub-conta ETH conservadora |
+
+**Importante:** O BTC está em `sub:BTCAgressive` e `sub:BTCConservative`, **não** em `main`.
+
+## Queries dos Painéis
+
+### Painel 301: Saldo BTC
+```sql
+WITH latest AS (
+  SELECT account_type, balance
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'BTC'
+    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+  ORDER BY synced_at DESC
+  LIMIT 2
+)
+SELECT now() AS "time", SUM(balance) AS "Saldo BTC"
+FROM latest
+```
+
+### Painel 302: Ganhos BTC no Período
+```sql
+WITH btc_snapshots AS (
+  SELECT synced_at, SUM(balance) AS total_balance
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'BTC'
+    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+  GROUP BY synced_at
+),
+period_ends AS (
+  SELECT
+    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1] AS end_bal,
+    (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS start_bal
+  FROM btc_snapshots
+  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()
+)
+SELECT now() AS "time", COALESCE(end_bal - start_bal, 0) AS "Ganhos BTC"
+FROM period_ends
+```
+
+### Painel 303: Ganhos em USDT
+```sql
+WITH btc_snapshots AS (
+  SELECT synced_at, SUM(balance) AS total_balance
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'BTC'
+    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+  GROUP BY synced_at
+),
+btc_delta AS (
+  SELECT
+    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1]
+    - (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS btc_earned
+  FROM btc_snapshots
+  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()
+),
+btc_price AS (
+  SELECT price_usdt
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'BTC'
+    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+    AND price_usdt IS NOT NULL
+  ORDER BY synced_at DESC
+  LIMIT 1
+)
+SELECT now() AS "time", COALESCE(btc_earned * btc_price.price_usdt, 0) AS "Ganhos USDT"
+FROM btc_delta, btc_price
+```
+
+### Painel 305: Saldo BTC ao Longo do Tempo
+```sql
+SELECT
+  synced_at AS "time",
+  SUM(balance) AS "Saldo BTC"
+FROM btc.exchange_balance_snapshots
+WHERE currency = 'BTC'
+  AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+  AND synced_at BETWEEN $__timeFrom() AND $__timeTo()
+GROUP BY synced_at
+ORDER BY synced_at
+```
+
+### Painel 306: Ganhos de Mineração por Snapshot
+```sql
+WITH ordered AS (
+  SELECT
+    synced_at,
+    SUM(balance) AS total_balance,
+    LAG(SUM(balance)) OVER (ORDER BY synced_at) AS prev_balance
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'BTC'
+    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')
+  GROUP BY synced_at
+)
+SELECT
+  synced_at AS "time",
+  COALESCE(total_balance - prev_balance, 0) AS "Ganhos BTC"
+FROM ordered
+WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()
+  AND total_balance - COALESCE(prev_balance, total_balance) > 0
+ORDER BY synced_at
+```
+
+### Painel 307: USDT Disponível
+```sql
+WITH latest AS (
+  SELECT DISTINCT ON (account_type)
+    account_type, available
+  FROM btc.exchange_balance_snapshots
+  WHERE currency = 'USDT'
+    AND account_type = 'main'
+  ORDER BY account_type, synced_at DESC
+)
+SELECT now() AS "time", available AS "USDT Disponível"
+FROM latest
+```
+
+## Botões de Transferência (Painel 308)
+
+O painel 308 é um painel de texto HTML com botões que abrem a KuCoin:
+
+1. **Transferir para Conta de Trading** — USDT da conta main para trading
+2. **Transferir BTC Mining → Trading** — BTC de mineração para trading
+
+URLs de transferência:
+- `https://www.kucoin.com/transfer/main/trade`
+- `https://www.kucoin.com/transfer/main/trade?coin=BTC`
+
+## Índices
+
+A tabela `btc.exchange_balance_snapshots` possui índice:
+```sql
+CREATE INDEX idx_exchange_balance_snapshots_lookup 
+ON btc.exchange_balance_snapshots 
+USING btree (account_type, currency, synced_at DESC)
+```
+
+## Problemas Conhecidos e Correções
+
+### 1. "No Data" nos painéis
+**Causa:** Queries usando `account_type = 'main' AND currency = 'BTC'` — não existe BTC na conta main.
+
+**Correção:** Alterar para `account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')`.
+
+### 2. "No Data" em painéis stat
+**Causa:** Stat panels precisam de `format: time_series` com `now()` como coluna de tempo.
+
+**Correção:** Alterar `format` de `table` para `time_series` e usar `SELECT now() AS "time", ...`.
+
+### 3. Dashboard não atualiza no Grafana
+**Causa:** Provisioning com `allowUiUpdates: false` e `updateIntervalSeconds: 30`.
+
+**Correção:** Copiar arquivo para `/home/homelab/monitoring/grafana/provisioning/dashboards/` e reiniciar container.
+
+## Deploy
+
+```bash
+# Copiar dashboard atualizado
+cat grafana/dashboards/btc-trading-monitor.json | \
+  ssh homelab@192.168.15.2 "sudo tee /home/homelab/monitoring/grafana/provisioning/dashboards/btc-trading-monitor.json > /dev/null"
+
+# Reiniciar Grafana
+ssh homelab@192.168.15.2 "docker restart grafana"
+
+# Verificar
+curl -s -u admin:Rpa_four_all! http://192.168.15.2:3002/api/dashboards/uid/btc-trading-monitor | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'panels={len(d[\"dashboard\"][\"panels\"])}')"
+```
+
+## Referências
+
+- Dashboard JSON: `grafana/dashboards/btc-trading-monitor.json`
+- Provisioning: `monitoring/grafana/provisioning/dashboards/`
+- Export script: `monitoring/grafana/export_dashboard_to_provisioning.sh`
+- Trading exporter: `btc_trading_agent/prometheus_exporter.py`

--- a/docs/INCIDENTS/2026-08-08_TUYA_SELFHEAL_RATE_LIMIT_RELOAD_THRASH.md
+++ b/docs/INCIDENTS/2026-08-08_TUYA_SELFHEAL_RATE_LIMIT_RELOAD_THRASH.md
@@ -1,0 +1,199 @@
+# 2026-08-08 — Tuya: rate limit do selfheal por thrash de reload (não por timer)
+
+**Severidade:** média/alta (alerta «Tuya expirado» + entry `setup_error`; 82 entidades ainda “ativas” em cache)  
+**Domínio:** integração Tuya no Home Assistant / `tuya-token-selfheal` / rate limit  
+**Status:** corrigido e validado no host (~11:19 -03); fix em PR  
+**Relacionado:**
+- [2026-08-02 — timer monotônico após reboot](2026-08-02_TUYA_TOKEN_SELFHEAL_TIMER_MONOTONIC_AFTER_REBOOT.md) — **não é esta regressão**
+- [2026-08-05 — timers failed + refresh 1010](2026-08-05_TUYA_TIMERS_FAILED_REFRESH_1010_AND_REAUTH.md) — timers nesta outage **saudáveis**
+
+---
+
+## Sintoma
+
+- Alerta do `tuya-token-renewer`: 🔴 **Tuya expirado** — token venceu há ~**740 min**.
+- HA: **82/82 entidades ativas** | 13 desabilitadas | 4 scenes ignoradas.
+- Config entry Tuya em **`setup_error`** (às vezes `setup_in_progress`).
+- Link genérico de reauth (`/config/integrations`) — não distingue rate-limit de 1010.
+- Sensação de regressão: “ontem já tinha sido corrigido” (reauth QR ~12:13 de 07/08).
+
+---
+
+## Diagnóstico
+
+### O que **não** foi a causa
+
+| Hipótese (incidentes 02/08 e 05/08) | Status ~11:10 -03 em 08/08 |
+|------------------------------------|----------------------------|
+| Timer monotônico / `NextElapse=infinity` | **Descartado** — selfheal, renewer e local-key `active` com `Next` wall-clock |
+| Unit monotônico no host | **Descartado** — `OnCalendar` + `Persistent=true` |
+| Refresh **1010** (access+refresh mortos) | **Descartado** — runtime do bridge ainda renovava (~120 min após refresh) |
+
+### Causa raiz (cadeia)
+
+```mermaid
+flowchart TD
+  A[Reauth QR ~12:13 07/08] --> B[Selfheal a cada 5 min]
+  B --> C[setup_error + 82/82 ativas<br/>token HA remaining &gt; 0]
+  C --> D[Reload path conta Heal OK<br/>last_mode=4 MODE_RELOAD]
+  D --> E[Queima MAX_HEALS_24H=24<br/>entre ~12:17 e 22:40 07/08]
+  E --> F[22:40: budget cheio<br/>token HA expira t+2h]
+  F --> G[22:50+: heal=False rate limit]
+  G --> H[Bridge runtime refresh OK]
+  H --> I[Inject no HA bloqueado]
+  I --> J[token HA rem negativo<br/>alerta renewer ~740 min]
+```
+
+1. Timers **OK** — o oneshot falha com exit 1 (`healthy=0`), mas o timer **reagenda**.
+2. Budget esgotado: `/var/lib/tuya-selfheal/state.json` com **24** entradas em `heal_history` (12:17–22:40 de 07/08); `last_mode=4` (reload), `reloads_total=22`, `heals_total=24`.
+3. A partir de **22:50 07/08**:  
+   `heal=False (rate limit: 24 heals nas últimas 24h)` e  
+   `Tuya degradado sem ação … remaining=-N`.
+4. `ensure_fresh_runtime_token` **continua** renovando o bridge **sem** passar pelo rate limit → HA e bridge **divergem**.
+5. O renewer só olha o token da **entry HA** → alerta de expirado mesmo com 82 entidades cacheadas e bridge fresco.
+
+### Evidência (homelab)
+
+| Campo | Valor |
+|-------|--------|
+| HA `token_info.t` (pré-recovery) | 2026-08-07 **20:40:14** -03 |
+| HA `expire_time` | 7200 s → expira **22:40:14** 07/08 |
+| HA rem ~11:10 08/08 | **≈ −750 min** |
+| Bridge runtime rem | **≈ +90–94 min** |
+| `tuya_selfheal_healthy` | **0** |
+| `tuya_entry_state_code` | **1** (`setup_error`) |
+| `tuya_entities_active` | **82** |
+| Último heal contado | 2026-08-07 **22:40:11** |
+
+### Por que “ontem já estava corrigido”
+
+- Manhã/meio-dia 07/08: reauth QR + heals restauraram sessão (82/82).
+- Tarde/noite 07/08: selfheal **gastou 24/24 heals** quase todos em **reload** no estado zumbi (`setup_error` + entidades ainda ativas).
+- À noite o access token do HA expirou; inject automático **bloqueado pelo rate limit** — regressão **sem** 1010 e **sem** timer morto.
+
+---
+
+## Bug de desenho (pré-fix)
+
+Em `tools/homelab/tuya_token_selfheal.py`:
+
+1. Reload com entidades já **> 0** contava como `heal_history` se `wait_recovery` via `active > 0` — no zumbi isso **sempre “sucedia”** e queimava o budget.
+2. Rate limit único para reload e inject: budget gasto em thrash impedia o inject legítimo.
+3. Refresh do runtime bridge sob rate limit **sem** propagaçao para a entry HA.
+4. Alerta do renewer não citava rate limit / bridge fresco → parecia outage de reauth genérica.
+
+---
+
+## Mitigação (código)
+
+| Mudança | Efeito |
+|---------|--------|
+| `reload_counts_toward_heal_budget(before, after)` | Reload só entra no budget se recuperou **0 → >0** entidades |
+| Path reload no `main()` | Zumbi: log *not counted toward heal budget* |
+| `should_heal` | **Bypass** de rate limit se `remaining <= 0` e bridge `t` estritamente maior |
+| Soft / proativo | Continua sujeito a `MAX_HEALS_24H` |
+| Testes | `tests/test_tuya_token_selfheal.py` (bypass, soft rate-limited, contagem de reload) |
+
+Arquivos: `tools/homelab/tuya_token_selfheal.py`, `tests/test_tuya_token_selfheal.py`.
+
+---
+
+## Recovery ops (2026-08-08 ~11:17–11:19 -03)
+
+Com bridge ainda vivo (~88 min):
+
+1. Deploy do script fixado → `/usr/local/bin/tuya_token_selfheal.py`  
+   (backup `…bak-20260808-pre-rate-limit-fix`).
+2. `sudo systemctl start tuya-token-selfheal.service`.
+3. Log:  
+   `heal=True (… rate-limit bypass | 82 entidades ainda ativas)`  
+   → `hot apply OK` → `Heal OK (hot): 82 entidades | token resta 86 min`.
+
+**QR não foi necessário** (bypass + inject bastaram).
+
+### Prova de saúde
+
+| Métrica | Antes | Depois |
+|---------|--------|--------|
+| `tuya_selfheal_healthy` | 0 | **1** |
+| `tuya_entry_state_code` | 1 (`setup_error`) | **0** (`loaded`) |
+| `tuya_token_remaining_minutes` | ~−755 | **~86** |
+| `tuya_bridge_token_remaining_minutes` | ~90 | **~86** (alinhado) |
+| `tuya_entities_active` | 82 | **82** |
+| `tuya_selfheal_last_mode` | 4 (reload) | **1** (hot) |
+
+---
+
+## Runbook (próxima queda com 82 ativas + alerta expirado)
+
+```mermaid
+flowchart TD
+  S[Alerta Tuya expirado<br/>ou setup_error] --> T{Timers tuya* active<br/>com NEXT?}
+  T -->|não| R[reset-failed + restart<br/>alinhar OnCalendar]
+  T -->|sim| B{Bridge rem_min &gt; 0?}
+  R --> B
+  B -->|não / 1010| Q[reauth QR + sync runtime]
+  B -->|sim| L{Log rate limit<br/>ou HA rem &lt;&lt; bridge?}
+  Q --> H
+  L -->|sim| H[Deploy/selfheal atualizado<br/>ou limpar heal_history<br/>+ start selfheal]
+  L -->|não| H2[start tuya-token-selfheal]
+  H --> V{healthy=1 e loaded?}
+  H2 --> V
+  V -->|sim| OK[OK]
+  V -->|não| D[hot/core/docker path<br/>ou reauth se 1010]
+```
+
+Comandos úteis:
+
+```bash
+# Timers
+systemctl list-timers 'tuya*' --all
+systemctl show tuya-token-selfheal.timer -p ActiveState,NextElapseUSecRealtime
+
+# Budget / divergência
+python3 -c "import json; s=json.load(open('/var/lib/tuya-selfheal/state.json')); print(len(s.get('heal_history',[])), s.get('last_mode'), s.get('heals_total'))"
+cat /var/lib/prometheus/node-exporter/tuya_token_selfheal.prom | grep -E 'healthy|remaining|entry_state'
+
+# Forçar rodada (pós-fix: bypass se HA morto + bridge fresco)
+sudo systemctl start tuya-token-selfheal.service
+journalctl -u tuya-token-selfheal.service -n 40 --no-pager
+
+# Só se bridge também morto (1010)
+# python3 tools/homelab/tuya_reauth_via_authentik.py --host homelab ...
+```
+
+**Não** reauth QR só porque o alerta diz “expirado” — se bridge rem > 0, inject + (se preciso) limpar budget ou confiar no bypass.
+
+---
+
+## Lições
+
+1. **Correção de timer ≠ fim das regressões Tuya.** Esta outage é de **política de rate limit + thrash de reload**.
+2. **82/82 ativas ≠ token saudável** — storage da entry pode estar morto com entidades em cache.
+3. **Budget único para reload e inject** era a falha crítica: o sistema se “auto-protegia” até ficar cego no momento do inject.
+4. **Renewer sem contexto de bridge/rate-limit** gera alerta que parece reauth obrigatória.
+
+---
+
+## Follow-ups
+
+- [x] Não contar reload zumbi no `MAX_HEALS_24H`.
+- [x] Bypass de rate limit com HA expirado + bridge fresco.
+- [x] Deploy + validação no host (2026-08-08).
+- [ ] Merge PR com o fix (e este doc).
+- [ ] Opcional: cooldown de reload em `setup_error` estável com entidades já ativas.
+- [ ] Opcional: alerta renewer com texto “bridge OK, HA stale / rate-limit” quando aplicável.
+- [ ] Opcional: métrica `tuya_selfheal_rate_limited` / contagem de bypass.
+
+---
+
+## Referências
+
+- Selfheal: `tools/homelab/tuya_token_selfheal.py`
+- Testes: `tests/test_tuya_token_selfheal.py`
+- Unit: `systemd/tuya-token-selfheal.service` (`MAX_HEALS_24H=24`)
+- State: `/var/lib/tuya-selfheal/state.json`
+- Prom: `/var/lib/prometheus/node-exporter/tuya_token_selfheal.prom`
+- Reauth (só se 1010): `tools/homelab/tuya_reauth_via_authentik.py`
+- Integração: [SMARTLIFE_TUYA_INTEGRATION.md](../SMARTLIFE_TUYA_INTEGRATION.md)
+- PR: https://github.com/eddiejdi/eddie-auto-dev/pull/313

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -3065,10 +3065,13 @@
             "uid": "btc-trading-pg"
           },
           "editorMode": "code",
-          "format": "table",
+          "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH latest AS (\n  SELECT account_type, balance, available, synced_at\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  ORDER BY synced_at DESC\n  LIMIT 2\n)\nSELECT\n  NOW() AS time,\n  SUM(balance) AS \"Saldo BTC\"\nFROM latest",
-          "refId": "A"
+          "rawSql": "WITH latest AS (\n  SELECT account_type, balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  ORDER BY synced_at DESC\n  LIMIT 2\n)\nSELECT\n  now() AS \"time\",\n  SUM(balance) AS \"Saldo BTC\"\nFROM latest",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "₿ Saldo BTC (Main)",
@@ -3139,10 +3142,13 @@
             "uid": "btc-trading-pg"
           },
           "editorMode": "code",
-          "format": "table",
+          "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nperiod_ends AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1] AS end_bal,\n    (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS start_bal\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  NOW() AS time,\n  end_bal - start_bal AS \"Ganhos BTC\"\nFROM period_ends",
-          "refId": "A"
+          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nperiod_ends AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1] AS end_bal,\n    (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS start_bal\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  now() AS \"time\",\n  COALESCE(end_bal - start_bal, 0) AS \"Ganhos BTC\"\nFROM period_ends",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "📈 Ganhos BTC no Período",
@@ -3213,10 +3219,13 @@
             "uid": "btc-trading-pg"
           },
           "editorMode": "code",
-          "format": "table",
+          "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nbtc_delta AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1]\n    - (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS btc_earned\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nbtc_price AS (\n  SELECT price_usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n    AND price_usdt IS NOT NULL\n  ORDER BY synced_at DESC\n  LIMIT 1\n)\nSELECT\n  NOW() AS time,\n  btc_earned * btc_price.price_usdt AS \"Ganhos USDT\"\nFROM btc_delta, btc_price",
-          "refId": "A"
+          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nbtc_delta AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1]\n    - (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS btc_earned\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nbtc_price AS (\n  SELECT price_usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n    AND price_usdt IS NOT NULL\n  ORDER BY synced_at DESC\n  LIMIT 1\n)\nSELECT\n  now() AS \"time\",\n  COALESCE(btc_earned * btc_price.price_usdt, 0) AS \"Ganhos USDT\"\nFROM btc_delta, btc_price",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "💰 Ganhos em USDT",
@@ -3465,7 +3474,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH ordered AS (\n  SELECT\n    synced_at,\n    SUM(balance) AS total_balance,\n    LAG(SUM(balance)) OVER (ORDER BY synced_at) AS prev_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n)\nSELECT\n  synced_at AS \"time\",\n  total_balance - COALESCE(prev_balance, total_balance) AS \"Ganhos BTC\"\nFROM ordered\nWHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n  AND total_balance - COALESCE(prev_balance, total_balance) > 0\nORDER BY synced_at",
+          "rawSql": "WITH ordered AS (\n  SELECT\n    synced_at,\n    SUM(balance) AS total_balance,\n    LAG(SUM(balance)) OVER (ORDER BY synced_at) AS prev_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n)\nSELECT\n  synced_at AS \"time\",\n  COALESCE(total_balance - prev_balance, 0) AS \"Ganhos BTC\"\nFROM ordered\nWHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n  AND total_balance - COALESCE(prev_balance, total_balance) > 0\nORDER BY synced_at",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -3566,10 +3575,13 @@
             "uid": "btc-trading-pg"
           },
           "editorMode": "code",
-          "format": "table",
+          "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, available\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'USDT'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT\n  NOW() AS time,\n  available AS \"USDT Disponível\"\nFROM latest",
-          "refId": "A"
+          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, available\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'USDT'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT\n  now() AS \"time\",\n  available AS \"USDT Disponível\"\nFROM latest",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
         }
       ],
       "title": "💵 USDT Disponível (Main)",

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -2988,6 +2988,594 @@
       "type": "marcusolsson-dynamictext-panel"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 93
+      },
+      "id": 300,
+      "panels": [],
+      "title": "⛏️ Mineração KuMining",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Saldo BTC disponível na KuCoin (conta main). Recompensas de mineração KuMining são creditadas nesta conta.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 8,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.0001
+              },
+              {
+                "color": "green",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "currencyBTC"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 4,
+        "h": 5,
+        "y": 94
+      },
+      "id": 301,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, balance, available, synced_at\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT balance AS value FROM latest WHERE account_type = 'main'",
+          "refId": "A"
+        }
+      ],
+      "title": "₿ Saldo BTC (Main)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Ganho de BTC no período selecionado (conta main). Reflete recompensas de mineração KuMining creditadas.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 8,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1e-05
+              }
+            ]
+          },
+          "unit": "currencyBTC"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 4,
+        "w": 4,
+        "h": 5,
+        "y": 94
+      },
+      "id": 302,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH period_ends AS (\n  SELECT\n    (ARRAY_AGG(balance ORDER BY synced_at DESC))[1] AS end_bal,\n    (ARRAY_AGG(balance ORDER BY synced_at ASC))[1] AS start_bal\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT COALESCE(end_bal - start_bal, 0)::numeric(12,8) AS value FROM period_ends",
+          "refId": "A"
+        }
+      ],
+      "title": "📈 Ganhos BTC no Período",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Valor dos ganhos de mineração em USDT no período selecionado.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "w": 4,
+        "h": 5,
+        "y": 94
+      },
+      "id": 303,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH btc_delta AS (\n  SELECT\n    (ARRAY_AGG(balance ORDER BY synced_at DESC))[1]\n    - (ARRAY_AGG(balance ORDER BY synced_at ASC))[1] AS btc_earned\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nlatest_price AS (\n  SELECT price_usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n  ORDER BY synced_at DESC LIMIT 1\n)\nSELECT ROUND(COALESCE(b.btc_earned * p.price_usdt, 0)::numeric, 2) AS value\nFROM btc_delta b CROSS JOIN latest_price p",
+          "refId": "A"
+        }
+      ],
+      "title": "💰 Ganhos em USDT",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 6,
+        "h": 5,
+        "y": 94
+      },
+      "id": 304,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div style=\"display:flex;flex-direction:column;justify-content:center;height:100%;padding:12px;font-size:12px;line-height:1.6;color:#c8ccd0;\">\n<div style=\"font-weight:700;font-size:14px;color:#FF9830;margin-bottom:8px;\">⛏️ Contrato KuMining</div>\n<div><b>Hashrate:</b> 10 TH</div>\n<div><b>Período:</b> 7 dias</div>\n<div><b>Cupom:</b> 1 TH · 1 dia (bônus)</div>\n<div><b>Início:</b> 08/08/2026, 21:00</div>\n<div><b>Término:</b> 14/08/2026, 21:00</div>\n<div style=\"margin-top:6px;\"><b>Custo Total:</b> ~2.62 USDT</div>\n<div><b>ROI Estimado:</b> ~518% (7 dias)</div>\n</div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.4.0",
+      "title": "📋 Contrato Ativo",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Evolução do saldo BTC na conta main (inclui recompensas de mineração).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "BTC",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 8,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "currencyBTC"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Saldo BTC"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 305,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  synced_at AS \"time\",\n  balance AS \"Saldo BTC\"\nFROM btc.exchange_balance_snapshots\nWHERE currency = 'BTC'\n  AND account_type = 'main'\n  AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY 1",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "title": "📈 Saldo BTC ao Longo do Tempo",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Ganho diário de BTC por mineração (diferença entre snapshots consecutivos da conta main).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "BTC ganho",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 8,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "currencyBTC"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "w": 12,
+        "h": 8,
+        "y": 99
+      },
+      "id": 306,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "WITH ordered AS (\n  SELECT\n    synced_at,\n    balance,\n    LAG(balance) OVER (ORDER BY synced_at) AS prev_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  synced_at AS \"time\",\n  COALESCE(balance - prev_balance, 0)::numeric(12,8) AS \"Ganho BTC\"\nFROM ordered\nWHERE prev_balance IS NOT NULL\nORDER BY 1",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "title": "⛏️ Ganhos de Mineração por Snapshot",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "w": 18,
+        "h": 4,
+        "y": 107
+      },
+      "id": 308,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<div style=\"display:flex;align-items:center;justify-content:center;height:100%;gap:16px;padding:8px;\">\n<a href=\"https://www.kucoin.com/pt/assets/transfer?from=main&to=trade\" target=\"_blank\" style=\"display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,#FF9830,#F57C00);color:#fff;font-weight:700;font-size:16px;padding:14px 32px;border-radius:10px;text-decoration:none;box-shadow:0 4px 15px rgba(255,152,48,0.3);transition:all 0.2s;\" onmouseover=\"this.style.transform='translateY(-2px)';this.style.boxShadow='0 6px 20px rgba(255,152,48,0.4)'\" onmouseout=\"this.style.transform='';this.style.boxShadow='0 4px 15px rgba(255,152,48,0.3)'\">\n<span style=\"font-size:20px;\">💸</span> Transferir para Conta de Trading\n</a>\n<a href=\"https://www.kucoin.com/pt/assets/transfer?from=main&to=trade&symbol=BTC-USDT\" target=\"_blank\" style=\"display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,#FF9830,#F57C00);color:#fff;font-weight:700;font-size:16px;padding:14px 32px;border-radius:10px;text-decoration:none;box-shadow:0 4px 15px rgba(255,152,48,0.3);transition:all 0.2s;\" onmouseover=\"this.style.transform='translateY(-2px)';this.style.boxShadow='0 6px 20px rgba(255,152,48,0.4)'\" onmouseout=\"this.style.transform='';this.style.boxShadow='0 4px 15px rgba(255,152,48,0.3)'\">\n<span style=\"font-size:20px;\">⛏️</span> Transferir BTC Mining → Trading\n</a>\n</div>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.4.0",
+      "title": "🚀 Ações Rápidas",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "btc-trading-pg"
+      },
+      "description": "Saldo USDT disponível para transferir da conta main para a conta de trading.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "w": 6,
+        "h": 4,
+        "y": 107
+      },
+      "id": 307,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "btc-trading-pg"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, balance, available\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'USDT'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT available AS value FROM latest WHERE account_type = 'main'",
+          "refId": "A"
+        }
+      ],
+      "title": "💵 USDT Disponível (Main)",
+      "type": "stat"
+    },
+    {
       "datasource": {
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
@@ -3010,7 +3598,7 @@
         "h": 16,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 113
       },
       "id": 203,
       "options": {
@@ -3075,7 +3663,7 @@
         "x": 0,
         "w": 24,
         "h": 12,
-        "y": 109
+        "y": 129
       },
       "id": 98,
       "options": {
@@ -3153,7 +3741,7 @@
             "x": 0,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 21,
           "options": {
@@ -3215,7 +3803,7 @@
             "x": 4,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 22,
           "options": {
@@ -3288,7 +3876,7 @@
             "x": 8,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 23,
           "options": {
@@ -3346,7 +3934,7 @@
             "x": 12,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 24,
           "options": {
@@ -3405,7 +3993,7 @@
             "x": 16,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 25,
           "options": {
@@ -3467,7 +4055,7 @@
             "x": 20,
             "w": 4,
             "h": 3,
-            "y": 97
+            "y": 117
           },
           "id": 26,
           "options": {
@@ -3524,7 +4112,7 @@
             "x": 0,
             "w": 8,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 27,
           "options": {
@@ -3618,7 +4206,7 @@
             "x": 8,
             "w": 8,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 28,
           "options": {
@@ -3706,7 +4294,7 @@
             "x": 16,
             "w": 8,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 29,
           "options": {
@@ -3802,7 +4390,7 @@
             "x": 0,
             "w": 6,
             "h": 6,
-            "y": 98
+            "y": 118
           },
           "id": 31,
           "options": {
@@ -3896,7 +4484,7 @@
             "x": 6,
             "w": 8,
             "h": 6,
-            "y": 98
+            "y": 118
           },
           "id": 32,
           "options": {
@@ -4000,7 +4588,7 @@
             "x": 14,
             "w": 5,
             "h": 6,
-            "y": 98
+            "y": 118
           },
           "id": 33,
           "options": {
@@ -4082,7 +4670,7 @@
             "x": 19,
             "w": 3,
             "h": 6,
-            "y": 98
+            "y": 118
           },
           "id": 56,
           "options": {
@@ -4157,7 +4745,7 @@
             "x": 22,
             "w": 2,
             "h": 6,
-            "y": 98
+            "y": 118
           },
           "id": 57,
           "options": {
@@ -4281,7 +4869,7 @@
             "x": 0,
             "w": 5,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 81,
           "options": {
@@ -4354,7 +4942,7 @@
             "x": 5,
             "w": 4,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 82,
           "options": {
@@ -4462,7 +5050,7 @@
             "x": 9,
             "w": 5,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 83,
           "options": {
@@ -4543,7 +5131,7 @@
             "x": 14,
             "w": 3,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 85,
           "options": {
@@ -4634,7 +5222,7 @@
             "x": 17,
             "w": 4,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 84,
           "options": {
@@ -4714,7 +5302,7 @@
             "x": 21,
             "w": 3,
             "h": 7,
-            "y": 99
+            "y": 119
           },
           "id": 86,
           "options": {
@@ -4824,7 +5412,7 @@
             "x": 0,
             "w": 24,
             "h": 10,
-            "y": 106
+            "y": 126
           },
           "id": 88,
           "options": {
@@ -4879,7 +5467,7 @@
             "x": 0,
             "w": 24,
             "h": 28,
-            "y": 116
+            "y": 136
           },
           "id": 89,
           "options": {
@@ -5015,7 +5603,7 @@
             "x": 0,
             "w": 5,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 91,
           "options": {
@@ -5088,7 +5676,7 @@
             "x": 5,
             "w": 4,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 92,
           "options": {
@@ -5181,7 +5769,7 @@
             "x": 9,
             "w": 5,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 93,
           "options": {
@@ -5260,7 +5848,7 @@
             "x": 14,
             "w": 4,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 94,
           "options": {
@@ -5364,7 +5952,7 @@
             "x": 18,
             "w": 6,
             "h": 7,
-            "y": 100
+            "y": 120
           },
           "id": 95,
           "options": {
@@ -5500,7 +6088,7 @@
             "x": 0,
             "w": 24,
             "h": 8,
-            "y": 107
+            "y": 127
           },
           "id": 96,
           "options": {
@@ -5631,7 +6219,7 @@
             "x": 0,
             "w": 12,
             "h": 9,
-            "y": 115
+            "y": 135
           },
           "id": 107,
           "options": {
@@ -5703,7 +6291,7 @@
             "x": 12,
             "w": 12,
             "h": 9,
-            "y": 115
+            "y": 135
           },
           "id": 108,
           "options": {
@@ -5822,7 +6410,7 @@
             "x": 0,
             "w": 12,
             "h": 8,
-            "y": 124
+            "y": 144
           },
           "id": 109,
           "options": {
@@ -5988,7 +6576,7 @@
             "x": 12,
             "w": 12,
             "h": 8,
-            "y": 124
+            "y": 144
           },
           "id": 110,
           "options": {
@@ -6089,7 +6677,7 @@
             "x": 0,
             "w": 6,
             "h": 3,
-            "y": 101
+            "y": 121
           },
           "id": 51,
           "options": {
@@ -6147,7 +6735,7 @@
             "x": 6,
             "w": 6,
             "h": 3,
-            "y": 101
+            "y": 121
           },
           "id": 52,
           "options": {
@@ -6205,7 +6793,7 @@
             "x": 12,
             "w": 6,
             "h": 3,
-            "y": 101
+            "y": 121
           },
           "id": 53,
           "options": {
@@ -6263,7 +6851,7 @@
             "x": 18,
             "w": 6,
             "h": 3,
-            "y": 101
+            "y": 121
           },
           "id": 54,
           "options": {
@@ -6333,7 +6921,7 @@
             "x": 0,
             "w": 24,
             "h": 6,
-            "y": 104
+            "y": 124
           },
           "id": 60,
           "options": {
@@ -6459,7 +7047,7 @@
             "x": 0,
             "w": 24,
             "h": 12,
-            "y": 110
+            "y": 130
           },
           "id": 105,
           "options": {
@@ -6525,7 +7113,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6580,7 +7168,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6635,7 +7223,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6690,7 +7278,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6746,7 +7334,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6801,7 +7389,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 127
+        "y": 147
       },
       "datasource": {
         "type": "prometheus",
@@ -6856,7 +7444,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 131
+        "y": 151
       },
       "datasource": {
         "type": "prometheus",
@@ -6939,7 +7527,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 131
+        "y": 151
       },
       "datasource": {
         "type": "prometheus",
@@ -6995,7 +7583,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 139
+        "y": 159
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",
@@ -7028,7 +7616,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 147
+        "y": 167
       },
       "datasource": {
         "type": "grafana-postgresql-datasource",

--- a/grafana/dashboards/btc-trading-monitor.json
+++ b/grafana/dashboards/btc-trading-monitor.json
@@ -3005,7 +3005,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
       },
-      "description": "Saldo BTC disponível na KuCoin (conta main). Recompensas de mineração KuMining são creditadas nesta conta.",
+      "description": "Saldo BTC total nas sub-contas de trading (BTCAgressive + BTCConservative). Recompensas de mineração KuMining são creditadas nestas contas.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3067,7 +3067,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, balance, available, synced_at\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT balance AS value FROM latest WHERE account_type = 'main'",
+          "rawSql": "WITH latest AS (\n  SELECT account_type, balance, available, synced_at\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  ORDER BY synced_at DESC\n  LIMIT 2\n)\nSELECT\n  NOW() AS time,\n  SUM(balance) AS \"Saldo BTC\"\nFROM latest",
           "refId": "A"
         }
       ],
@@ -3141,7 +3141,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH period_ends AS (\n  SELECT\n    (ARRAY_AGG(balance ORDER BY synced_at DESC))[1] AS end_bal,\n    (ARRAY_AGG(balance ORDER BY synced_at ASC))[1] AS start_bal\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT COALESCE(end_bal - start_bal, 0)::numeric(12,8) AS value FROM period_ends",
+          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nperiod_ends AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1] AS end_bal,\n    (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS start_bal\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  NOW() AS time,\n  end_bal - start_bal AS \"Ganhos BTC\"\nFROM period_ends",
           "refId": "A"
         }
       ],
@@ -3215,7 +3215,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH btc_delta AS (\n  SELECT\n    (ARRAY_AGG(balance ORDER BY synced_at DESC))[1]\n    - (ARRAY_AGG(balance ORDER BY synced_at ASC))[1] AS btc_earned\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nlatest_price AS (\n  SELECT price_usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n  ORDER BY synced_at DESC LIMIT 1\n)\nSELECT ROUND(COALESCE(b.btc_earned * p.price_usdt, 0)::numeric, 2) AS value\nFROM btc_delta b CROSS JOIN latest_price p",
+          "rawSql": "WITH btc_snapshots AS (\n  SELECT synced_at, SUM(balance) AS total_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n),\nbtc_delta AS (\n  SELECT\n    (ARRAY_AGG(total_balance ORDER BY synced_at DESC))[1]\n    - (ARRAY_AGG(total_balance ORDER BY synced_at ASC))[1] AS btc_earned\n  FROM btc_snapshots\n  WHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n),\nbtc_price AS (\n  SELECT price_usdt\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n    AND price_usdt IS NOT NULL\n  ORDER BY synced_at DESC\n  LIMIT 1\n)\nSELECT\n  NOW() AS time,\n  btc_earned * btc_price.price_usdt AS \"Ganhos USDT\"\nFROM btc_delta, btc_price",
           "refId": "A"
         }
       ],
@@ -3362,7 +3362,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  synced_at AS \"time\",\n  balance AS \"Saldo BTC\"\nFROM btc.exchange_balance_snapshots\nWHERE currency = 'BTC'\n  AND account_type = 'main'\n  AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\nORDER BY 1",
+          "rawSql": "SELECT\n  synced_at AS \"time\",\n  SUM(balance) AS \"Saldo BTC\"\nFROM btc.exchange_balance_snapshots\nWHERE currency = 'BTC'\n  AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\nGROUP BY synced_at\nORDER BY synced_at",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -3465,7 +3465,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "WITH ordered AS (\n  SELECT\n    synced_at,\n    balance,\n    LAG(balance) OVER (ORDER BY synced_at) AS prev_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type = 'main'\n    AND synced_at BETWEEN $__timeFrom() AND $__timeTo()\n)\nSELECT\n  synced_at AS \"time\",\n  COALESCE(balance - prev_balance, 0)::numeric(12,8) AS \"Ganho BTC\"\nFROM ordered\nWHERE prev_balance IS NOT NULL\nORDER BY 1",
+          "rawSql": "WITH ordered AS (\n  SELECT\n    synced_at,\n    SUM(balance) AS total_balance,\n    LAG(SUM(balance)) OVER (ORDER BY synced_at) AS prev_balance\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'BTC'\n    AND account_type IN ('sub:BTCAgressive', 'sub:BTCConservative')\n  GROUP BY synced_at\n)\nSELECT\n  synced_at AS \"time\",\n  total_balance - COALESCE(prev_balance, total_balance) AS \"Ganhos BTC\"\nFROM ordered\nWHERE synced_at BETWEEN $__timeFrom() AND $__timeTo()\n  AND total_balance - COALESCE(prev_balance, total_balance) > 0\nORDER BY synced_at",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -3506,7 +3506,7 @@
         "type": "grafana-postgresql-datasource",
         "uid": "btc-trading-pg"
       },
-      "description": "Saldo USDT disponível para transferir da conta main para a conta de trading.",
+      "description": "USDT disponível na conta main para transferência.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3568,7 +3568,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, balance, available\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'USDT'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT available AS value FROM latest WHERE account_type = 'main'",
+          "rawSql": "WITH latest AS (\n  SELECT DISTINCT ON (account_type)\n    account_type, available\n  FROM btc.exchange_balance_snapshots\n  WHERE currency = 'USDT'\n    AND account_type = 'main'\n  ORDER BY account_type, synced_at DESC\n)\nSELECT\n  NOW() AS time,\n  available AS \"USDT Disponível\"\nFROM latest",
           "refId": "A"
         }
       ],

--- a/scripts/homelab_mcp_server.py
+++ b/scripts/homelab_mcp_server.py
@@ -509,6 +509,11 @@ _VALID_RISK_LEVELS   = {"none", "low", "medium", "high", "critical"}
 _VALID_ACTION_TYPES  = {"restart", "deploy", "modify", "delete", "create", "query", "config", "other"}
 _VALID_STATUSES      = {"pending", "approved", "rejected", "in_progress", "done", "failed", "expired"}
 
+# Ações que SEMPRE exigem aprovação humana, mesmo com risk_level low/none.
+# Deploy e restart podem causar downtime ou alterar ambiente de produção.
+_ALWAYS_GATE_ACTION_TYPES: set[str] = {"deploy", "restart"}
+_FORCE_MIN_RISK_FOR_GATED = "medium"
+
 
 def _db_write(sql: str, params: tuple) -> dict:
     """Executa SQL de escrita no PostgreSQL do homelab (INSERT/UPDATE)."""
@@ -612,6 +617,17 @@ def intent_declare(
     except json.JSONDecodeError:
         return json.dumps({"ok": False, "error": "context não é JSON válido."}, ensure_ascii=False)
 
+    # ── Guard: ações de deploy/restart SEMPRE exigem aprovação humana ────
+    # Mesmo que o agente declare risk_level='low' ou 'none', deploy e restart
+    # são forçados para risk_level mínimo 'medium' para garantir que o humano
+    # seja notificado via Telegram antes de qualquer alteração em produção.
+    _risk_order = {"none": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+    if action_type in _ALWAYS_GATE_ACTION_TYPES:
+        min_risk_idx = _risk_order[_FORCE_MIN_RISK_FOR_GATED]
+        current_risk_idx = _risk_order.get(risk_level, 0)
+        if current_risk_idx < min_risk_idx:
+            risk_level = _FORCE_MIN_RISK_FOR_GATED
+
     intent_id = f"intent-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
     initial_status = "approved" if risk_level in _AUTO_APPROVE_LEVELS else "pending"
 
@@ -637,11 +653,14 @@ def intent_declare(
         return json.dumps(result, ensure_ascii=False)
 
     row = result["rows"][0] if result["rows"] else {}
+    risk_forced = action_type in _ALWAYS_GATE_ACTION_TYPES and initial_status == "pending"
     return json.dumps({
         "ok": True,
         "intent_id": intent_id,
         "status": initial_status,
         "auto_approved": initial_status == "approved",
+        "risk_level": risk_level,
+        "risk_forced": risk_forced,
         "message": (
             "Auto-aprovado — pode prosseguir." if initial_status == "approved"
             else "Aguardando aprovação humana. Chame intent_check_status() antes de executar."
@@ -729,6 +748,41 @@ def intent_complete(
     """
     final_status = "done" if success else "failed"
     now = datetime.now(timezone.utc)
+
+    # ── Guard: não permitir complete sem aprovação prévia ────────────────
+    # Antes desta correção, qualquer agente podia chamar intent_complete()
+    # num intent 'pending' e marcá-lo como 'done' sem aprovação humana.
+    # Agora só permitimos complete se o status atual for 'approved'.
+    current = _db_read_one(
+        "SELECT status, risk_level FROM agent_actions WHERE intent_id = %s",
+        (intent_id,),
+    )
+    if not current["ok"]:
+        return json.dumps(current, ensure_ascii=False)
+    if current["row"] is None:
+        return json.dumps({"ok": False, "error": f"intent_id não encontrado: {intent_id}"}, ensure_ascii=False)
+
+    current_status = current["row"]["status"]
+    risk = current["row"].get("risk_level", "medium")
+
+    if current_status == "pending" and risk not in _AUTO_APPROVE_LEVELS:
+        return json.dumps({
+            "ok": False,
+            "error": (
+                f"Intent '{intent_id}' está 'pending' e requer aprovação humana "
+                f"(risk={risk}). Aguarde intent_check_status() retornar 'approved' "
+                "antes de chamar intent_complete()."
+            ),
+            "status": current_status,
+            "risk_level": risk,
+        }, ensure_ascii=False, indent=2)
+
+    if current_status in ("rejected", "expired"):
+        return json.dumps({
+            "ok": False,
+            "error": f"Intent '{intent_id}' já foi {current_status} — não pode ser completado.",
+            "status": current_status,
+        }, ensure_ascii=False, indent=2)
 
     result = _db_write(
         """

--- a/tests/test_tuya_token_selfheal.py
+++ b/tests/test_tuya_token_selfheal.py
@@ -166,7 +166,8 @@ def test_should_heal_zero_entities_above_soft_bridge_not_newer() -> None:
         (FRESH_TOKEN, FRESH_TOKEN, 75, 0, "ainda válido"),
         (EXPIRED_TOKEN, None, 0, 0, "ausente/inválido"),
         (EXPIRED_TOKEN, EXPIRED_TOKEN, 0, 0, "não é mais novo"),
-        (EXPIRED_TOKEN, FRESH_TOKEN, 0, 24, "rate limit"),
+        # Soft-threshold / proativo ainda respeita rate limit (HA ainda válido).
+        (NEAR_EXPIRY_TOKEN, NEWER_RUNTIME, 75, 24, "rate limit"),
     ],
 )
 def test_should_heal_guards(ha_token, runtime, active, heals, expected_reason) -> None:
@@ -183,8 +184,55 @@ def test_should_heal_guards(ha_token, runtime, active, heals, expected_reason) -
     assert expected_reason in reason
 
 
+def test_should_heal_expired_bypasses_rate_limit() -> None:
+    """Incidente 2026-08-08: budget cheio não pode bloquear inject com HA morto + bridge fresco."""
+    heal, reason = selfheal.should_heal(
+        EXPIRED_TOKEN,
+        FRESH_TOKEN,
+        entities_active=82,
+        heals_last_24h=24,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
+        entities_total=82,
+    )
+    assert heal, reason
+    assert "expirado" in reason
+    assert "rate-limit bypass" in reason
+
+
+def test_should_heal_soft_still_rate_limited_when_budget_full() -> None:
+    """Proativo (soft) continua barrado com budget cheio — só expired faz bypass."""
+    heal, reason = selfheal.should_heal(
+        NEAR_EXPIRY_TOKEN,
+        NEWER_RUNTIME,
+        entities_active=75,
+        heals_last_24h=24,
+        now_ms=NOW_MS,
+        soft_threshold_min=45,
+        entities_total=75,
+    )
+    assert not heal
+    assert "rate limit" in reason
+
+
+def test_reload_counts_toward_heal_budget_only_on_recovery() -> None:
+    """Reload zumbi (já havia ativas) não conta; 0→N conta."""
+    assert not selfheal.reload_counts_toward_heal_budget(82, 82)
+    assert not selfheal.reload_counts_toward_heal_budget(10, 82)
+    assert selfheal.reload_counts_toward_heal_budget(0, 82)
+    assert selfheal.reload_counts_toward_heal_budget(0, 1)
+    assert not selfheal.reload_counts_toward_heal_budget(0, 0)
+
+
 def test_should_reload_entry_setup_error() -> None:
     do, reason = selfheal.should_reload_entry("setup_error", 0, 75, 50.0)
+    assert do
+    assert "setup_error" in reason
+
+
+def test_should_reload_entry_setup_error_with_active_entities() -> None:
+    """setup_error + entidades ativas: ainda pode reloadar (mas não queima budget no main)."""
+    do, reason = selfheal.should_reload_entry("setup_error", 82, 82, 50.0)
     assert do
     assert "setup_error" in reason
 

--- a/tools/homelab/tuya_token_selfheal.py
+++ b/tools/homelab/tuya_token_selfheal.py
@@ -7,12 +7,15 @@ MQTT tuya_sharing cai. O pandaplus-bridge mantém sessão própria, mas o SDK
 só renova o token quando faltam <60s; sem intervenção proativa restam
 janelas de 5–15 min com HA sem token válido.
 
-Modos de falha cobertos (jul/2026):
+Modos de falha cobertos (jul/2026 + ago/2026):
 1. Token OAuth expirado / na janela soft → refresh proativo + injeção.
 2. Entry em ``setup_error`` (timeout API Tuya) com token ainda "válido" →
    reload da config entry (self-heal antigo *não* cobria — só olhava token).
+   Reload com entidades já ativas (zumbi) **não** consome MAX_HEALS_24H.
 3. 0/N entidades ativas com token aparentemente válido → reload; se bridge
    tiver token mais novo, injeta mesmo acima do soft threshold.
+4. Rate limit 24h: aplica a heals proativos; **bypass** se HA já expirou e
+   o bridge/runtime é estritamente mais novo (incidente 2026-08-08).
 
 Fluxo:
 1. Se o access token (HA ou bridge) está abaixo do limiar soft, **força
@@ -130,6 +133,10 @@ def should_reload_entry(
     Cobre o buraco do incidente 2026-07-25: entry em ``setup_error`` por
     timeout da API Tuya, token ainda com dezenas de minutos, 0 entidades
     ativas — o heal de token recusava com "ainda válido" e ninguém reloadava.
+
+    Nota (2026-08-08): reload com entidades já ativas (zumbi) ainda pode
+    rodar, mas **não** deve consumir ``MAX_HEALS_24H`` — ver
+    ``reload_counts_toward_heal_budget``.
     """
     state = (entry_state or "").strip().lower()
     if state == "setup_error":
@@ -150,6 +157,20 @@ def should_reload_entry(
     return False, "reload não necessário"
 
 
+def reload_counts_toward_heal_budget(
+    entities_active_before: int,
+    entities_active_after: int,
+) -> bool:
+    """Só conta reload no budget de heals se recuperou entidades (0 → >0).
+
+    Incidente 2026-08-08: entry em ``setup_error`` com 82/82 ainda "ativas"
+    fazia reload a cada 5 min, cada um contava como Heal OK e esgotava
+    ``MAX_HEALS_24H`` — depois o inject legítimo (HA expirado + bridge fresco)
+    era barrado pelo rate limit.
+    """
+    return entities_active_before <= 0 and entities_active_after > 0
+
+
 def should_heal(
     ha_token: dict,
     runtime_token: dict | None,
@@ -161,16 +182,20 @@ def should_heal(
 ) -> tuple[bool, str]:
     """Decide se a injeção do token do bridge deve ser aplicada.
 
-    Regras (2026-07-23 + buracos 2026-07-27):
+    Regras (2026-07-23 + buracos 2026-07-27 + rate-limit 2026-08-08):
     - Token do HA **expirado** (remaining <= 0): heal **mesmo com entidades
       ainda "ativas"** — estado zumbi típico (cloud morta, HA cacheia on/off).
+      **Bypass de rate limit** quando o bridge é estritamente mais novo
+      (inject é o único path automático; budget queimado em reload não pode
+      bloquear).
     - Soft threshold (HEAL_SOFT_THRESHOLD_MIN, default 45): heal proativo se
       remaining estiver abaixo do limiar e o runtime/bridge for mais novo.
     - **0 entidades ativas** com entidades no registry: permite heal mesmo
       *acima* do soft threshold se o bridge for estritamente mais novo
       (token em memória pode estar stale / entry semi-morta).
     - Bridge/runtime precisa de token válido e estritamente mais novo (t maior).
-    - Rate limit por 24h.
+    - Rate limit por 24h para heals **proativos** (soft / 0-ativas com token
+      ainda válido); **não** aplica quando HA já expirou + bridge fresco.
     """
     now_ms = time.time() * 1000 if now_ms is None else now_ms
     if soft_threshold_min is None:
@@ -192,15 +217,24 @@ def should_heal(
         return False, "token runtime do bridge ausente/inválido"
     if bridge_t <= ha_t:
         return False, "token do bridge não é mais novo que o do HA"
-    if heals_last_24h >= MAX_HEALS_24H:
-        return False, f"rate limit: {heals_last_24h} heals nas últimas 24h"
 
+    rate_limited = heals_last_24h >= MAX_HEALS_24H
+
+    # HA access token morto + bridge fresco: inject prioritário (bypass budget).
     if remaining <= 0:
         return (
             True,
             f"token HA expirado ({remaining:.0f} min) + bridge mais novo"
-            + (f" | {entities_active} entidades ainda ativas" if entities_active > 0 else ""),
+            + (" | rate-limit bypass" if rate_limited else "")
+            + (
+                f" | {entities_active} entidades ainda ativas"
+                if entities_active > 0
+                else ""
+            ),
         )
+
+    if rate_limited:
+        return False, f"rate limit: {heals_last_24h} heals nas últimas 24h"
 
     if zero_entities and remaining > soft_threshold_min:
         return (
@@ -889,6 +923,7 @@ def main() -> int:
     # Reload só faz sentido se o token no storage ainda pode autenticar.
     # Token já morto → pular direto para inject (reload só gasta tempo).
     if do_reload and status.get("entry_id") and ha_remaining > 0:
+        entities_before_reload = int(status["entities_active"])
         log.info(
             "Tuya reload: %s/%s ativas | state=%s | %s",
             status["entities_active"],
@@ -907,15 +942,29 @@ def main() -> int:
                 ha_token = status.get("token_info") or {}
                 ha_remaining = token_remaining_minutes(ha_token)
                 if active > 0:
-                    state["heals_total"] += 1
-                    state["last_heal_timestamp"] = int(time.time())
-                    state["heal_history"].append(time.time())
-                    log.info(
-                        "Heal OK (reload): %s entidades ativas | token resta %.0f min | state=%s",
-                        active,
-                        ha_remaining,
-                        status.get("entry_state"),
-                    )
+                    # Zumbi (setup_error + entidades já ativas): reload pode
+                    # "suceder" sem recuperar nada e não deve queimar MAX_HEALS.
+                    if reload_counts_toward_heal_budget(
+                        entities_before_reload, active
+                    ):
+                        state["heals_total"] += 1
+                        state["last_heal_timestamp"] = int(time.time())
+                        state["heal_history"].append(time.time())
+                        log.info(
+                            "Heal OK (reload): %s entidades ativas | token resta %.0f min | state=%s",
+                            active,
+                            ha_remaining,
+                            status.get("entry_state"),
+                        )
+                    else:
+                        log.info(
+                            "Reload applied (not counted toward heal budget): "
+                            "%s→%s ativas | token resta %.0f min | state=%s",
+                            entities_before_reload,
+                            active,
+                            ha_remaining,
+                            status.get("entry_state"),
+                        )
                 else:
                     log.warning(
                         "Reload aplicado mas entidades ainda 0 — tentando inject se bridge mais novo"

--- a/tools/hooks/wiki_doc_analyzer.py
+++ b/tools/hooks/wiki_doc_analyzer.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""wiki_doc_analyzer.py — Pré-análise de documentação antes de publicar na wiki.
+
+Executado como pre-commit hook. Analisa .md staged:
+  1. Validação estrutural (headings, links, code blocks, frontmatter)
+  2. Extração de termos-chave e decisões para memória do agente wiki
+  3. Detecção de duplicatas com páginas existentes na wiki
+
+Uso:
+    python3 tools/hooks/wiki_doc_analyzer.py [--staged] [--verbose]
+
+Exit codes:
+    0 — OK (warnings podem existir)
+    1 — Bloqueado (erro estrutural crítico)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+# ── Configuração ──────────────────────────────────────────────────────────────
+
+WIKI_GQL = os.environ.get("WIKI_GQL_URL", "http://192.168.15.2:3009/graphql")
+SECRETS_ENDPOINT = "http://192.168.15.2:8088/secret/wikijs/token"
+
+# Padrões para skip (mesmos do post-commit)
+SKIP_PATTERNS = [
+    r"^wiki_",
+    r"CONVERSAS_",
+    r"COMPARISON",
+    r"^\.github/",
+    r"^docs/confluence",
+    r"^\.claude/",
+]
+
+# ── Regex para análise ────────────────────────────────────────────────────────
+
+RE_HEADING = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+RE_CODE_BLOCK = re.compile(r"```(\w+)?\n(.*?)```", re.DOTALL)
+RE_INTERNAL_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+RE_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+RE_ADR = re.compile(r"(?:ADR|Decision|Decisão)[:\s]+(.+)", re.IGNORECASE)
+RE_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
+RE_TODO = re.compile(r"(?:TODO|FIXME|HACK|XXX)[:\s]+(.+)", re.IGNORECASE)
+
+
+# ── Utilitários ───────────────────────────────────────────────────────────────
+
+def _git_staged_files() -> list[Path]:
+    """Retorna arquivos .md staged para commit."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=AM"],
+            capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        return [
+            REPO_ROOT / f
+            for f in result.stdout.splitlines()
+            if f.endswith(".md")
+        ]
+    except Exception:
+        return []
+
+
+def _load_wiki_token() -> str:
+    """Carrega token da wiki (env > .env > secrets agent)."""
+    val = os.environ.get("WIKI_TOKEN", "")
+    if val:
+        return val
+    env_f = REPO_ROOT / ".env"
+    if env_f.exists():
+        for line in env_f.read_text().splitlines():
+            if line.startswith("WIKI_TOKEN="):
+                return line.split("=", 1)[1].strip().strip("\"'")
+    try:
+        import urllib.request
+        req = urllib.request.Request(SECRETS_ENDPOINT)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read()).get("value", "")
+    except Exception:
+        return ""
+
+
+def _should_skip(filepath: Path) -> bool:
+    """Verifica se o arquivo deve ser ignorado."""
+    rel = str(filepath.relative_to(REPO_ROOT)) if filepath.is_relative_to(REPO_ROOT) else filepath.name
+    return any(re.search(pat, rel) for pat in SKIP_PATTERNS)
+
+
+# ── 1. Validação Estrutural ───────────────────────────────────────────────────
+
+class StructuralValidator:
+    """Valida estrutura do markdown."""
+
+    def __init__(self, content: str, filepath: Path):
+        self.content = content
+        self.filepath = filepath
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def validate(self) -> tuple[list[str], list[str]]:
+        self._check_frontmatter()
+        self._check_headings()
+        self._check_code_blocks()
+        self._check_internal_links()
+        self._check_line_length()
+        self._check_empty_sections()
+        return self.errors, self.warnings
+
+    def _check_frontmatter(self):
+        """Verifica se frontmatter existe e tem campos obrigatórios."""
+        match = RE_FRONTMATTER.match(self.content)
+        if not match:
+            self.warnings.append("Sem frontmatter (recomendado: title, description)")
+            return
+        fm = match.group(1)
+        if "title:" not in fm:
+            self.errors.append("Frontmatter sem campo 'title'")
+        if "description:" not in fm:
+            self.warnings.append("Frontmatter sem campo 'description'")
+
+    def _check_headings(self):
+        """Valida hierarquia de headings."""
+        headings = RE_HEADING.findall(self.content)
+        if not headings:
+            self.warnings.append("Documento sem headings (H1/H2/H3)")
+            return
+
+        levels = [len(h[0]) for h in headings]
+        if levels[0] != 1:
+            self.errors.append(f"Primeiro heading deve ser H1 (encontrou H{levels[0]})")
+
+        for i in range(1, len(levels)):
+            if levels[i] - levels[i - 1] > 1:
+                self.warnings.append(
+                    f"Pulo de H{levels[i-1]} para H{levels[i]} (linhas podem estar inconsistentes)"
+                )
+
+    def _check_code_blocks(self):
+        """Verifica code blocks."""
+        blocks = RE_CODE_BLOCK.findall(self.content)
+        for lang, _ in blocks:
+            if not lang:
+                self.warnings.append("Code block sem linguagem especificada")
+
+    def _check_internal_links(self):
+        """Verifica links internos quebrados (básico)."""
+        links = RE_INTERNAL_LINK.findall(self.content)
+        for text, url in links:
+            if url.startswith("#"):
+                continue  # Anchor local
+            if url.startswith("http"):
+                continue  # Link externo
+            # Link interno — verificar se o arquivo existe
+            target = self.filepath.parent / url
+            if not target.exists():
+                self.warnings.append(f"Link interno quebrado: [{text}]({url})")
+
+    def _check_line_length(self):
+        """Avisa sobre linhas muito longas."""
+        for i, line in enumerate(self.content.split("\n"), 1):
+            if len(line) > 200 and not line.strip().startswith("```"):
+                self.warnings.append(f"Linha {i}: {len(line)} chars (>200)")
+
+    def _check_empty_sections(self):
+        """Detecta seções vazias."""
+        lines = self.content.split("\n")
+        for i in range(len(lines) - 1):
+            if re.match(r"^#{1,6}\s+", lines[i]):
+                next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
+                if not next_line or next_line.startswith("#"):
+                    self.warnings.append(f"Seção vazia: {lines[i].strip()}")
+
+
+# ── 2. Extração de Termos ────────────────────────────────────────────────────
+
+class TermExtractor:
+    """Extrai termos-chave, decisões e contexto do documento."""
+
+    def __init__(self, content: str, filepath: Path):
+        self.content = content
+        self.filepath = filepath
+        self.result: dict[str, Any] = {
+            "file": str(filepath.relative_to(REPO_ROOT) if filepath.is_relative_to(REPO_ROOT) else filepath.name),
+            "headings": [],
+            "decisions": [],
+            "todos": [],
+            "code_langs": [],
+            "key_terms": [],
+        }
+
+    def extract(self) -> dict[str, Any]:
+        self._extract_headings()
+        self._extract_decisions()
+        self._extract_todos()
+        self._extract_code_langs()
+        self._extract_key_terms()
+        return self.result
+
+    def _extract_headings(self):
+        """Extrai todos os headings como estrutura do documento."""
+        self.result["headings"] = [
+            {"level": len(h[0]), "text": h[1].strip()}
+            for h in RE_HEADING.findall(self.content)
+        ]
+
+    def _extract_decisions(self):
+        """Extrai decisões/ADRs mencionadas."""
+        self.result["decisions"] = RE_ADR.findall(self.content)
+
+    def _extract_todos(self):
+        """Extrai TODOs e FIXMEs."""
+        self.result["todos"] = RE_TODO.findall(self.content)
+
+    def _extract_code_langs(self):
+        """Lista linguagens de code blocks."""
+        self.result["code_langs"] = list(set(
+            lang for lang, _ in RE_CODE_BLOCK.findall(self.content) if lang
+        ))
+
+    def _extract_key_terms(self):
+        """Extrai termos técnicos relevantes."""
+        # Termos de alto sinal: tecnologias, serviços, conceitos
+        patterns = [
+            r"\b(Python|Rust|Go|TypeScript|Docker|Kubernetes|PostgreSQL|Redis)\b",
+            r"\b(MCP|LLM|Ollama|GPU|CPU|RAM|VRAM)\b",
+            r"\b(trading|deploy|rollback|hotfix|incident|outage)\b",
+            r"\b(Grafana|Prometheus|Alertmanager|Telegram)\b",
+        ]
+        terms = set()
+        for pat in patterns:
+            terms.update(re.findall(pat, self.content, re.IGNORECASE))
+        self.result["key_terms"] = sorted(terms)
+
+
+# ── 3. Detecção de Duplicatas ────────────────────────────────────────────────
+
+class DuplicateDetector:
+    """Verifica se o conteúdo já existe na wiki."""
+
+    def __init__(self, content: str, filepath: Path, token: str):
+        self.content = content
+        self.filepath = filepath
+        self.token = token
+        self.duplicates: list[dict[str, str]] = []
+
+    def check(self) -> list[dict[str, str]]:
+        if not self.token:
+            return []
+
+        try:
+            from specialized_agents.wiki_client import WikiJsClient
+            client = WikiJsClient(WIKI_GQL, self.token, default_locale="pt")
+
+            # Extrair título do documento
+            title_match = RE_HEADING.search(self.content)
+            if not title_match:
+                return []
+
+            search_term = title_match.group(2).strip()[:50]
+
+            # Listar páginas e comparar similaridade básica
+            pages = client.list_pages()
+            for page in pages:
+                page_title = page.get("title", "").lower()
+                if self._similar(search_term.lower(), page_title):
+                    self.duplicates.append({
+                        "wiki_path": page.get("path", "?"),
+                        "title": page.get("title", "?"),
+                        "updated": page.get("updatedAt", "?"),
+                    })
+
+        except Exception:
+            pass  # Falha silenciosa — não bloqueia commit
+
+        return self.duplicates
+
+    def _similar(self, a: str, b: str) -> bool:
+        """Similaridade básica por tokens compartilhados."""
+        tokens_a = set(a.split())
+        tokens_b = set(b.split())
+        if not tokens_a or not tokens_b:
+            return False
+        overlap = len(tokens_a & tokens_b) / max(len(tokens_a), len(tokens_b))
+        return overlap > 0.7
+
+
+# ── Relatório ─────────────────────────────────────────────────────────────────
+
+def _print_report(
+    filepath: Path,
+    errors: list[str],
+    warnings: list[str],
+    terms: dict[str, Any],
+    duplicates: list[dict[str, str]],
+    verbose: bool,
+):
+    """Imprime relatório de análise."""
+    rel = filepath.relative_to(REPO_ROOT) if filepath.is_relative_to(REPO_ROOT) else filepath.name
+    print(f"\n📄 Analisando: {rel}")
+
+    if errors:
+        print(f"  ❌ Erros ({len(errors)}):")
+        for e in errors:
+            print(f"     - {e}")
+
+    if warnings:
+        print(f"  ⚠️  Warnings ({len(warnings)}):")
+        for w in warnings:
+            print(f"     - {w}")
+
+    if verbose:
+        headings = terms.get("headings", [])
+        if headings:
+            print(f"  📑 Estrutura: {len(headings)} headings")
+            for h in headings[:5]:
+                print(f"     {'  ' * (h['level'] - 1)}H{h['level']}: {h['text']}")
+
+        decisions = terms.get("decisions", [])
+        if decisions:
+            print(f"  🎯 Decisões: {len(decisions)}")
+            for d in decisions[:3]:
+                print(f"     - {d[:80]}")
+
+        todos = terms.get("todos", [])
+        if todos:
+            print(f"  📝 TODOs: {len(todos)}")
+            for t in todos[:3]:
+                print(f"     - {t[:80]}")
+
+        langs = terms.get("code_langs", [])
+        if langs:
+            print(f"  💻 Code blocks: {', '.join(langs)}")
+
+        key_terms = terms.get("key_terms", [])
+        if key_terms:
+            print(f"  🔑 Termos-chave: {', '.join(key_terms[:10])}")
+
+    if duplicates:
+        print(f"  🔄 Possíveis duplicatas ({len(duplicates)}):")
+        for d in duplicates:
+            print(f"     - {d['title']} → {d['wiki_path']} (atualizado: {d['updated']})")
+
+    if not errors and not warnings and not duplicates:
+        print("  ✅ Tudo OK")
+
+
+# ── Persistência para memória do agente ──────────────────────────────────────
+
+def _persist_to_memory(terms: list[dict[str, Any]]):
+    """Salva termos extraídos para uso do agente wiki."""
+    memory_file = REPO_ROOT / "tools" / "hooks" / ".wiki_doc_terms.json"
+    existing = []
+    if memory_file.exists():
+        try:
+            existing = json.loads(memory_file.read_text())
+        except Exception:
+            existing = []
+
+    # Adicionar novos termos (dedup por arquivo)
+    existing_files = {t["file"] for t in existing}
+    for t in terms:
+        if t["file"] not in existing_files:
+            existing.append(t)
+
+    # Manter apenas últimos 100 documentos
+    existing = existing[-100:]
+
+    try:
+        memory_file.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
+    except Exception:
+        pass  # Não bloqueia commit
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Pré-análise de documentação wiki")
+    parser.add_argument("--staged", action="store_true", help="Analisar apenas arquivos staged")
+    parser.add_argument("--verbose", action="store_true", help="Saída detalhada")
+    parser.add_argument("--skip-dedup", action="store_true", help="Pular checagem de duplicatas")
+    parser.add_argument("files", nargs="*", help="Arquivos específicos para analisar")
+    args = parser.parse_args()
+
+    if args.files:
+        files = [Path(f) for f in args.files if Path(f).exists()]
+    elif args.staged:
+        files = _git_staged_files()
+    else:
+        files = list(REPO_ROOT.rglob("*.md"))
+        files = [f for f in files if f.is_file() and not _should_skip(f)]
+
+    if not files:
+        print("📭 Nenhum .md para analisar")
+        return 0
+
+    token = _load_wiki_token()
+    all_terms = []
+    has_errors = False
+
+    for filepath in files:
+        try:
+            content = filepath.read_text(encoding="utf-8", errors="replace")
+        except Exception as exc:
+            print(f"❌ Erro lendo {filepath}: {exc}")
+            has_errors = True
+            continue
+
+        # 1. Validação estrutural
+        validator = StructuralValidator(content, filepath)
+        errors, warnings = validator.validate()
+
+        # 2. Extração de termos
+        extractor = TermExtractor(content, filepath)
+        terms = extractor.extract()
+
+        # 3. Detecção de duplicatas
+        duplicates = []
+        if not args.skip_dedup and token:
+            detector = DuplicateDetector(content, filepath, token)
+            duplicates = detector.check()
+
+        # Relatório
+        _print_report(filepath, errors, warnings, terms, duplicates, args.verbose)
+
+        if errors:
+            has_errors = True
+
+        all_terms.append(terms)
+
+    # Persistir termos para memória
+    if all_terms:
+        _persist_to_memory(all_terms)
+
+    print()
+    if has_errors:
+        print("❌ Análise encontrou erros — commit bloqueado")
+        print("   Corrija os erros ou use --no-verify para ignorar")
+        return 1
+
+    print("✅ Análise de documentação concluída")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/wiki_doc_analyzer.py
+++ b/tools/hooks/wiki_doc_analyzer.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""wiki_doc_analyzer.py — Pré-análise de documentação antes de publicar na wiki.
+"""wiki_doc_analyzer.py — Pré-análise de documentação focada na tarefa.
 
-Executado como pre-commit hook. Analisa .md staged:
+Executado como pre-commit hook. Analisa .md staged no contexto da atividade:
   1. Validação estrutural (headings, links, code blocks, frontmatter)
-  2. Extração de termos-chave e decisões para memória do agente wiki
-  3. Detecção de duplicatas com páginas existentes na wiki
+  2. Extração de conhecimento relevante para a tarefa sendo commitada
+  3. Gera resumo de contexto para o agente wiki
+
+Foco: agregar conhecimento à tarefa atual, não análise genérica.
 
 Uso:
     python3 tools/hooks/wiki_doc_analyzer.py [--staged] [--verbose]
 
 Exit codes:
-    0 — OK (warnings podem existir)
+    0 — OK
     1 — Bloqueado (erro estrutural crítico)
 """
 from __future__ import annotations
@@ -29,10 +31,8 @@ sys.path.insert(0, str(REPO_ROOT))
 
 # ── Configuração ──────────────────────────────────────────────────────────────
 
-WIKI_GQL = os.environ.get("WIKI_GQL_URL", "http://192.168.15.2:3009/graphql")
 SECRETS_ENDPOINT = "http://192.168.15.2:8088/secret/wikijs/token"
 
-# Padrões para skip (mesmos do post-commit)
 SKIP_PATTERNS = [
     r"^wiki_",
     r"CONVERSAS_",
@@ -42,56 +42,77 @@ SKIP_PATTERNS = [
     r"^\.claude/",
 ]
 
-# ── Regex para análise ────────────────────────────────────────────────────────
+# ── Regex ─────────────────────────────────────────────────────────────────────
 
 RE_HEADING = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 RE_CODE_BLOCK = re.compile(r"```(\w+)?\n(.*?)```", re.DOTALL)
-RE_INTERNAL_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 RE_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-RE_ADR = re.compile(r"(?:ADR|Decision|Decisão)[:\s]+(.+)", re.IGNORECASE)
-RE_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
+RE_ADR = re.compile(r"(?:ADR|Decision|Decisão|decidido)[:\s]+(.+)", re.IGNORECASE)
 RE_TODO = re.compile(r"(?:TODO|FIXME|HACK|XXX)[:\s]+(.+)", re.IGNORECASE)
+
+# Mapeamento de paths para categorias de tarefa
+TASK_CATEGORIES = {
+    r"btc_trading_agent|trading": "trading",
+    r"specialized_agents|coordinator": "agentes",
+    r"deploy|systemd|docker": "infraestrutura",
+    r"grafana|monitoring|alert": "monitoramento",
+    r"wiki|docs|documentation": "documentação",
+    r"scripts|tools": "automação",
+    r"tests|test": "testes",
+    r"security|vault|auth|secrets": "segurança",
+}
 
 
 # ── Utilitários ───────────────────────────────────────────────────────────────
 
 def _git_staged_files() -> list[Path]:
-    """Retorna arquivos .md staged para commit."""
     try:
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-only", "--diff-filter=AM"],
             capture_output=True, text=True, cwd=REPO_ROOT
         )
-        return [
-            REPO_ROOT / f
-            for f in result.stdout.splitlines()
-            if f.endswith(".md")
-        ]
+        return [REPO_ROOT / f for f in result.stdout.splitlines() if f.endswith(".md")]
     except Exception:
         return []
 
 
-def _load_wiki_token() -> str:
-    """Carrega token da wiki (env > .env > secrets agent)."""
-    val = os.environ.get("WIKI_TOKEN", "")
-    if val:
-        return val
-    env_f = REPO_ROOT / ".env"
-    if env_f.exists():
-        for line in env_f.read_text().splitlines():
-            if line.startswith("WIKI_TOKEN="):
-                return line.split("=", 1)[1].strip().strip("\"'")
+def _git_staged_python() -> list[Path]:
+    """Retorna arquivos .py staged (para contexto da tarefa)."""
     try:
-        import urllib.request
-        req = urllib.request.Request(SECRETS_ENDPOINT)
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            return json.loads(resp.read()).get("value", "")
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=AM"],
+            capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        return [REPO_ROOT / f for f in result.stdout.splitlines() if f.endswith(".py")]
+    except Exception:
+        return []
+
+
+def _git_diff_summary() -> str:
+    """Retorna resumo do diff staged."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--stat"],
+            capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        return result.stdout.strip()
     except Exception:
         return ""
 
 
+def _detect_task_category(staged_files: list[Path], py_files: list[Path]) -> str:
+    """Detecta a categoria da tarefa baseado nos arquivos staged."""
+    all_files = [str(f) for f in staged_files + py_files]
+    combined = " ".join(all_files).lower()
+
+    for pattern, category in TASK_CATEGORIES.items():
+        if re.search(pattern, combined, re.IGNORECASE):
+            return category
+
+    return "geral"
+
+
 def _should_skip(filepath: Path) -> bool:
-    """Verifica se o arquivo deve ser ignorado."""
     rel = str(filepath.relative_to(REPO_ROOT)) if filepath.is_relative_to(REPO_ROOT) else filepath.name
     return any(re.search(pat, rel) for pat in SKIP_PATTERNS)
 
@@ -99,8 +120,6 @@ def _should_skip(filepath: Path) -> bool:
 # ── 1. Validação Estrutural ───────────────────────────────────────────────────
 
 class StructuralValidator:
-    """Valida estrutura do markdown."""
-
     def __init__(self, content: str, filepath: Path):
         self.content = content
         self.filepath = filepath
@@ -111,13 +130,10 @@ class StructuralValidator:
         self._check_frontmatter()
         self._check_headings()
         self._check_code_blocks()
-        self._check_internal_links()
         self._check_line_length()
-        self._check_empty_sections()
         return self.errors, self.warnings
 
     def _check_frontmatter(self):
-        """Verifica se frontmatter existe e tem campos obrigatórios."""
         match = RE_FRONTMATTER.match(self.content)
         if not match:
             self.warnings.append("Sem frontmatter (recomendado: title, description)")
@@ -129,169 +145,242 @@ class StructuralValidator:
             self.warnings.append("Frontmatter sem campo 'description'")
 
     def _check_headings(self):
-        """Valida hierarquia de headings."""
         headings = RE_HEADING.findall(self.content)
         if not headings:
-            self.warnings.append("Documento sem headings (H1/H2/H3)")
+            self.warnings.append("Documento sem headings")
             return
-
         levels = [len(h[0]) for h in headings]
         if levels[0] != 1:
             self.errors.append(f"Primeiro heading deve ser H1 (encontrou H{levels[0]})")
 
-        for i in range(1, len(levels)):
-            if levels[i] - levels[i - 1] > 1:
-                self.warnings.append(
-                    f"Pulo de H{levels[i-1]} para H{levels[i]} (linhas podem estar inconsistentes)"
-                )
-
     def _check_code_blocks(self):
-        """Verifica code blocks."""
         blocks = RE_CODE_BLOCK.findall(self.content)
         for lang, _ in blocks:
             if not lang:
                 self.warnings.append("Code block sem linguagem especificada")
 
-    def _check_internal_links(self):
-        """Verifica links internos quebrados (básico)."""
-        links = RE_INTERNAL_LINK.findall(self.content)
-        for text, url in links:
-            if url.startswith("#"):
-                continue  # Anchor local
-            if url.startswith("http"):
-                continue  # Link externo
-            # Link interno — verificar se o arquivo existe
-            target = self.filepath.parent / url
-            if not target.exists():
-                self.warnings.append(f"Link interno quebrado: [{text}]({url})")
-
     def _check_line_length(self):
-        """Avisa sobre linhas muito longas."""
         for i, line in enumerate(self.content.split("\n"), 1):
             if len(line) > 200 and not line.strip().startswith("```"):
                 self.warnings.append(f"Linha {i}: {len(line)} chars (>200)")
 
-    def _check_empty_sections(self):
-        """Detecta seções vazias."""
-        lines = self.content.split("\n")
-        for i in range(len(lines) - 1):
-            if re.match(r"^#{1,6}\s+", lines[i]):
-                next_line = lines[i + 1].strip() if i + 1 < len(lines) else ""
-                if not next_line or next_line.startswith("#"):
-                    self.warnings.append(f"Seção vazia: {lines[i].strip()}")
 
+# ── 2. Extração de Conhecimento da Tarefa ────────────────────────────────────
 
-# ── 2. Extração de Termos ────────────────────────────────────────────────────
+class TaskKnowledgeExtractor:
+    """Extrai conhecimento relevante para a tarefa sendo commitada."""
 
-class TermExtractor:
-    """Extrai termos-chave, decisões e contexto do documento."""
-
-    def __init__(self, content: str, filepath: Path):
+    def __init__(self, content: str, filepath: Path, task_category: str):
         self.content = content
         self.filepath = filepath
+        self.task_category = task_category
         self.result: dict[str, Any] = {
             "file": str(filepath.relative_to(REPO_ROOT) if filepath.is_relative_to(REPO_ROOT) else filepath.name),
-            "headings": [],
+            "task_category": task_category,
+            "title": "",
+            "summary": "",
+            "key_concepts": [],
             "decisions": [],
-            "todos": [],
-            "code_langs": [],
-            "key_terms": [],
+            "action_items": [],
+            "related_services": [],
         }
 
     def extract(self) -> dict[str, Any]:
-        self._extract_headings()
+        self._extract_title()
+        self._extract_summary()
+        self._extract_key_concepts()
         self._extract_decisions()
-        self._extract_todos()
-        self._extract_code_langs()
-        self._extract_key_terms()
+        self._extract_action_items()
+        self._extract_related_services()
         return self.result
 
-    def _extract_headings(self):
-        """Extrai todos os headings como estrutura do documento."""
-        self.result["headings"] = [
-            {"level": len(h[0]), "text": h[1].strip()}
-            for h in RE_HEADING.findall(self.content)
-        ]
+    def _extract_title(self):
+        match = RE_HEADING.search(self.content)
+        if match:
+            self.result["title"] = match.group(2).strip()
 
-    def _extract_decisions(self):
-        """Extrai decisões/ADRs mencionadas."""
-        self.result["decisions"] = RE_ADR.findall(self.content)
+    def _extract_summary(self):
+        """Extrai primeiro parágrafo significativo como resumo."""
+        lines = self.content.split("\n")
+        in_content = False
+        summary_lines = []
 
-    def _extract_todos(self):
-        """Extrai TODOs e FIXMEs."""
-        self.result["todos"] = RE_TODO.findall(self.content)
+        for line in lines:
+            # Pular frontmatter
+            if line.strip() == "---" and not in_content:
+                in_content = True
+                continue
 
-    def _extract_code_langs(self):
-        """Lista linguagens de code blocks."""
-        self.result["code_langs"] = list(set(
-            lang for lang, _ in RE_CODE_BLOCK.findall(self.content) if lang
-        ))
+            # Pular headings e linhas vazias no início
+            if not in_content or line.strip().startswith("#") or not line.strip():
+                if summary_lines:
+                    break
+                continue
 
-    def _extract_key_terms(self):
-        """Extrai termos técnicos relevantes."""
-        # Termos de alto sinal: tecnologias, serviços, conceitos
-        patterns = [
-            r"\b(Python|Rust|Go|TypeScript|Docker|Kubernetes|PostgreSQL|Redis)\b",
-            r"\b(MCP|LLM|Ollama|GPU|CPU|RAM|VRAM)\b",
-            r"\b(trading|deploy|rollback|hotfix|incident|outage)\b",
-            r"\b(Grafana|Prometheus|Alertmanager|Telegram)\b",
-        ]
+            summary_lines.append(line.strip())
+            if len(summary_lines) >= 3:
+                break
+
+        self.result["summary"] = " ".join(summary_lines)[:300]
+
+    def _extract_key_concepts(self):
+        """Extrai conceitos-chave baseado na categoria da tarefa."""
+        patterns_by_category = {
+            "trading": [
+                r"\b(trading|trade|buy|sell|position|order|exchange|btc|bitcoin)\b",
+                r"\b(strategy|signal|indicator|rsi|macd|bollinger)\b",
+                r"\b(risk|profit|loss|drawdown|sharpe)\b",
+            ],
+            "agentes": [
+                r"\b(agent|coordinator|langgraph|state|node|edge)\b",
+                r"\b(mcp|tool|function|call|invoke)\b",
+                r"\b(memory|context|prompt|llm|model)\b",
+            ],
+            "infraestrutura": [
+                r"\b(deploy|deploy|systemd|docker|compose)\b",
+                r"\b(service|unit|restart|start|stop|enable)\b",
+                r"\b(server|host|ssh|nginx|proxy)\b",
+            ],
+            "monitoramento": [
+                r"\b(grafana|dashboard|panel|metric)\b",
+                r"\b(prometheus|alertmanager|alert|rule)\b",
+                r"\b(log|trace|span|observability)\b",
+            ],
+            "documentação": [
+                r"\b(wiki|page|document|readme|guide)\b",
+                r"\b(section|heading|structure|format)\b",
+                r"\b(link|reference|anchor|toc)\b",
+            ],
+            "automação": [
+                r"\b(script|hook|pipeline|workflow|ci)\b",
+                r"\b(automate|schedule|cron|trigger)\b",
+                r"\b(tool|utility|helper|cli)\b",
+            ],
+            "testes": [
+                r"\b(test|assert|expect|mock|fixture)\b",
+                r"\b(pytest|unittest|coverage|regression)\b",
+                r"\b(validate|verify|check|assert)\b",
+            ],
+            "segurança": [
+                r"\b(security|secret|vault|token|key)\b",
+                r"\b(auth|auth|permission|rbac|role)\b",
+                r"\b(encrypt|hash|certificate|tls)\b",
+            ],
+        }
+
+        # Usar padrões da categoria + padrões gerais
+        patterns = patterns_by_category.get(self.task_category, [])
+        patterns.extend([
+            r"\b(Python|Rust|Go|TypeScript|PostgreSQL|Redis)\b",
+            r"\b(MCP|LLM|Ollama|GPU|CPU|RAM)\b",
+        ])
+
         terms = set()
         for pat in patterns:
             terms.update(re.findall(pat, self.content, re.IGNORECASE))
-        self.result["key_terms"] = sorted(terms)
+
+        self.result["key_concepts"] = sorted(terms)[:15]
+
+    def _extract_decisions(self):
+        """Extrai decisões relevantes para a tarefa."""
+        decisions = RE_ADR.findall(self.content)
+        self.result["decisions"] = [d.strip()[:100] for d in decisions[:5]]
+
+    def _extract_action_items(self):
+        """Extrai TODOs e itens de ação."""
+        todos = RE_TODO.findall(self.content)
+        self.result["action_items"] = [t.strip()[:100] for t in todos[:5]]
+
+    def _extract_related_services(self):
+        """Identifica serviços relacionados à tarefa."""
+        service_patterns = [
+            r"\b(shared-telegram-bot|shared-whatsapp-bot|github-agent)\b",
+            r"\b(specialized-agents|coordinator-langgraph)\b",
+            r"\b(btc-trading-agent|crypto-agent|trading-engine)\b",
+            r"\b(grafana|prometheus|alertmanager|secrets-agent)\b",
+            r"\b(cloudflared|nextcloud|wiki)\b",
+        ]
+
+        services = set()
+        for pat in service_patterns:
+            services.update(re.findall(pat, self.content, re.IGNORECASE))
+
+        self.result["related_services"] = sorted(services)[:10]
 
 
-# ── 3. Detecção de Duplicatas ────────────────────────────────────────────────
+# ── 3. Geração de Resumo de Tarefa ───────────────────────────────────────────
 
-class DuplicateDetector:
-    """Verifica se o conteúdo já existe na wiki."""
+class TaskSummaryGenerator:
+    """Gera resumo consolidado da tarefa para o agente wiki."""
 
-    def __init__(self, content: str, filepath: Path, token: str):
-        self.content = content
-        self.filepath = filepath
-        self.token = token
-        self.duplicates: list[dict[str, str]] = []
+    def __init__(
+        self,
+        task_category: str,
+        staged_files: list[Path],
+        py_files: list[Path],
+        all_knowledge: list[dict[str, Any]],
+        diff_summary: str,
+    ):
+        self.task_category = task_category
+        self.staged_files = staged_files
+        self.py_files = py_files
+        self.all_knowledge = all_knowledge
+        self.diff_summary = diff_summary
 
-    def check(self) -> list[dict[str, str]]:
-        if not self.token:
-            return []
+    def generate(self) -> dict[str, Any]:
+        """Gera resumo consolidado."""
+        # Consolidar conceitos
+        all_concepts = set()
+        for k in self.all_knowledge:
+            all_concepts.update(k.get("key_concepts", []))
 
-        try:
-            from specialized_agents.wiki_client import WikiJsClient
-            client = WikiJsClient(WIKI_GQL, self.token, default_locale="pt")
+        # Consolidar serviços
+        all_services = set()
+        for k in self.all_knowledge:
+            all_services.update(k.get("related_services", []))
 
-            # Extrair título do documento
-            title_match = RE_HEADING.search(self.content)
-            if not title_match:
-                return []
+        # Consolidar decisões
+        all_decisions = []
+        for k in self.all_knowledge:
+            all_decisions.extend(k.get("decisions", []))
 
-            search_term = title_match.group(2).strip()[:50]
+        # Gerar título da tarefa
+        task_title = self._infer_task_title()
 
-            # Listar páginas e comparar similaridade básica
-            pages = client.list_pages()
-            for page in pages:
-                page_title = page.get("title", "").lower()
-                if self._similar(search_term.lower(), page_title):
-                    self.duplicates.append({
-                        "wiki_path": page.get("path", "?"),
-                        "title": page.get("title", "?"),
-                        "updated": page.get("updatedAt", "?"),
-                    })
+        return {
+            "task_category": self.task_category,
+            "task_title": task_title,
+            "files_changed": len(self.staged_files) + len(self.py_files),
+            "md_files": [str(f.name) for f in self.staged_files],
+            "py_files": [str(f.name) for f in self.py_files],
+            "key_concepts": sorted(all_concepts)[:20],
+            "related_services": sorted(all_services)[:10],
+            "decisions": all_decisions[:5],
+            "diff_summary": self.diff_summary[:500],
+        }
 
-        except Exception:
-            pass  # Falha silenciosa — não bloqueia commit
+    def _infer_task_title(self) -> str:
+        """Infere título da tarefa baseado nos arquivos."""
+        if not self.staged_files and not self.py_files:
+            return "Atualização diversas"
 
-        return self.duplicates
+        # Usar primeiro .md como referência
+        if self.staged_files:
+            first_md = self.staged_files[0]
+            try:
+                content = first_md.read_text(encoding="utf-8", errors="replace")
+                match = RE_HEADING.search(content)
+                if match:
+                    return match.group(2).strip()[:80]
+            except Exception:
+                pass
 
-    def _similar(self, a: str, b: str) -> bool:
-        """Similaridade básica por tokens compartilhados."""
-        tokens_a = set(a.split())
-        tokens_b = set(b.split())
-        if not tokens_a or not tokens_b:
-            return False
-        overlap = len(tokens_a & tokens_b) / max(len(tokens_a), len(tokens_b))
-        return overlap > 0.7
+        # Fallback: usar nome do diretório
+        if self.py_files:
+            parent = self.py_files[0].parent.name
+            return f"Atualização em {parent}"
+
+        return "Atualização de documentação"
 
 
 # ── Relatório ─────────────────────────────────────────────────────────────────
@@ -300,13 +389,11 @@ def _print_report(
     filepath: Path,
     errors: list[str],
     warnings: list[str],
-    terms: dict[str, Any],
-    duplicates: list[dict[str, str]],
+    knowledge: dict[str, Any],
     verbose: bool,
 ):
-    """Imprime relatório de análise."""
     rel = filepath.relative_to(REPO_ROOT) if filepath.is_relative_to(REPO_ROOT) else filepath.name
-    print(f"\n📄 Analisando: {rel}")
+    print(f"\n📄 {rel}")
 
     if errors:
         print(f"  ❌ Erros ({len(errors)}):")
@@ -314,100 +401,104 @@ def _print_report(
             print(f"     - {e}")
 
     if warnings:
-        print(f"  ⚠️  Warnings ({len(warnings)}):")
+        print(f"  ⚠️  ({len(warnings)}):")
         for w in warnings:
             print(f"     - {w}")
 
     if verbose:
-        headings = terms.get("headings", [])
-        if headings:
-            print(f"  📑 Estrutura: {len(headings)} headings")
-            for h in headings[:5]:
-                print(f"     {'  ' * (h['level'] - 1)}H{h['level']}: {h['text']}")
+        title = knowledge.get("title", "")
+        if title:
+            print(f"  📌 Título: {title}")
 
-        decisions = terms.get("decisions", [])
+        concepts = knowledge.get("key_concepts", [])
+        if concepts:
+            print(f"  🔑 Conceitos: {', '.join(concepts[:8])}")
+
+        services = knowledge.get("related_services", [])
+        if services:
+            print(f"  🔧 Serviços: {', '.join(services[:5])}")
+
+        decisions = knowledge.get("decisions", [])
         if decisions:
             print(f"  🎯 Decisões: {len(decisions)}")
-            for d in decisions[:3]:
-                print(f"     - {d[:80]}")
 
-        todos = terms.get("todos", [])
-        if todos:
-            print(f"  📝 TODOs: {len(todos)}")
-            for t in todos[:3]:
-                print(f"     - {t[:80]}")
-
-        langs = terms.get("code_langs", [])
-        if langs:
-            print(f"  💻 Code blocks: {', '.join(langs)}")
-
-        key_terms = terms.get("key_terms", [])
-        if key_terms:
-            print(f"  🔑 Termos-chave: {', '.join(key_terms[:10])}")
-
-    if duplicates:
-        print(f"  🔄 Possíveis duplicatas ({len(duplicates)}):")
-        for d in duplicates:
-            print(f"     - {d['title']} → {d['wiki_path']} (atualizado: {d['updated']})")
-
-    if not errors and not warnings and not duplicates:
-        print("  ✅ Tudo OK")
+    if not errors and not warnings:
+        print("  ✅ OK")
 
 
-# ── Persistência para memória do agente ──────────────────────────────────────
+def _print_task_summary(summary: dict[str, Any]):
+    """Imprime resumo consolidado da tarefa."""
+    print("\n" + "=" * 60)
+    print("📋 RESUMO DA TAREFA")
+    print("=" * 60)
+    print(f"Categoria: {summary['task_category']}")
+    print(f"Título:    {summary['task_title']}")
+    print(f"Arquivos:  {summary['files_changed']} ({len(summary['md_files'])} .md, {len(summary['py_files'])} .py)")
 
-def _persist_to_memory(terms: list[dict[str, Any]]):
-    """Salva termos extraídos para uso do agente wiki."""
-    memory_file = REPO_ROOT / "tools" / "hooks" / ".wiki_doc_terms.json"
-    existing = []
-    if memory_file.exists():
-        try:
-            existing = json.loads(memory_file.read_text())
-        except Exception:
-            existing = []
+    if summary["key_concepts"]:
+        print(f"Conceitos: {', '.join(summary['key_concepts'][:10])}")
 
-    # Adicionar novos termos (dedup por arquivo)
-    existing_files = {t["file"] for t in existing}
-    for t in terms:
-        if t["file"] not in existing_files:
-            existing.append(t)
+    if summary["related_services"]:
+        print(f"Serviços:  {', '.join(summary['related_services'][:5])}")
 
-    # Manter apenas últimos 100 documentos
-    existing = existing[-100:]
+    if summary["decisions"]:
+        print(f"Decisões:  {len(summary['decisions'])} registradas")
+
+    print("=" * 60)
+
+
+# ── Persistência ──────────────────────────────────────────────────────────────
+
+def _persist_task_context(summary: dict[str, Any], knowledge: list[dict[str, Any]]):
+    """Salva contexto da tarefa para uso do agente wiki."""
+    context_file = REPO_ROOT / "tools" / "hooks" / ".wiki_task_context.json"
+
+    context = {
+        "task": summary,
+        "documents": knowledge,
+    }
 
     try:
-        memory_file.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
+        context_file.write_text(json.dumps(context, indent=2, ensure_ascii=False))
     except Exception:
-        pass  # Não bloqueia commit
+        pass
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main():
-    parser = argparse.ArgumentParser(description="Pré-análise de documentação wiki")
+    parser = argparse.ArgumentParser(description="Pré-análise de documentação focada na tarefa")
     parser.add_argument("--staged", action="store_true", help="Analisar apenas arquivos staged")
     parser.add_argument("--verbose", action="store_true", help="Saída detalhada")
-    parser.add_argument("--skip-dedup", action="store_true", help="Pular checagem de duplicatas")
     parser.add_argument("files", nargs="*", help="Arquivos específicos para analisar")
     args = parser.parse_args()
 
+    # Coletar arquivos
     if args.files:
-        files = [Path(f) for f in args.files if Path(f).exists()]
+        md_files = [Path(f) for f in args.files if Path(f).exists() and f.endswith(".md")]
+        py_files = []
     elif args.staged:
-        files = _git_staged_files()
+        md_files = _git_staged_files()
+        py_files = _git_staged_python()
     else:
-        files = list(REPO_ROOT.rglob("*.md"))
-        files = [f for f in files if f.is_file() and not _should_skip(f)]
+        print("ℹ️  Use --staged para analisar arquivos do commit atual")
+        return 0
 
-    if not files:
+    if not md_files and not py_files:
         print("📭 Nenhum .md para analisar")
         return 0
 
-    token = _load_wiki_token()
-    all_terms = []
+    # Detectar categoria da tarefa
+    task_category = _detect_task_category(md_files, py_files)
+    diff_summary = _git_diff_summary()
+
+    print(f"\n🔍 Analisando tarefa: {task_category.upper()}")
+
+    all_knowledge = []
     has_errors = False
 
-    for filepath in files:
+    # Analisar cada .md
+    for filepath in md_files:
         try:
             content = filepath.read_text(encoding="utf-8", errors="replace")
         except Exception as exc:
@@ -415,39 +506,41 @@ def main():
             has_errors = True
             continue
 
-        # 1. Validação estrutural
+        # Validação
         validator = StructuralValidator(content, filepath)
         errors, warnings = validator.validate()
 
-        # 2. Extração de termos
-        extractor = TermExtractor(content, filepath)
-        terms = extractor.extract()
-
-        # 3. Detecção de duplicatas
-        duplicates = []
-        if not args.skip_dedup and token:
-            detector = DuplicateDetector(content, filepath, token)
-            duplicates = detector.check()
+        # Extração de conhecimento
+        extractor = TaskKnowledgeExtractor(content, filepath, task_category)
+        knowledge = extractor.extract()
 
         # Relatório
-        _print_report(filepath, errors, warnings, terms, duplicates, args.verbose)
+        _print_report(filepath, errors, warnings, knowledge, args.verbose)
 
         if errors:
             has_errors = True
 
-        all_terms.append(terms)
+        all_knowledge.append(knowledge)
 
-    # Persistir termos para memória
-    if all_terms:
-        _persist_to_memory(all_terms)
+    # Gerar resumo da tarefa
+    summary_gen = TaskSummaryGenerator(
+        task_category, md_files, py_files, all_knowledge, diff_summary
+    )
+    summary = summary_gen.generate()
+
+    # Imprimir resumo
+    _print_task_summary(summary)
+
+    # Persistir contexto
+    if all_knowledge:
+        _persist_task_context(summary, all_knowledge)
 
     print()
     if has_errors:
         print("❌ Análise encontrou erros — commit bloqueado")
-        print("   Corrija os erros ou use --no-verify para ignorar")
         return 1
 
-    print("✅ Análise de documentação concluída")
+    print("✅ Análise de tarefa concluída")
     return 0
 
 


### PR DESCRIPTION
## Summary

- **Reload zumbi** (`setup_error` + entidades já ativas) deixa de consumir `MAX_HEALS_24H` — só conta no budget se recuperou entidades `0 → >0`.
- **`should_heal`**: bypass do rate limit quando o access token do HA já expirou e o runtime do bridge é estritamente mais novo; heals proativos (soft threshold) continuam rate-limited.
- Testes de regressão para bypass, soft ainda limitado, e `reload_counts_toward_heal_budget`.

Incidente **2026-08-08**: 24 reloads queimaram o budget; bridge ainda renovava, inject no HA bloqueado → alerta «Tuya expirado» com 82/82 ativas. Fix **já deployado e validado** no homelab (hot inject, `entry loaded`, token HA ~86 min).

## Test plan

- [x] `pytest tests/test_tuya_token_selfheal.py`
- [x] Deploy manual do script + `systemctl start tuya-token-selfheal` no host
- [x] Métricas: `tuya_selfheal_healthy=1`, `tuya_entry_state_code=0`, rem HA ≈ rem bridge > 0
- [ ] CI checks no PR